### PR TITLE
Add lint and tests to the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  pytest_and_lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[dev]
+
+    - name: Run linting
+      run: |
+        ruff check . || (echo "::error::Linting failed. Run 'ruff check --fix .' locally to fix common issues." && exit 1)
+        ruff format --check . || (echo "::error::Formatting failed. Run 'ruff format .' locally to fix." && exit 1)
+
+    - name: Run tests with pytest
+      run: |
+        pytest

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -137,10 +137,10 @@ def find_feature_tests(target_directory: str, feature_id: str) -> list[str]:
     raise ValueError(f'The directory provided does not exist: {base_dir}')
 
   relevant_files: set[str] = set()
-  TARGET_METADATA_FILE = 'WEB_FEATURES.yml'
+  target_metadata_file = 'WEB_FEATURES.yml'
 
   # rglob recursively finds all WEB_FEATURES.yml files in the entire repository
-  for yaml_path in base_dir.rglob(TARGET_METADATA_FILE):
+  for yaml_path in base_dir.rglob(target_metadata_file):
     try:
       with open(yaml_path, encoding='utf-8') as f:
         data = yaml.safe_load(f)
@@ -309,5 +309,7 @@ def gather_local_test_context(test_paths: list[str], wpt_root: str) -> WPTContex
     test_to_deps[test_p_str] = relevant_deps
 
   return WPTContext(
-    test_contents=test_contents, dependency_contents=dependency_contents, test_to_deps=test_to_deps
+    test_contents=test_contents,
+    dependency_contents=dependency_contents,
+    test_to_deps=test_to_deps,
   )

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -149,7 +149,9 @@ class WPTGenEngine:
     spec_analysis, test_analysis = analysis
 
     suggestions_prompt = self.jinja_env.get_template('test_suggestions.jinja').render(
-      feature_id=web_feature_id, feature_spec_summary=spec_analysis, test_summaries=[test_analysis]
+      feature_id=web_feature_id,
+      feature_spec_summary=spec_analysis,
+      test_summaries=[test_analysis],
     )
 
     with self.console.status('[blue]Brainstorming test scenarios...[/blue]'):


### PR DESCRIPTION
Fixes #11 

This change adds `pytest` and `ruff` checks to the CI, as well as fixes some linting issues found with the command.

Edit: This may end up changing to use `pylint` over `ruff`, but I can handle that in  a subsequent PR.