### PR TITLE
Project Scaffolding, Multi-LLM Config, and Typer CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+GEMINI_API_KEY=your_api_key_here
+OPENAI_API_KEY=your_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.venv/
+pycache/
+*.pyc
+.env*
+!.env.example
+.pytest_cache/
+*.egg-info/
+.eggs/
+build/
+dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,69 @@
+[build-system]
+requires = ["setuptools>=82.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wpt-gen"
+version = "0.1.0"
+description = "A CLI Tool for AI-Powered Web Platform Test Generation"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    # Core LLM Integration
+    "google-genai>=1.62.0",
+
+    # Context & Scraping
+    "trafilatura>=2.0.0",
+
+    # Prompt Templating
+    "jinja2>=3.1.6",
+
+    # CLI Infrastructure
+    "typer>=0.23.0",
+    "rich>=14.3.2",
+    "pyyaml>=6.0.3",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-mock>=3.15.1",
+    "ruff>=0.15.0",
+    "mypy>=1.19.1",
+]
+
+[project.scripts]
+wpt-gen = "wptgen.main:app"
+
+[tool.setuptools.packages.find]
+include = ["wptgen*"]
+
+[tool.setuptools.package-data]
+wptgen = ["templates/*.jinja", "templates/*.xml", "templates/*.txt"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+indent-width = 2
+
+[tool.ruff.format]
+quote-style = "single"
+
+[tool.ruff.lint]
+# Enable a wide set of rules for strict linting
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "UP",   # pyupgrade
+    "PT",   # flake8-pytest-style
+]
+ignore = [
+    "E501", # Line too long
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["wptgen"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from wptgen.config import Config, load_config
+
+
+def test_load_config_default_gemini_happy_path(monkeypatch):
+  """Test the happy path: default provider (gemini) with a valid API key."""
+  # Mock the environment variable
+  monkeypatch.setenv('GEMINI_API_KEY', 'mock-gemini-key-123')
+
+  # Pass a non-existent config path so it relies purely on the code's defaults
+  config = load_config(config_path='non_existent_dummy.yaml')
+
+  assert isinstance(config, Config)
+  assert config.provider == 'gemini'
+  assert config.model == 'gemini-3-pro-preview'
+  assert config.api_key == 'mock-gemini-key-123'
+
+
+def test_load_config_provider_override_openai(monkeypatch):
+  """Test overriding the provider via the CLI flag to openai."""
+  # Mock the OpenAI key instead
+  monkeypatch.setenv('OPENAI_API_KEY', 'mock-openai-key-456')
+
+  # Force the provider to openai
+  config = load_config(config_path='non_existent_dummy.yaml', provider_override='openai')
+
+  assert config.provider == 'openai'
+  assert config.model == 'gpt-5.2-high'
+  assert config.api_key == 'mock-openai-key-456'
+
+
+def test_load_config_missing_api_key_raises_error(monkeypatch):
+  """Test that missing the required environment variable raises a ValueError."""
+  # Ensure the environment variable is explicitly removed for this test
+  monkeypatch.delenv('GEMINI_API_KEY', raising=False)
+
+  # Verify the exact error is raised
+  with pytest.raises(ValueError, match='GEMINI_API_KEY environment variable is missing'):
+    load_config(config_path='non_existent_dummy.yaml')
+
+
+def test_load_config_unsupported_provider():
+  """Test that requesting a random/unsupported provider raises an error."""
+  with pytest.raises(ValueError, match='CRITICAL: Unsupported provider'):
+    load_config(config_path='non_existent_dummy.yaml', provider_override='sillyLLM')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from typer.testing import CliRunner
+
+from wptgen.config import Config
+from wptgen.main import app
+
+# The CliRunner simulates a user typing commands into the terminal
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_config():
+  """Provides a dummy configuration object for successful test runs."""
+  return Config(
+    provider='gemini',
+    model='gemini-3-pro-preview',
+    api_key='fake-key',
+  )
+
+
+def test_help_menu():
+  """Test that the CLI help menu renders correctly without errors."""
+  result = runner.invoke(app, ['--help'])
+
+  assert result.exit_code == 0
+  assert 'AI-Powered Web Platform Test Generation CLI' in result.stdout
+
+
+def test_generate_success(mocker, mock_config):
+  """Test the happy path execution of the generate command."""
+  # Mock load_config and the Engine so they don't actually execute
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+  mock_engine_class = mocker.patch('wptgen.main.WPTGenEngine')
+  mock_engine_instance = mock_engine_class.return_value
+
+  # Simulate running `wpt-gen generate grid --provider gemini`
+  result = runner.invoke(app, ['generate', 'grid', '--provider', 'gemini'])
+
+  # Check standard output and exit code
+  assert result.exit_code == 0
+  assert 'Starting WPT-Gen for feature' in result.stdout
+  assert 'Workflow completed successfully' in result.stdout
+
+  # Verify our logic called the underlying functions with the correct CLI arguments
+  mock_load_config.assert_called_once_with(config_path='wpt-gen.yml', provider_override='gemini')
+  mock_engine_class.assert_called_once_with(config=mock_config)
+  mock_engine_instance.run_workflow.assert_called_once_with('grid')
+
+
+def test_generate_config_error(mocker):
+  """Test that configuration errors (like missing API keys) are caught and exit gracefully."""
+  # Force load_config to raise a ValueError
+  mock_error_message = 'GEMINI_API_KEY environment variable is missing'
+  mocker.patch('wptgen.main.load_config', side_effect=ValueError(mock_error_message))
+
+  result = runner.invoke(app, ['generate', 'popover'])
+
+  # Typer.Exit(code=1) translates to exit_code 1 in the runner
+  assert result.exit_code == 1
+  assert 'Configuration Error' in result.stdout
+  assert mock_error_message in result.stdout
+
+
+def test_generate_unexpected_error(mocker, mock_config):
+  """Test that unexpected runtime errors inside the engine are caught and exit gracefully."""
+  # Setup mocks but force the engine's run_workflow to crash
+  mocker.patch('wptgen.main.load_config', return_value=mock_config)
+  mock_engine_class = mocker.patch('wptgen.main.WPTGenEngine')
+  mock_engine_instance = mock_engine_class.return_value
+  mock_engine_instance.run_workflow.side_effect = Exception('Engine simulation failed')
+
+  result = runner.invoke(app, ['generate', 'grid'])
+
+  assert result.exit_code == 1
+  assert 'Unexpected Error' in result.stdout
+  assert 'Engine simulation failed' in result.stdout

--- a/wpt-gen.yml
+++ b/wpt-gen.yml
@@ -1,0 +1,8 @@
+version: "1"
+default_provider: gemini
+
+providers:
+  gemini:
+    model: gemini-3-pro-preview
+  openai:
+    model: gpt-5.2-high

--- a/wptgen/__init__.py
+++ b/wptgen/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = '0.1.0'

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+
+@dataclass
+class Config:
+  """Configuration object for WPT-Gen."""
+
+  provider: str
+  model: str
+  api_key: str
+
+
+def load_config(config_path: str = 'wpt-gen.yml', provider_override: str | None = None) -> Config:
+  """
+  Loads configuration from YAML and environment variables.
+  Selects the active LLM provider and fetches the corresponding API key.
+  """
+  path = Path(config_path)
+  yaml_data: dict = {}
+
+  if path.exists():
+    with open(path, encoding='utf-8') as f:
+      yaml_data = yaml.safe_load(f) or {}
+
+  # Determine the active provider
+  # CLI override takes precedence, then YAML default.
+  active_provider = provider_override or yaml_data.get('default_provider', 'gemini')
+  active_provider = active_provider.lower()
+
+  # Extract provider-specific settings
+  providers_config = yaml_data.get('providers', {})
+  provider_settings = providers_config.get(active_provider, {})
+
+  # Provide sensible defaults if the YAML is missing the specific provider block
+  if active_provider == 'gemini':
+    model = provider_settings.get('model', 'gemini-3-pro-preview')
+    env_var_name = 'GEMINI_API_KEY'
+  elif active_provider == 'openai':
+    model = provider_settings.get('model', 'gpt-5.2-high')
+    env_var_name = 'OPENAI_API_KEY'
+  else:
+    raise ValueError(f"CRITICAL: Unsupported provider '{active_provider}' requested.")
+
+  # Enforce the environment variable constraint for the active provider
+  api_key = os.environ.get(env_var_name)
+  if not api_key:
+    raise ValueError(
+      f'CRITICAL: {env_var_name} environment variable is missing. '
+      f"Required when using the '{active_provider}' provider."
+    )
+
+  return Config(provider=active_provider, model=model, api_key=api_key)

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import yaml
+from trafilatura import extract, fetch_url
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_feature_yaml(web_feature_id: str) -> dict[str, Any] | None:
+  """
+  Fetches the YAML definition for a given web feature ID from the
+  web-platform-dx/web-features repository.
+
+  Returns the parsed YAML dictionary, or None if the feature ID is not found.
+  """
+  url = f'https://raw.githubusercontent.com/web-platform-dx/web-features/main/features/{web_feature_id}.yml'
+
+  try:
+    # Use standard library to avoid bloating dependencies
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req) as response:
+      yaml_content = response.read().decode('utf-8')
+
+      # Use safe_load to securely parse the YAML string into a Python dictionary
+      return yaml.safe_load(yaml_content)
+
+  except urllib.error.HTTPError as e:
+    if e.code == 404:
+      # Feature ID doesn't exist in the repository
+      return None
+    # If it's a 500 error or rate limit, we want it to crash loudly so we know
+    raise e
+
+
+def extract_spec_url(feature_data: dict[str, Any]) -> str | None:
+  """
+  Safely extracts the primary specification URL from the parsed feature data.
+  """
+  spec = feature_data.get('spec')
+
+  if not spec:
+    return None
+
+  # Sometimes the spec field is a single URL string
+  if isinstance(spec, str):
+    return spec
+
+  # Sometimes it might be formatted as a list of URLs
+  # TODO(DanielRyanSmith): Handle multiple specs.
+  if isinstance(spec, list) and len(spec) > 0:
+    return spec[0]
+
+  return None
+
+
+def fetch_and_extract_text(url: str) -> str | None:
+  """
+  Fetches the HTML content from a URL and extracts the core textual content,
+  stripping away navigation, footers, and boilerplate.
+
+  Returns the content formatted as Markdown.
+  """
+  logger.info(f'Fetching content from: {url}')
+
+  # Fetch the raw HTML
+  downloaded_html = fetch_url(url)
+
+  if not downloaded_html:
+    logger.error(f'Failed to download HTML from {url}')
+    return None
+
+  # Extract the core content
+  content = extract(
+    downloaded_html,
+    output_format='markdown',
+    include_comments=False,
+    include_tables=True,  # Specs rely heavily on tables for state definitions
+    include_links=False,  # Strip hyperlinks to save tokens
+  )
+
+  if not content:
+    logger.warning(f'Could not extract meaningful text from {url}')
+    return None
+
+  return content
+
+
+def find_feature_tests(target_directory: str, feature_id: str) -> list[str]:
+  """
+  Scans a directory recursively for test files relevant to a specific feature ID.
+  """
+  base_dir = Path(target_directory).resolve()
+  if not base_dir.is_dir():
+    raise ValueError(f'The directory provided does not exist: {base_dir}')
+
+  relevant_files: set[str] = set()
+  TARGET_METADATA_FILE = 'WEB_FEATURES.yml'
+
+  # rglob recursively finds all WEB_FEATURES.yml files in the entire repository
+  for yaml_path in base_dir.rglob(TARGET_METADATA_FILE):
+    try:
+      with open(yaml_path, encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+
+      if not data or 'features' not in data:
+        continue
+
+      feature_config = next((f for f in data['features'] if f.get('name') == feature_id), None)
+
+      if feature_config:
+        patterns = feature_config.get('files', [])
+        # Pass the directory containing the YAML file
+        matched_files = _resolve_patterns(yaml_path.parent, patterns)
+        relevant_files.update(matched_files)
+
+    except yaml.YAMLError:
+      continue
+    except Exception as e:
+      print(f'Error processing {yaml_path}: {e}')
+
+  # Convert back to a sorted list of absolute string paths
+  return sorted(relevant_files)
+
+
+def _resolve_patterns(directory: Path, patterns: list[str]) -> set[str]:
+  """
+  Helper function to match file patterns recursively against files in a directory.
+  """
+  all_files = [
+    p for p in directory.rglob('*') if p.is_file() and p.suffix.lower() not in ('.yml', '.yaml')
+  ]
+
+  selected_files: set[Path] = set()
+
+  for pattern in patterns:
+    is_negative = pattern.startswith('!')
+    clean_pattern = pattern[1:] if is_negative else pattern
+
+    matches = set()
+    for f in all_files:
+      rel_path = f.relative_to(directory)
+
+      # 1. Standard strict match
+      is_match = rel_path.match(clean_pattern)
+
+      # If pattern is `**/*.html`, it misses root files like `test.html`.
+      # We strip `**/` and check if `test.html` matches `*.html`.
+      if not is_match and clean_pattern.startswith('**/'):
+        is_match = rel_path.match(clean_pattern[3:])
+
+      if is_match:
+        matches.add(f)
+
+    if is_negative:
+      selected_files.difference_update(matches)
+    else:
+      selected_files.update(matches)
+
+  return {str(f) for f in selected_files}

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from wptgen.config import Config
+
+
+class WPTGenEngine:
+  def __init__(self, config: Config):
+    self.config = config
+
+  def run_workflow(self, web_feature_id: str):
+    """
+    Orchestrates the 5-step WPT generation flow.
+    (Skeleton implementation)
+    """
+    print(f'[Engine] Starting workflow for feature: {web_feature_id}')
+    # 1. Fetch Context
+    # 2. Analyze Tests
+    # 3. Analyze Gaps
+    # 4. Generate Tests
+    # 5. Verify & Refine
+    print('[Engine] Workflow complete.')

--- a/wptgen/llm.py
+++ b/wptgen/llm.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+
+from wptgen.config import load_config
+from wptgen.engine import WPTGenEngine
+
+# Initialize Typer app and Rich console
+app = typer.Typer(
+  name='wpt-gen',
+  help='AI-Powered Web Platform Test Generation CLI',
+  add_completion=False,
+)
+console = Console()
+
+
+@app.command()
+def generate(
+  web_feature_id: Annotated[
+    str,
+    typer.Argument(help="The web feature ID to generate tests for (e.g., 'grid', 'popover')."),
+  ],
+  provider: Annotated[
+    str | None,
+    typer.Option(
+      '--provider',
+      '-p',
+      help="Override the default LLM provider (e.g., 'gemini', 'openai').",
+    ),
+  ] = None,
+  config_path: Annotated[
+    str, typer.Option('--config', '-c', help='Path to a custom wpt-gen.yml file.')
+  ] = 'wpt-gen.yml',
+):
+  """
+  Generate Web Platform Tests for a specific web feature.
+  """
+  console.print(f'[bold blue]Starting WPT-Gen for feature:[/bold blue] {web_feature_id}')
+
+  try:
+    # 1. Load configuration (merging YAML, env vars, and CLI overrides)
+    config = load_config(config_path=config_path, provider_override=provider)
+
+    console.print(
+      Panel(
+        f'[bold]Provider:[/bold] {config.provider}\n[bold]Model:[/bold] {config.model}',
+        title='Active Configuration',
+        expand=False,
+        border_style='green',
+      )
+    )
+
+    # 2. Instantiate the core engine
+    engine = WPTGenEngine(config=config)
+
+    # 3. Execute the workflow
+    # Note: In Phase 1, this will just print the skeleton output
+    engine.run_workflow(web_feature_id)
+
+    console.print('[bold green]✔ Workflow completed successfully.[/bold green]')
+
+  except ValueError as e:
+    # Catch configuration errors (like missing API keys) and exit gracefully
+    console.print(f'[bold red]Configuration Error:[/bold red] {str(e)}')
+    raise typer.Exit(code=1) from e
+  except Exception as e:
+    # Catch unexpected runtime errors
+    console.print(f'[bold red]Unexpected Error:[/bold red] {str(e)}')
+    raise typer.Exit(code=1) from e
+
+
+@app.callback()
+def main_callback():
+  """
+  AI-Powered Web Platform Test Generation CLI
+  """
+  pass
+
+
+if __name__ == '__main__':
+  app()


### PR DESCRIPTION
Fixes #2 

This PR establishes the foundational architecture for `WPT-Gen`. It locks in our packaging structure, establishes a multi-provider configuration hierarchy, and introduces the Typer-based command-line interface. This sets the stage for the core engine and scraping modules to be built on top of a fully tested base.

#### **Key Additions & Architectural Decisions**

* **Project Packaging (`pyproject.toml`):** Configured the project using `setuptools`.
* **Multi-LLM Configuration (`config.py` & `wpt-gen.yaml`):** Built a flexible configuration loader with a strict fallback hierarchy (CLI overrides > YAML > Defaults). It handles dynamic switching between Gemini and OpenAI, enforcing that the correct environment variables (`GEMINI_API_KEY` or `OPENAI_API_KEY`) are present before allowing execution to proceed.
* **CLI Interface (`main.py`):** Implemented the root CLI using `Typer` and `Rich` for clean terminal output. Included is a dummy `@app.callback()` to prevent Typer from automatically collapsing our command structure. This ensures our final intended syntax (`wpt-gen generate <feature>`) is locked in from day one.
* **Foundational Test Suite:** Added comprehensive `pytest` coverage for the scaffolding. Leveraged `pytest-mock` and Typer's `CliRunner` to simulate CLI execution and environment variable shifts without making network calls or relying on local files.


To verify, pull down this branch and run:
```
python -m venv .venv
source .venv/bin/activate
pip install -e ".[dev]"
pytest tests/test_config.py tests/test_main.py
```