### PR TITLE
Implement Semantic Caching for Spec Synthesis

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,0 +1,148 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wptgen.config import Config
+from wptgen.engine import WPTGenEngine
+
+
+@pytest.fixture
+def mock_config(tmp_path):
+  """Provides a basic Config object with a temporary cache path."""
+  return Config(
+    provider='llmbargainbin',
+    model='discountmodel',
+    api_key='fake-key',
+    wpt_path='/fake/wpt',
+    yes_tokens=True,
+    cache_path=str(tmp_path / '.wpt-gen-cache'),
+  )
+
+
+@pytest.fixture
+def mock_llm():
+  """Provides a mocked LLM client."""
+  llm = MagicMock()
+  llm.generate_content.return_value = 'Mocked LLM Response'
+  llm.count_tokens.return_value = 100
+  llm.prompt_exceeds_input_token_limit.return_value = False
+  return llm
+
+
+@pytest.fixture
+def engine(mock_config, mock_llm):
+  """Provides a WPTGenEngine instance with a mocked LLM client."""
+  with patch('wptgen.engine.get_llm_client', return_value=mock_llm):
+    return WPTGenEngine(mock_config)
+
+
+@pytest.mark.asyncio
+async def test_requirements_analysis_cache_miss(engine, mock_llm, mocker):
+  """Verify that Phase 2 generates and saves cache on a miss."""
+  context = {
+    'metadata': MagicMock(name='Feat', description='Desc', specs=['http://spec']),
+    'spec_contents': 'spec',
+    'wpt_context': MagicMock(),
+  }
+
+  # Mock LLM to return distinct responses based on prompt content.
+  def llm_side_effect(prompt):
+    if '<spec_document>' in prompt:
+      return 'New Spec Synthesis'
+    return 'New Test Analysis'
+
+  mock_llm.generate_content.side_effect = llm_side_effect
+
+  # Mock Confirm.ask to return True if called
+  # (though it shouldn't be for cache check if file doesn't exist).
+  mock_confirm_ask = mocker.patch('wptgen.engine.Confirm.ask', return_value=True)
+
+  web_feature_id = 'test-feat'
+  result = await engine._phase_requirements_analysis(web_feature_id, context)
+
+  assert result == ('New Spec Synthesis', 'New Test Analysis')
+
+  # Verify cache file was created
+  cache_file = engine.spec_synthesis_cache_dir / f'{web_feature_id}.md'
+  assert cache_file.exists()
+  assert cache_file.read_text() == 'New Spec Synthesis'
+
+  # Confirm.ask should NOT have been called for cache because file didn't exist
+  # Wait, Confirm.ask is also used in _confirm_prompts, but we set yes_tokens=True
+  mock_confirm_ask.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_requirements_analysis_cache_hit_accept(engine, mock_llm, mocker):
+  """Verify that Phase 2 uses cached synthesis when user accepts."""
+  web_feature_id = 'cached-feat'
+  cache_file = engine.spec_synthesis_cache_dir / f'{web_feature_id}.md'
+  cache_file.write_text('Cached Spec Synthesis')
+
+  context = {
+    'metadata': MagicMock(name='Feat', description='Desc', specs=['http://spec']),
+    'spec_contents': 'spec',
+    'wpt_context': MagicMock(),
+  }
+
+  # User accepts cache
+  mock_confirm_ask = mocker.patch('wptgen.engine.Confirm.ask', return_value=True)
+  # Only Test Analysis should be generated
+  mock_llm.generate_content.return_value = 'New Test Analysis'
+
+  result = await engine._phase_requirements_analysis(web_feature_id, context)
+
+  assert result == ('Cached Spec Synthesis', 'New Test Analysis')
+
+  # LLM should only have been called once (for Test Analysis).
+  assert mock_llm.generate_content.call_count == 1
+  mock_confirm_ask.assert_called_once_with('Use cached Spec Synthesis?')
+
+
+@pytest.mark.asyncio
+async def test_requirements_analysis_cache_hit_reject(engine, mock_llm, mocker):
+  """Verify that Phase 2 regenerates synthesis when user rejects cache."""
+  web_feature_id = 'rejected-cache-feat'
+  cache_file = engine.spec_synthesis_cache_dir / f'{web_feature_id}.md'
+  cache_file.write_text('Old Cached Spec Synthesis')
+
+  context = {
+    'metadata': MagicMock(name='Feat', description='Desc', specs=['http://spec']),
+    'spec_contents': 'spec',
+    'wpt_context': MagicMock(),
+  }
+
+  # User rejects cache
+  mocker.patch('wptgen.engine.Confirm.ask', return_value=False)
+
+  # Both should be generated
+  def llm_side_effect(prompt):
+    if '<spec_document>' in prompt:
+      return 'New Spec Synthesis'
+    return 'New Test Analysis'
+
+  mock_llm.generate_content.side_effect = llm_side_effect
+
+  result = await engine._phase_requirements_analysis(web_feature_id, context)
+
+  assert result == ('New Spec Synthesis', 'New Test Analysis')
+
+  # LLM should have been called twice.
+  assert mock_llm.generate_content.call_count == 2
+
+  # Cache file should be updated.
+  assert cache_file.read_text() == 'New Spec Synthesis'

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -24,7 +24,7 @@ from wptgen.engine import WPTGenEngine
 
 
 @pytest.fixture
