### PR TITLE
Allow test generation for unregistered web features

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -550,6 +550,48 @@ async def test_run_async_workflow_full_path(engine: WPTGenEngine, mocker: Mocker
 
 
 @pytest.mark.asyncio
+async def test_phase_context_assembly_unregistered_feature_with_spec_urls_and_description(
+  engine: WPTGenEngine, mocker: MockerFixture
+) -> None:
+  """Context assembly succeeds for unregistered features if spec_urls and description are provided."""
+  engine.config.spec_urls = ['http://custom-spec']
+  engine.config.feature_description = 'Custom Description'
+  mocker.patch('wptgen.engine.fetch_feature_yaml', return_value=None)
+  mocker.patch('wptgen.engine.fetch_and_extract_text', return_value='Custom Spec Content')
+  mocker.patch('wptgen.engine.find_feature_tests', return_value=[])
+  mocker.patch('wptgen.engine.gather_local_test_context', return_value=WPTContext())
+
+  context = await engine._phase_context_assembly('custom-feat')
+
+  assert context is not None
+  assert context['feature_id'] == 'custom-feat'
+  assert context['metadata'].name == 'custom-feat'
+  assert context['metadata'].description == 'Custom Description'
+  assert context['metadata'].specs == ['http://custom-spec']
+  assert context['spec_contents'] == 'Custom Spec Content'
+
+
+@pytest.mark.asyncio
+async def test_phase_context_assembly_unregistered_feature_missing_spec_or_desc(
+  engine: WPTGenEngine, mocker: MockerFixture
+) -> None:
+  """Context assembly fails for unregistered features if either spec_urls or description are missing."""
+  mocker.patch('wptgen.engine.fetch_feature_yaml', return_value=None)
+
+  # Case 1: Only spec_urls provided
+  engine.config.spec_urls = ['http://spec']
+  engine.config.feature_description = None
+  result = await engine._phase_context_assembly('custom-feat')
+  assert result is None
+
+  # Case 2: Only description provided
+  engine.config.spec_urls = None
+  engine.config.feature_description = 'Description'
+  result = await engine._phase_context_assembly('custom-feat')
+  assert result is None
+
+
+@pytest.mark.asyncio
 async def test_phase_context_assembly_read_test_fails(
   engine: WPTGenEngine, mocker: MockerFixture
 ) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -79,6 +79,7 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     suggestions_only=False,
     max_retries_override=3,
     spec_urls_override=None,
+    feature_description_override=None,
   )
   mock_engine_class.assert_called_once_with(config=mock_config)
   mock_engine_instance.run_workflow.assert_called_once_with('grid')
@@ -102,6 +103,7 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     suggestions_only=False,
     max_retries_override=3,
     spec_urls_override=None,
+    feature_description_override=None,
   )
 
 
@@ -123,6 +125,7 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     suggestions_only=False,
     max_retries_override=3,
     spec_urls_override=None,
+    feature_description_override=None,
   )
 
 
@@ -144,6 +147,7 @@ def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -
     suggestions_only=True,
     max_retries_override=3,
     spec_urls_override=None,
+    feature_description_override=None,
   )
 
 
@@ -165,6 +169,7 @@ def test_generate_max_retries(mocker: MockerFixture, mock_config: Config) -> Non
     suggestions_only=False,
     max_retries_override=5,
     spec_urls_override=None,
+    feature_description_override=None,
   )
 
 
@@ -217,4 +222,27 @@ def test_generate_spec_urls(mocker: MockerFixture, mock_config: Config) -> None:
     suggestions_only=False,
     max_retries_override=3,
     spec_urls_override=['https://url1.com', 'https://url2.com'],
+    feature_description_override=None,
+  )
+
+
+def test_generate_description(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test that the --description flag is correctly passed to load_config."""
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+  mocker.patch('wptgen.main.WPTGenEngine')
+
+  # Run with --description
+  result = runner.invoke(app, ['generate', 'grid', '--description', 'Test Description'])
+
+  assert result.exit_code == 0
+  mock_load_config.assert_called_once_with(
+    config_path=DEFAULT_CONFIG_PATH,
+    provider_override=None,
+    wpt_dir_override=None,
+    show_responses=False,
+    yes_tokens_override=False,
+    suggestions_only=False,
+    max_retries_override=3,
+    spec_urls_override=None,
+    feature_description_override='Test Description',
   )

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -35,6 +35,7 @@ class Config:
   max_retries: int = 3
   cache_path: str | None = None
   spec_urls: list[str] | None = None
+  feature_description: str | None = None
 
 
 def _get_default_cache_path() -> str:
@@ -66,6 +67,7 @@ def load_config(
   suggestions_only: bool = False,
   max_retries_override: int | None = None,
   spec_urls_override: list[str] | None = None,
+  feature_description_override: str | None = None,
 ) -> Config:
   """
   Loads configuration from YAML and environment variables.
@@ -123,4 +125,5 @@ def load_config(
     max_retries=max_retries,
     cache_path=cache_path,
     spec_urls=spec_urls_override,
+    feature_description=feature_description_override,
   )

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -25,6 +25,7 @@ from rich.prompt import Confirm, Prompt
 
 from wptgen.config import Config
 from wptgen.context import (
+  WebFeatureMetadata,
   extract_feature_metadata,
   fetch_and_extract_text,
   fetch_feature_yaml,
@@ -140,12 +141,29 @@ class WPTGenEngine:
 
     feature_data = fetch_feature_yaml(web_feature_id)
     if not feature_data:
-      self.console.print(f'[bold red]Error:[/bold red] Feature {web_feature_id} not found.')
-      return None
+      if self.config.spec_urls and self.config.feature_description:
+        self.console.print(
+          f'[yellow]Warning:[/yellow] Feature [bold]{web_feature_id}[/bold] not found in the web-features repository.'
+        )
+        metadata = WebFeatureMetadata(
+          name=web_feature_id,
+          description=self.config.feature_description,
+          specs=self.config.spec_urls,
+        )
+      else:
+        self.console.print(f'[bold red]Error:[/bold red] Feature {web_feature_id} not found.')
+        self.console.print(
+          'To generate tests for an unregistered feature, please provide both a spec URL using [bold]--spec-urls[/bold] '
+          'and a description using [bold]--description[/bold].'
+        )
+        return None
+    else:
+      metadata = extract_feature_metadata(feature_data)
+      if self.config.spec_urls:
+        metadata.specs = self.config.spec_urls
+      if self.config.feature_description:
+        metadata.description = self.config.feature_description
 
-    metadata = extract_feature_metadata(feature_data)
-    if self.config.spec_urls:
-      metadata.specs = self.config.spec_urls
     if not metadata.specs:
       self.console.print('[bold red]Error:[/bold red] No specification URL found.')
       return None

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -92,6 +92,14 @@ def generate(
       help='Comma-separated list of spec URLs to use, bypassing automatic fetching.',
     ),
   ] = None,
+  description: Annotated[
+    str | None,
+    typer.Option(
+      '--description',
+      '-d',
+      help='Manually provide a description for the web feature.',
+    ),
+  ] = None,
 ) -> None:
   """
   Generate Web Platform Tests for a specific web feature.
@@ -116,6 +124,7 @@ def generate(
       suggestions_only=suggestions_only,
       max_retries_override=max_retries,
       spec_urls_override=spec_urls_list,
+      feature_description_override=description,
     )
 
     console.print(


### PR DESCRIPTION
Fixes #40 

Users can now generate tests for web feature IDs that do not yet exist in the official `web-features` repository. For these unregistered features, users must manually provide both `--spec-urls` and `--description` values.