### PR TITLE
Add `--suggestions-only` flag to skip test generation

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -174,6 +174,74 @@ async def test_phase_test_generation_calls_confirm(
   assert len(mock_confirm.call_args[0][0]) == 2
 
 
+@pytest.mark.asyncio
+async def test_provide_test_suggestions_save(
+  engine: WPTGenEngine, mocker: MockerFixture, tmp_path: Path
+) -> None:
+  """Verifies that _provide_test_suggestions saves the response to a file when the user confirms."""
+  context = {'feature_id': 'test-feat'}
+  suggestions_response = 'Mock Suggestions Content'
+
+  mocker.patch('wptgen.engine.Confirm.ask', return_value=True)
+  # Default filename will be test_feat_test_suggestions.md
+  expected_filename = tmp_path / 'test_feat_test_suggestions.md'
+
+  # Patch Path to use our tmp_path for the specific filename
+  with patch('wptgen.engine.Path.write_text') as mock_write:
+    with patch('wptgen.engine.Path.absolute', return_value=expected_filename):
+      await engine._provide_test_suggestions(context, suggestions_response)
+
+  mock_write.assert_called_once_with(suggestions_response, encoding='utf-8')
+
+
+@pytest.mark.asyncio
+async def test_provide_test_suggestions_no_save(
+  engine: WPTGenEngine, mocker: MockerFixture
+) -> None:
+  """Verifies that _provide_test_suggestions does NOT save if the user declines."""
+  context = {'feature_id': 'test-feat'}
+  suggestions_response = 'Mock Suggestions Content'
+
+  mocker.patch('wptgen.engine.Confirm.ask', return_value=False)
+  mock_write = mocker.patch('wptgen.engine.Path.write_text')
+
+  await engine._provide_test_suggestions(context, suggestions_response)
+
+  mock_write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_async_workflow_suggestions_only(
+  engine: WPTGenEngine, mocker: MockerFixture
+) -> None:
+  """Verifies that the workflow short-circuits to _provide_test_suggestions when config.suggestions_only is True."""
+  engine.config.suggestions_only = True
+
+  mock_metadata = MagicMock()
+  mock_metadata.name = 'Test Feature'
+  mock_metadata.description = 'Test Description'
+  mock_metadata.specs = ['http://spec']
+
+  context = {
+    'feature_id': 'test-feat',
+    'metadata': mock_metadata,
+    'spec_contents': 'spec content',
+    'wpt_context': MagicMock(),
+  }
+
+  mocker.patch.object(engine, '_phase_context_assembly', return_value=context)
+  # Mock token check to fit in context
+  mocker.patch.object(engine.llm, 'prompt_exceeds_input_token_limit', return_value=False)
+  mocker.patch.object(engine, '_phase_unified_suggestions', return_value='suggestions')
+  mock_provide = mocker.patch.object(engine, '_provide_test_suggestions', return_value=None)
+  mock_gen = mocker.patch.object(engine, '_phase_test_generation')
+
+  await engine._run_async_workflow('test-feat')
+
+  mock_provide.assert_called_once_with(context, 'suggestions')
+  mock_gen.assert_not_called()
+
+
 def test_engine_init(engine: WPTGenEngine, mock_config: Config) -> None:
   """Verifies that the engine initializes correctly with the given configuration."""
   assert engine.config == mock_config

--- a/tests/test_engine_unified_flow.py
+++ b/tests/test_engine_unified_flow.py
@@ -30,6 +30,7 @@ def engine(mocker: MockerFixture) -> WPTGenEngine:
   mock_config.api_key = 'fake-key'
   mock_config.wpt_path = '/fake/wpt'
   mock_config.yes_tokens = False
+  mock_config.suggestions_only = False
   mock_config.cache_path = '/tmp/cache'
 
   mock_llm = MagicMock()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -66,6 +66,7 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     wpt_dir_override=None,
     show_responses=False,
     yes_tokens_override=False,
+    suggestions_only=False,
   )
   mock_engine_class.assert_called_once_with(config=mock_config)
   mock_engine_instance.run_workflow.assert_called_once_with('grid')
@@ -86,6 +87,7 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     wpt_dir_override=None,
     show_responses=True,
     yes_tokens_override=False,
+    suggestions_only=False,
   )
 
 
@@ -104,6 +106,26 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     wpt_dir_override=None,
     show_responses=False,
     yes_tokens_override=True,
