### PR TITLE
Configurable retry logic

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,3 +68,16 @@ def test_load_config_spec_urls(monkeypatch: pytest.MonkeyPatch) -> None:
   config = load_config(config_path='non_existent_dummy.yaml', spec_urls_override=spec_urls)
 
   assert config.spec_urls == spec_urls
+
+
+def test_load_config_max_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Test that max_retries is correctly loaded into the Config object."""
+  monkeypatch.setenv('GEMINI_API_KEY', 'mock-key')
+
+  # Case 1: Default
+  config = load_config(config_path='non_existent_dummy.yaml')
+  assert config.max_retries == 3
+
+  # Case 2: Override
+  config = load_config(config_path='non_existent_dummy.yaml', max_retries_override=10)
+  assert config.max_retries == 10

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -113,6 +113,29 @@ def test_gemini_count_tokens(mocker: MockerFixture, gemini_config: Config) -> No
   )
 
 
+def test_gemini_retry_on_failure(mocker: MockerFixture, gemini_config: Config) -> None:
+  """Test that GeminiClient retries on failure."""
+  mocker.patch('time.sleep')  # Speed up tests
+  mock_client_class = mocker.patch('wptgen.llm.genai.Client')
+  mock_instance = mock_client_class.return_value
+
+  # Mock the response to fail twice then succeed
+  mock_response = mocker.MagicMock()
+  mock_response.text = 'Success after retry'
+
+  mock_instance.models.generate_content.side_effect = [
+    Exception('Transient error 1'),
+    Exception('Transient error 2'),
+    mock_response,
+  ]
+
+  client = GeminiClient(api_key=gemini_config.api_key, model=gemini_config.model)
+  result = client.generate_content(prompt='Test prompt')
+
+  assert result == 'Success after retry'
+  assert mock_instance.models.generate_content.call_count == 3
+
+
 def test_openai_generate_content(mocker: MockerFixture, openai_config: Config) -> None:
   """Test that OpenAIClient correctly maps to the OpenAI SDK."""
   # Arrange: Mock the OpenAI class and its deep method chain
@@ -144,6 +167,32 @@ def test_openai_generate_content(mocker: MockerFixture, openai_config: Config) -
       {'role': 'user', 'content': 'Test prompt'},
     ],
   )
+
+
+def test_openai_retry_on_failure(mocker: MockerFixture, openai_config: Config) -> None:
+  """Test that OpenAIClient retries on failure."""
+  mocker.patch('time.sleep')
+  mock_openai_class = mocker.patch('wptgen.llm.OpenAI')
+  mock_instance = mock_openai_class.return_value
+
+  # Simulate OpenAI's deep response structure
+  mock_message = mocker.MagicMock()
+  mock_message.content = 'Success after OpenAI retry'
+  mock_choice = mocker.MagicMock()
+  mock_choice.message = mock_message
+  mock_response = mocker.MagicMock()
+  mock_response.choices = [mock_choice]
+
+  mock_instance.chat.completions.create.side_effect = [
+    Exception('OpenAI error 1'),
+    mock_response,
+  ]
+
+  client = OpenAIClient(api_key=openai_config.api_key, model=openai_config.model)
+  result = client.generate_content(prompt='Test prompt')
+
+  assert result == 'Success after OpenAI retry'
+  assert mock_instance.chat.completions.create.call_count == 2
 
 
 def test_gemini_prompt_exceeds_limit(mocker: MockerFixture, gemini_config: Config) -> None:
@@ -203,3 +252,22 @@ def test_openai_prompt_exceeds_limit(mocker: MockerFixture, openai_config: Confi
   # "a " is usually 1 token. 400,001 "a "s should exceed the limit.
   huge_prompt = 'a ' * 400001
   assert client.prompt_exceeds_input_token_limit(huge_prompt) is True
+
+
+def test_llm_client_custom_retries(mocker: MockerFixture, gemini_config: Config) -> None:
+  """Test that LLM clients respect the custom max_retries setting."""
+  mocker.patch('time.sleep')
+  mock_client_class = mocker.patch('wptgen.llm.genai.Client')
+  mock_instance = mock_client_class.return_value
+
+  # Config with 5 retries
+  gemini_config.max_retries = 5
+  client = get_llm_client(gemini_config)
+
+  # Mock to fail forever
+  mock_instance.models.generate_content.side_effect = Exception('Fail')
+
+  with pytest.raises(Exception, match='Fail'):
+    client.generate_content('test')
+
+  assert mock_instance.models.generate_content.call_count == 5

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -34,6 +34,7 @@ def mock_config() -> Config:
     model='gemini-3-pro-preview',
     api_key='fake-key',
     wpt_path=os.path.join('..', 'wpt'),
+    max_retries=3,
   )
 
 
@@ -76,6 +77,7 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     show_responses=False,
     yes_tokens_override=False,
     suggestions_only=False,
+    max_retries_override=3,
     spec_urls_override=None,
   )
   mock_engine_class.assert_called_once_with(config=mock_config)
@@ -98,6 +100,7 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     show_responses=True,
     yes_tokens_override=False,
     suggestions_only=False,
+    max_retries_override=3,
     spec_urls_override=None,
   )
 
@@ -118,6 +121,7 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     show_responses=False,
     yes_tokens_override=True,
     suggestions_only=False,
+    max_retries_override=3,
     spec_urls_override=None,
   )
 
@@ -138,6 +142,28 @@ def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -
     show_responses=False,
     yes_tokens_override=False,
     suggestions_only=True,
+    max_retries_override=3,
+    spec_urls_override=None,
+  )
+
+
+def test_generate_max_retries(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test that the --max-retries flag is correctly passed to load_config."""
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+  mocker.patch('wptgen.main.WPTGenEngine')
+
+  # Run with --max-retries
+  result = runner.invoke(app, ['generate', 'grid', '--max-retries', '5'])
+
+  assert result.exit_code == 0
+  mock_load_config.assert_called_once_with(
+    config_path='wpt-gen.yml',
+    provider_override=None,
+    wpt_dir_override=None,
+    show_responses=False,
+    yes_tokens_override=False,
+    suggestions_only=False,
+    max_retries_override=5,
     spec_urls_override=None,
   )
 