-def mock_config():
+def mock_config(tmp_path):
   """Provides a basic Config object for testing."""
   return Config(
     provider='llmbargainbin',
@@ -32,6 +32,7 @@ def mock_config():
     api_key='fake-key',
     wpt_path=os.path.abspath(os.sep + 'fake' + os.sep + 'wpt'),
     yes_tokens=False,
+    cache_path=str(tmp_path / '.wpt-gen-cache'),
   )
 
 

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -29,6 +30,23 @@ class Config:
   wpt_path: str
   show_responses: bool = False
   yes_tokens: bool = False
+  cache_path: str | None = None
+
+
+def _get_default_cache_path() -> str:
+  """Returns a platform-appropriate default cache directory."""
+  home = Path.home()
+  if sys.platform == 'win32':
+    base = Path(os.environ.get('LOCALAPPDATA', home / 'AppData' / 'Local'))
+    return str(base / 'wpt-gen' / 'Cache')
+  elif sys.platform == 'darwin':
+    return str(home / 'Library' / 'Caches' / 'wpt-gen')
+  else:
+    # Linux / Unix - Follow XDG spec if possible
+    xdg_cache = os.environ.get('XDG_CACHE_HOME')
+    if xdg_cache:
+      return str(Path(xdg_cache) / 'wpt-gen')
+    return str(home / '.cache' / 'wpt-gen')
 
 
 WPT_DEFAULT_PATH = os.path.abspath(os.path.join(os.getcwd(), os.pardir, 'wpt'))
