### PR TITLE
New `--show-responses` flag to see all LLM responses

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -56,11 +56,11 @@ def test_engine_init(engine, mock_config):
 
 
 @pytest.mark.asyncio
-async def test_generate_safe_verbose(engine, mock_llm, mocker):
-  """Tests that _generate_safe prints the LLM response when verbose is enabled."""
-  engine.config.verbose = True
+async def test_generate_safe_show_responses(engine, mock_llm, mocker):
+  """Tests that _generate_safe prints the LLM response when show_responses is enabled."""
+  engine.config.show_responses = True
   mock_llm.generate_content.return_value = 'Verbose Response'
-  mock_console_print = mocker.patch('wptgen.engine.console.print')
+  mock_console_print = mocker.patch.object(engine.console, 'print')
 
   result = await engine._generate_safe('prompt', 'Task')
 
@@ -71,11 +71,11 @@ async def test_generate_safe_verbose(engine, mock_llm, mocker):
 
 
 @pytest.mark.asyncio
-async def test_generate_safe_not_verbose(engine, mock_llm, mocker):
-  """Tests that _generate_safe does NOT print the LLM response when verbose is disabled."""
-  engine.config.verbose = False
+async def test_generate_safe_not_show_responses(engine, mock_llm, mocker):
+  """Tests that _generate_safe does NOT print the LLM response when show_responses is disabled."""
+  engine.config.show_responses = False
   mock_llm.generate_content.return_value = 'Quiet Response'
-  mock_console_print = mocker.patch('wptgen.engine.console.print')
+  mock_console_print = mocker.patch.object(engine.console, 'print')
 
   result = await engine._generate_safe('prompt', 'Task')
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -63,23 +63,26 @@ def test_generate_success(mocker, mock_config):
     config_path='wpt-gen.yml',
     provider_override='gemini',
     wpt_dir_override=None,
-    verbose_override=False,
+    show_responses=False,
   )
   mock_engine_class.assert_called_once_with(config=mock_config)
   mock_engine_instance.run_workflow.assert_called_once_with('grid')
 
 
-def test_generate_verbose(mocker, mock_config):
-  """Test that the --verbose flag is correctly passed to load_config."""
+def test_generate_show_responses(mocker, mock_config):
+  """Test that the --show-responses flag is correctly passed to load_config."""
   mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
   mocker.patch('wptgen.main.WPTGenEngine')
 
-  # Run with --verbose
-  result = runner.invoke(app, ['generate', 'grid', '--verbose'])
+  # Run with --show-responses
+  result = runner.invoke(app, ['generate', 'grid', '--show-responses'])
 
   assert result.exit_code == 0
   mock_load_config.assert_called_once_with(
-    config_path='wpt-gen.yml', provider_override=None, wpt_dir_override=None, verbose_override=True
+    config_path='wpt-gen.yml',
+    provider_override=None,
+    wpt_dir_override=None,
+    show_responses=True,
   )
 
 

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -27,7 +27,7 @@ class Config:
   model: str
   api_key: str
   wpt_path: str
-  verbose: bool = False
+  show_responses: bool = False
 
 
 WPT_DEFAULT_PATH = os.path.abspath(os.path.join(os.getcwd(), os.pardir, 'wpt'))
@@ -37,7 +37,7 @@ def load_config(
   config_path: str = 'wpt-gen.yml',
   provider_override: str | None = None,
   wpt_dir_override: str | None = None,
-  verbose_override: bool = False,
+  show_responses: bool = False,
 ) -> Config:
   """
   Loads configuration from YAML and environment variables.
@@ -78,8 +78,12 @@ def load_config(
     )
 
   wpt_path = wpt_dir_override or yaml_data.get('wpt_path', WPT_DEFAULT_PATH)
-  verbose = verbose_override or yaml_data.get('verbose', False)
+  show_responses = show_responses or yaml_data.get('show_responses', False)
 
   return Config(
-    provider=active_provider, model=model, api_key=api_key, wpt_path=wpt_path, verbose=verbose
+    provider=active_provider,
+    model=model,
+    api_key=api_key,
+    wpt_path=wpt_path,
+    show_responses=show_responses,
   )

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -228,7 +228,7 @@ class WPTGenEngine:
       loop = asyncio.get_running_loop()
       response = await loop.run_in_executor(None, self.llm.generate_content, prompt)
       self.console.print(f'✔ {task_name} finished.')
-      if self.config.verbose:
+      if self.config.show_responses:
         self.console.print(Panel(response, title=f'LLM Response: {task_name}', border_style='cyan'))
       return response
     except Exception as e:

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -58,8 +58,11 @@ def generate(
   config_path: Annotated[
     str, typer.Option('--config', '-c', help='Path to a custom wpt-gen.yml file.')
   ] = 'wpt-gen.yml',
-  verbose: Annotated[
-    bool, typer.Option('--verbose', '-v', help='Display every LLM-generated response to the user.')
+  show_responses: Annotated[
+    bool,
+    typer.Option(
+      '--show-responses', '-s', help='Display every LLM-generated response to the user.'
+    ),
   ] = False,
 ):
   """
@@ -77,7 +80,7 @@ def generate(
       config_path=config_path,
       provider_override=provider,
       wpt_dir_override=wpt_dir_str,
-      verbose_override=verbose,
+      show_responses=show_responses,
     )
 
     console.print(


### PR DESCRIPTION
Fixes #16

This PR adds a new `--show-responses` (or `-s`) command-line flag to the generate command. When enabled, the CLI will display every raw LLM-generated response in a dedicated Rich panel, providing better transparency into the intermediate steps of the test generation workflow (Spec Synthesis, Test Analysis, etc.).