@@ -189,5 +215,6 @@ def test_generate_spec_urls(mocker: MockerFixture, mock_config: Config) -> None:
     show_responses=False,
     yes_tokens_override=False,
     suggestions_only=False,
+    max_retries_override=3,
     spec_urls_override=['https://url1.com', 'https://url2.com'],
   )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,212 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from pytest_mock import MockerFixture
+
+from wptgen.utils import retry
+
+
+def test_retry_success() -> None:
+  """Test that retry doesn't interfere with successful calls."""
+  call_count = 0
+
+  @retry(exceptions=ValueError, max_attempts=3)
+  def success_func() -> str:
+    nonlocal call_count
+    call_count += 1
+    return 'success'
+
+  result = success_func()
+  assert result == 'success'
+  assert call_count == 1
+
+
+def test_retry_eventual_success(mocker: MockerFixture) -> None:
+  """Test that retry succeeds if the function eventually succeeds."""
+  mocker.patch('time.sleep')  # Speed up tests
+  call_count = 0
+
+  @retry(exceptions=ValueError, max_attempts=3)
+  def eventual_success() -> str:
+    nonlocal call_count
+    call_count += 1
+    if call_count < 3:
+      raise ValueError('Fail')
+    return 'success'
+
+  result = eventual_success()
+  assert result == 'success'
+  assert call_count == 3
+
+
+def test_retry_max_attempts_reached(mocker: MockerFixture) -> None:
+  """Test that retry raises the last exception after max attempts."""
+  mocker.patch('time.sleep')
+  call_count = 0
+
+  @retry(exceptions=ValueError, max_attempts=3)
+  def always_fail() -> None:
+    nonlocal call_count
+    call_count += 1
+    raise ValueError(f'Fail {call_count}')
+
+  with pytest.raises(ValueError, match='Fail 3'):
+    always_fail()
+
+  assert call_count == 3
+
+
+def test_retry_unhandled_exception(mocker: MockerFixture) -> None:
+  """Test that retry doesn't catch exceptions not in the list."""
+  mocker.patch('time.sleep')
+  call_count = 0
+
+  @retry(exceptions=ValueError, max_attempts=3)
+  def unhandled_fail() -> None:
+    nonlocal call_count
+    call_count += 1
+    raise TypeError('Unhandled')
+
+  with pytest.raises(TypeError, match='Unhandled'):
+    unhandled_fail()
+
+  assert call_count == 1
+
+
+def test_retry_max_attempts_attr(mocker: MockerFixture) -> None:
+  """Test that retry correctly looks up max attempts from an instance attribute."""
+  mocker.patch('time.sleep')
+
+  class TestClass:
+    def __init__(self, retries: int):
+      self.retries = retries
+      self.calls = 0
+
+    @retry(exceptions=ValueError, max_attempts_attr='retries')
+    def do_something(self) -> str:
+      self.calls += 1
+      raise ValueError('Fail')
+
+  # Case 1: 2 retries
+  obj2 = TestClass(retries=2)
+  with pytest.raises(ValueError, match='Fail'):
+    obj2.do_something()
+  assert obj2.calls == 2
+
+  # Case 2: 4 retries
+  obj4 = TestClass(retries=4)
+  with pytest.raises(ValueError, match='Fail'):
+    obj4.do_something()
+  assert obj4.calls == 4
+
+
+def test_retry_multiple_exceptions(mocker: MockerFixture) -> None:
+  """Test that retry catches any exception in the provided tuple."""
+  mocker.patch('time.sleep')
+  call_count = 0
+
+  @retry(exceptions=(ValueError, KeyError), max_attempts=3)
+  def multiple_fail() -> None:
+    nonlocal call_count
+    call_count += 1
+    if call_count == 1:
+      raise ValueError('Value')
+    raise KeyError('Key')
+
+  with pytest.raises(KeyError, match='Key'):
+    multiple_fail()
+
+  assert call_count == 3
+
+
+def test_retry_backoff_timing(mocker: MockerFixture) -> None:
+  """Test that the delay increases exponentially without jitter."""
+  mock_sleep = mocker.patch('time.sleep')
+  call_count = 0
+
+  @retry(
+    exceptions=ValueError,
+    max_attempts=4,
+    initial_delay=1.0,
+    backoff_factor=2.0,
+    jitter=False,
+  )
+  def backoff_fail() -> None:
+    nonlocal call_count
+    call_count += 1
+    raise ValueError('Fail')
+
+  with pytest.raises(ValueError, match='Fail'):
+    backoff_fail()
+
+  # Expected sleeps: 1.0, 2.0, 4.0
+  assert mock_sleep.call_count == 3
+  mock_sleep.assert_has_calls(
+    [
+      mocker.call(1.0),
+      mocker.call(2.0),
+      mocker.call(4.0),
+    ]
+  )
+
+
+def test_retry_max_delay(mocker: MockerFixture) -> None:
+  """Test that the delay is capped by the global MAX_DELAY."""
+  from wptgen.utils import MAX_DELAY
+
+  mock_sleep = mocker.patch('time.sleep')
+
+  @retry(
+    exceptions=ValueError,
+    max_attempts=3,
+    initial_delay=MAX_DELAY + 10.0,  # Start above limit
+    backoff_factor=2.0,
+    jitter=False,
+  )
+  def huge_delay_fail() -> None:
+    raise ValueError('Fail')
+
+  with pytest.raises(ValueError, match='Fail'):
+    huge_delay_fail()
+
+  # Each sleep should be capped at MAX_DELAY
+  assert mock_sleep.call_count == 2
+  mock_sleep.assert_has_calls(
+    [
+      mocker.call(MAX_DELAY),
+      mocker.call(MAX_DELAY),
+    ]
+  )
+
+
+def test_retry_max_attempts_cap(mocker: MockerFixture) -> None:
+  """Test that max_attempts is capped by the global MAX_RETRIES."""
+  from wptgen.utils import MAX_RETRIES
+
+  mocker.patch('time.sleep')
+  call_count = 0
+
+  # Set max_attempts higher than the global MAX_RETRIES
+  @retry(exceptions=ValueError, max_attempts=MAX_RETRIES + 10)
+  def capped_fail() -> None:
+    nonlocal call_count
+    call_count += 1
+    raise ValueError('Fail')
+
+  with pytest.raises(ValueError, match='Fail'):
+    capped_fail()
+
+  # Should only have attempted MAX_RETRIES times
+  assert call_count == MAX_RETRIES

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -32,6 +32,7 @@ class Config:
   show_responses: bool = False
   yes_tokens: bool = False
   suggestions_only: bool = False