@@ -82,6 +100,7 @@ def load_config(
   wpt_path = wpt_dir_override or yaml_data.get('wpt_path', WPT_DEFAULT_PATH)
   show_responses = show_responses or yaml_data.get('show_responses', False)
   yes_tokens = yes_tokens_override or yaml_data.get('yes_tokens', False)
+  cache_path = yaml_data.get('cache_path') or _get_default_cache_path()
 
   return Config(
     provider=active_provider,
@@ -90,4 +109,5 @@ def load_config(
     wpt_path=wpt_path,
     show_responses=show_responses,
     yes_tokens=yes_tokens,
+    cache_path=cache_path,
   )

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -48,6 +48,9 @@ class WPTGenEngine:
     template_dir = Path(__file__).parent.joinpath('templates')
     self.jinja_env = Environment(loader=FileSystemLoader(template_dir))
 
+    self.spec_synthesis_cache_dir = Path(self.config.cache_path) / 'spec_synthesis'
+    self.spec_synthesis_cache_dir.mkdir(parents=True, exist_ok=True)
+
   def run_workflow(self, web_feature_id: str):
     """Entry point for the synchronous CLI to launch the async workflow."""
     asyncio.run(self._run_async_workflow(web_feature_id))
@@ -112,6 +115,15 @@ class WPTGenEngine:
   ) -> tuple[str, str] | None:
     self.console.print('\n[bold cyan]--- Phase 2: Requirements Analysis ---[/bold cyan]')
 
+    cache_file = self.spec_synthesis_cache_dir / f'{web_feature_id}.md'
+    spec_analysis = None
+
+    if cache_file.exists():
+      self.console.print(f'[yellow]Found cached Spec Synthesis for {web_feature_id}.[/yellow]')
+      if Confirm.ask('Use cached Spec Synthesis?'):
+        spec_analysis = cache_file.read_text(encoding='utf-8')
+        self.console.print('✔ Using cached Spec Synthesis.')
+
     spec_prompt = self.jinja_env.get_template('spec_synthesis.jinja').render(
       feature_name=context['metadata'].name,
       feature_description=context['metadata'].description,
@@ -123,25 +135,33 @@ class WPTGenEngine:
       feature_id=web_feature_id, wpt_context=context['wpt_context']
     )
 
-    await self._confirm_prompts(
-      [(spec_prompt, 'Spec Synthesis'), (test_prompt, 'Test Analysis')],
-      'Requirements Analysis',
-    )
+    prompts_to_confirm = []
+    if not spec_analysis:
+      prompts_to_confirm.append((spec_prompt, 'Spec Synthesis'))
+    prompts_to_confirm.append((test_prompt, 'Test Analysis'))
 
-    self.console.print(
-      'Submitting [bold]Spec Synthesis[/bold] and [bold]Test Analysis[/bold] tasks concurrently...'
-    )
+    await self._confirm_prompts(prompts_to_confirm, 'Requirements Analysis')
 
-    results = await asyncio.gather(
-      self._generate_safe(spec_prompt, 'Spec Synthesis'),
-      self._generate_safe(test_prompt, 'Test Analysis'),
-    )
-
-    spec_analysis, test_analysis = results
+    if spec_analysis:
+      self.console.print('Submitting [bold]Test Analysis[/bold] task...')
+      test_analysis = await self._generate_safe(test_prompt, 'Test Analysis')
+    else:
+      self.console.print(
+        'Submitting [bold]Spec Synthesis[/bold] and [bold]Test Analysis[/bold] tasks concurrently...'
+      )
+      results = await asyncio.gather(
+        self._generate_safe(spec_prompt, 'Spec Synthesis'),
+        self._generate_safe(test_prompt, 'Test Analysis'),
+      )
+      spec_analysis, test_analysis = results
 
     if not spec_analysis or not test_analysis:
       self.console.print('[bold red]Critical Error:[/bold red] One or more analysis steps failed.')
       return None
+
+    # Save to cache if it was newly generated
+    if not cache_file.exists() or (spec_analysis and not cache_file.read_text() == spec_analysis):
+      cache_file.write_text(spec_analysis, encoding='utf-8')
 
     self.console.print('\n[bold green]✔ Requirements Analysis Complete.[/bold green]')
     return (spec_analysis, test_analysis)


### PR DESCRIPTION
Fixes #5

This PR introduces a semantic caching layer for the **Spec Synthesis** phase. Generating a comprehensive technical reference from raw specification text is token-intensive and time-consuming. By caching these results, we significantly reduce LLM costs and improve the developer experience when re-running the tool for a specific feature.

### Key Features

*   **Intelligent Cache Lookups:** Before starting the Requirements Analysis, the engine checks for an existing synthesis for the target `web_feature_id`.
*   **User-in-the-Loop:** When a cache hit occurs, the tool prompts the user to reuse the cached version or regenerate it (useful if the spec content has changed).
*   **Platform-Aware Storage:** Adheres to OS-specific conventions for user-level data, making it ideal for `pip` distribution:
    *   **Linux:** `~/.cache/wpt-gen` (respects `XDG_CACHE_HOME`)
    *   **macOS:** `~/Library/Caches/wpt-gen`
    *   **Windows:** `%LOCALAPPDATA%\wpt-gen\Cache`
*   **Global Persistence:** Caching is tied to the user profile, not the current working directory, allowing synthesis sharing across different local clones of the `wpt` repository.

### Technical Changes

#### `wptgen/config.py`
- Implemented `_get_default_cache_path()` to calculate platform-appropriate directories using `sys.platform`.
- Updated `Config` and `load_config` to prioritize user-defined paths from `wpt-gen.yml` while falling back to the new platform defaults.

#### `wptgen/engine.py`
- Modified `WPTGenEngine.__init__` to ensure the cache directory exists on startup.
- Refactored `_phase_requirements_analysis` to handle the cache lookup, user confirmation, and conditional generation logic.
- Implemented automatic cache updates whenever a new synthesis is successfully generated.

#### Testing
- **New `tests/test_caching.py`:** Dedicated test suite covering cache hits, misses, and user rejection scenarios.
- **Updated `tests/test_engine.py`:** Updated existing engine tests to use isolated temporary directories for caching to prevent cross-test pollution and `stdin` errors during CI.