+    suggestions_only=False,
+  )
+
+
+def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test that the --suggestions-only flag is correctly passed to load_config."""
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+  mocker.patch('wptgen.main.WPTGenEngine')
+
+  # Run with --suggestions-only
+  result = runner.invoke(app, ['generate', 'grid', '--suggestions-only'])
+
+  assert result.exit_code == 0
+  mock_load_config.assert_called_once_with(
+    config_path='wpt-gen.yml',
+    provider_override=None,
+    wpt_dir_override=None,
+    show_responses=False,
+    yes_tokens_override=False,
+    suggestions_only=True,
   )
 
 

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -31,6 +31,7 @@ class Config:
   wpt_path: str
   show_responses: bool = False
   yes_tokens: bool = False
+  suggestions_only: bool = False
   cache_path: str | None = None
 
 
@@ -59,6 +60,7 @@ def load_config(
   wpt_dir_override: str | None = None,
   show_responses: bool = False,
   yes_tokens_override: bool = False,
+  suggestions_only: bool = False,
 ) -> Config:
   """
   Loads configuration from YAML and environment variables.
@@ -101,6 +103,7 @@ def load_config(
   wpt_path = wpt_dir_override or yaml_data.get('wpt_path', WPT_DEFAULT_PATH)
   show_responses = show_responses or yaml_data.get('show_responses', False)
   yes_tokens = yes_tokens_override or yaml_data.get('yes_tokens', False)
+  suggestions_only = suggestions_only or yaml_data.get('suggestions_only', False)
   cache_path = yaml_data.get('cache_path') or _get_default_cache_path()
 
   return Config(
@@ -110,5 +113,6 @@ def load_config(
     wpt_path=wpt_path,
     show_responses=show_responses,
     yes_tokens=yes_tokens,
+    suggestions_only=suggestions_only,
     cache_path=cache_path,
   )

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -97,8 +97,30 @@ class WPTGenEngine:
     if not suggestions:
       return
 
+    # Skip Phase 4 if the user only wants the suggestions.
+    if self.config.suggestions_only:
+      await self._provide_test_suggestions(context, suggestions)
+      return
+
     # Phase 4: User Selection & Generation
     await self._phase_test_generation(context, suggestions)
+
+  async def _provide_test_suggestions(
+    self, context: dict[str, Any], suggestions_response: str
+  ) -> None:
+    """Prints the test suggestions response and optionally saves it to a file."""
+    self.console.print('\n[bold cyan]--- Test Suggestions ---[/bold cyan]')
+    self.console.print(suggestions_response)
+
+    if Confirm.ask('\nSave suggestions to a file?'):
+      # Create a sanitized filename from the feature ID
+      safe_id = FILENAME_SANITIZATION_RE.sub('_', context['feature_id'].lower())
+      filename = f'{safe_id}_test_suggestions.md'
+      try:
+        Path(filename).write_text(suggestions_response, encoding='utf-8')
+        self.console.print(f'[green]Saved:[/green] {Path(filename).absolute()}')
+      except Exception as e:
+        self.console.print(f'[bold red]Error saving file:[/bold red] {e}')
 
   async def _phase_unified_suggestions(self, prompt: str) -> str | None:
     self.console.print('\n[bold cyan]--- Phase 2: Consolidated Test Suggestions ---[/bold cyan]')
@@ -146,7 +168,12 @@ class WPTGenEngine:
       f'{len(wpt_context.dependency_contents)} dependency files.'
     )
 
-    return {'metadata': metadata, 'spec_contents': spec_contents, 'wpt_context': wpt_context}
+    return {
+      'feature_id': web_feature_id,
+      'metadata': metadata,
+      'spec_contents': spec_contents,
+      'wpt_context': wpt_context,
+    }
 
   async def _phase_requirements_analysis(
     self, web_feature_id: str, context: dict[str, Any]

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -68,6 +68,13 @@ def generate(
     bool,
     typer.Option('--yes-tokens', help='Automatically confirm all token count prompts.'),
   ] = False,
+  suggestions_only: Annotated[
+    bool,
+    typer.Option(
+      '--suggestions-only',
+      help='Only show test suggestions and skip the test generation step.',
+    ),
+  ] = False,
 ) -> None:
   """
   Generate Web Platform Tests for a specific web feature.
@@ -86,6 +93,7 @@ def generate(
       wpt_dir_override=wpt_dir_str,
       show_responses=show_responses,
       yes_tokens_override=yes_tokens,
+      suggestions_only=suggestions_only,
     )
 
     console.print(


### PR DESCRIPTION
Fixes #15

Introduces a new command-line flag `--suggestions-only` that allows users to retrieve and save test suggestions from the LLM without proceeding to the automated test generation phase.

Key changes:
- Added `suggestions_only` to the global configuration and CLI `generate` command.
- Implemented `_provide_test_suggestions` in the engine to display raw LLM responses and provide an option to save them to disk.
- Added automatic, sanitized filenaming for suggestions (e.g., `<feature_id>_test_suggestions.md`).
- Updated the main engine workflow to short-circuit after the suggestion phase when the flag is active.
- Added comprehensive unit tests in `tests/test_engine.py` to verify the new flow and file saving logic.
- Added documentation for the new engine methods.