+  max_retries: int = 3
   cache_path: str | None = None
   spec_urls: list[str] | None = None
 
@@ -62,6 +63,7 @@ def load_config(
   show_responses: bool = False,
   yes_tokens_override: bool = False,
   suggestions_only: bool = False,
+  max_retries_override: int | None = None,
   spec_urls_override: list[str] | None = None,
 ) -> Config:
   """
@@ -106,6 +108,7 @@ def load_config(
   show_responses = show_responses or yaml_data.get('show_responses', False)
   yes_tokens = yes_tokens_override or yaml_data.get('yes_tokens', False)
   suggestions_only = suggestions_only or yaml_data.get('suggestions_only', False)
+  max_retries = max_retries_override or yaml_data.get('max_retries', 3)
   cache_path = yaml_data.get('cache_path') or _get_default_cache_path()
 
   return Config(
@@ -116,6 +119,7 @@ def load_config(
     show_responses=show_responses,
     yes_tokens=yes_tokens,
     suggestions_only=suggestions_only,
+    max_retries=max_retries,
     cache_path=cache_path,
     spec_urls=spec_urls_override,
   )

--- a/wptgen/llm.py
+++ b/wptgen/llm.py
@@ -22,14 +22,19 @@ from openai import OpenAI
 from openai.types.chat import ChatCompletionMessageParam
 
 from wptgen.config import Config
+from wptgen.utils import retry
+
+# Default retry configuration for LLM calls
+MAX_RETRIES = 3
 
 
 class LLMClient(ABC):
   """Abstract base class for all LLM providers."""
 
-  def __init__(self, api_key: str, model: str):
+  def __init__(self, api_key: str, model: str, max_retries: int = MAX_RETRIES):
     self.api_key = api_key
     self.model = model
+    self.max_retries = max_retries
 
   @abstractmethod
   def count_tokens(self, prompt: str) -> int:
@@ -48,17 +53,19 @@ class LLMClient(ABC):
 
 
 class GeminiClient(LLMClient):
-  def __init__(self, api_key: str, model: str):
-    super().__init__(api_key, model)
+  def __init__(self, api_key: str, model: str, max_retries: int = MAX_RETRIES):
+    super().__init__(api_key, model, max_retries)
     # Initialize the official Google GenAI client
     self.client = genai.Client(api_key=self.api_key)
 
+  @retry(exceptions=Exception, max_attempts_attr='max_retries')
   def count_tokens(self, prompt: str) -> int:
     response = self.client.models.count_tokens(model=self.model, contents=prompt)
     if response.total_tokens is None:
       raise ValueError('Gemini API returned no token count.')
     return response.total_tokens
 
+  @retry(exceptions=Exception, max_attempts_attr='max_retries')
   def generate_content(self, prompt: str, system_instruction: str | None = None) -> str:
     config = types.GenerateContentConfig()
     if system_instruction:
@@ -90,8 +97,8 @@ class GeminiClient(LLMClient):
 
 
 class OpenAIClient(LLMClient):
-  def __init__(self, api_key: str, model: str):
-    super().__init__(api_key, model)
+  def __init__(self, api_key: str, model: str, max_retries: int = MAX_RETRIES):
+    super().__init__(api_key, model, max_retries)
     self.client = OpenAI(api_key=self.api_key)
 
   def count_tokens(self, prompt: str) -> int:
@@ -103,6 +110,7 @@ class OpenAIClient(LLMClient):
       encoding = tiktoken.get_encoding('cl100k_base')
     return len(encoding.encode(prompt))
 
+  @retry(exceptions=Exception, max_attempts_attr='max_retries')
   def generate_content(self, prompt: str, system_instruction: str | None = None) -> str:
     messages: list[ChatCompletionMessageParam] = []
     if system_instruction:
@@ -141,8 +149,8 @@ class OpenAIClient(LLMClient):
 def get_llm_client(config: Config) -> LLMClient:
   """Factory function to instantiate the correct LLM provider."""
   if config.provider == 'gemini':
-    return GeminiClient(api_key=config.api_key, model=config.model)
+    return GeminiClient(api_key=config.api_key, model=config.model, max_retries=config.max_retries)
   elif config.provider == 'openai':
-    return OpenAIClient(api_key=config.api_key, model=config.model)
+    return OpenAIClient(api_key=config.api_key, model=config.model, max_retries=config.max_retries)
   else:
     raise ValueError(f'Unsupported provider: {config.provider}')

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -77,6 +77,13 @@ def generate(
       help='Only show test suggestions and skip the test generation step.',
     ),
   ] = False,
+  max_retries: Annotated[
+    int,
+    typer.Option(
+      '--max-retries',
+      help='Maximum number of retries for LLM calls.',
+    ),
+  ] = 3,
   spec_urls: Annotated[
     str | None,
     typer.Option(
@@ -107,6 +114,7 @@ def generate(
       show_responses=show_responses,
       yes_tokens_override=yes_tokens,
       suggestions_only=suggestions_only,
+      max_retries_override=max_retries,
       spec_urls_override=spec_urls_list,
     )
 

--- a/wptgen/utils.py
+++ b/wptgen/utils.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import time
+from collections.abc import Callable
+from functools import wraps
+from typing import ParamSpec, TypeVar
+
+T = TypeVar('T')
+P = ParamSpec('P')
+
+# Maximum delay between retries in seconds
+MAX_DELAY = 60.0
+
+# Default maximum number of retry attempts for transient failures
+MAX_RETRIES = 5
+
+
+def retry(
+  exceptions: type[Exception] | tuple[type[Exception], ...],
+  max_attempts: int = 3,
+  max_attempts_attr: str | None = None,
+  initial_delay: float = 1.0,
+  backoff_factor: float = 2.0,
+  jitter: bool = True,
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+  """
+  A decorator that retries a function with exponential backoff.
+
+  Args:
+    exceptions: The exception(s) that should trigger a retry.
+    max_attempts: Maximum number of attempts before giving up (static).
+    max_attempts_attr: If provided, look up this attribute on 'self' for the max attempts.
+      This takes precedence over 'max_attempts'.
+    initial_delay: Initial delay between retries in seconds.
+    backoff_factor: Multiplier for the delay after each attempt.
+    jitter: Whether to add random jitter to the delay.
+  """
+
+  def decorator(func: Callable[P, T]) -> Callable[P, T]:
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+      # Determine the actual max attempts
+      if max_attempts_attr is not None:
+        if not args:
+          raise ValueError(
+            f"Cannot find attribute '{max_attempts_attr}' because 'self' is missing from arguments."
+          )
+        try:
+          actual_max_attempts = getattr(args[0], max_attempts_attr)
+        except AttributeError as e:
+          raise ValueError(
+            f"Argument 'self' (type {type(args[0]).__name__}) has no attribute '{max_attempts_attr}'."
+          ) from e
+      else:
+        actual_max_attempts = max_attempts
+
+      # Cap the max attempts at the global MAX_RETRIES limit
+      actual_max_attempts = min(actual_max_attempts, MAX_RETRIES)
+
+      # Validate max_attempts is a positive integer
+      if not isinstance(actual_max_attempts, int) or actual_max_attempts < 1:
+        raise ValueError(f'max_attempts must be an integer >= 1, got {actual_max_attempts}')
+
+      delay = initial_delay
+
+      for attempt in range(1, actual_max_attempts + 1):
+        try:
+          return func(*args, **kwargs)
+        except exceptions:
+          # If we've reached the maximum attempts, re-raise the caught exception natively
+          if attempt == actual_max_attempts:
+            raise
+
+          sleep_time = min(delay, MAX_DELAY)
+          if jitter:
+            sleep_time *= random.uniform(0.5, 1.5)
+
+          time.sleep(sleep_time)
+          delay *= backoff_factor
+
+      # Satisfy the type checker. This code is mathematically unreachable at runtime
+      # because the loop will always either return or raise on its final iteration.
+      raise AssertionError('Unreachable code reached in retry decorator')
+
+    return wrapper
+
+  return decorator


### PR DESCRIPTION
Fixes #37

This PR adds a configurable LLM interaction logic with a reusable retry mechanism.

- Implemented a `@retry` decorator in `wptgen/utils.py` that supports exponential backoff, jitter, and dynamic retry counts.
- The decorator can now resolve the number of attempts at runtime by looking up an attribute on the instance (e.g., `self.max_retries`).
- Applied the retry logic to `GeminiClient` and `OpenAIClient` methods (`generate_content`, `count_tokens`) to handle transient API errors.
- Added a new `--max-retries` flag to the `generate` command, allowing users to specify the maximum number of retry attempts (defaults to 3).
- The retry count can also be configured via the `max_retries` key in `wpt-gen.yml`.