### PR TITLE
Add system instruction support for test generation

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -64,7 +65,7 @@ async def test_requirements_analysis_cache_miss(
   }
 
   # Mock LLM to return distinct responses based on prompt content.
-  def llm_side_effect(prompt: str) -> str:
+  def llm_side_effect(prompt: str, *args: Any) -> str:
     if '<spec_document>' in prompt:
       return 'New Spec Synthesis'
     return 'New Test Analysis'
@@ -138,7 +139,7 @@ async def test_requirements_analysis_cache_hit_reject(
   mocker.patch('wptgen.engine.Confirm.ask', return_value=False)
 
   # Both should be generated
-  def llm_side_effect(prompt: str) -> str:
+  def llm_side_effect(prompt: str, *args: Any) -> str:
     if '<spec_document>' in prompt:
       return 'New Spec Synthesis'
     return 'New Test Analysis'

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -105,6 +105,9 @@ async def test_confirm_prompts_batch_calculation(
 
   await engine._confirm_prompts([('p1', 'T1'), ('p2', 'T2')], 'Phase')
 
+  # Check that count_tokens was called
+  cast(MagicMock, engine.llm.count_tokens).assert_called_with('p2')
+
   # Check that it printed total tokens (100 + 200 = 300)
   found_total = False
   for call in mock_console.call_args_list:
@@ -258,12 +261,12 @@ async def test_generate_safe_show_responses(
   mock_llm.generate_content.return_value = 'Verbose Response'
   mock_console_print = mocker.patch.object(engine.console, 'print')
 
-  result = await engine._generate_safe('prompt', 'Task')
+  result = await engine._generate_safe('prompt', 'Task', 'System Instruction')
 
   assert result == 'Verbose Response'
+  mock_llm.generate_content.assert_called_with('prompt', 'System Instruction')
   # Check that console.print was called with the response in a Panel
-  # We can't easily check the Panel object equality, but we can check if it was called.
-  assert mock_console_print.call_count >= 2  # "✔ Task finished." and the Panel
+  assert mock_console_print.call_count >= 2
 
 
 @pytest.mark.asyncio
@@ -326,8 +329,9 @@ async def test_generate_and_save_success(
 
   # Patch Path to write to our tmp_path
   with patch('wptgen.engine.Path', return_value=filename):
-    await engine._generate_and_save('prompt', 'test.html')
+    await engine._generate_and_save('prompt', 'test.html', 'System Instruction')
 
+  mock_llm.generate_content.assert_called_with('prompt', 'System Instruction')
   assert filename.exists()
   assert filename.read_text() == '<html></html>'
 
@@ -475,7 +479,7 @@ async def test_phase_test_suggestions_failure(
 
 @pytest.mark.asyncio
 async def test_phase_test_generation_success(engine: WPTGenEngine, mocker: MockerFixture) -> None:
-  """Test generation proceeds for suggestions approved by the user."""
+  """Test generation proceeds for suggestions approved by the user with system instruction."""
   context = {'metadata': MagicMock(name='Feat', description='Desc')}
   suggestions_response = (
     '<test_suggestion><title>Test 1</title><description>D1</description></test_suggestion>'
@@ -489,6 +493,8 @@ async def test_phase_test_generation_success(engine: WPTGenEngine, mocker: Mocke
 
   mock_gen_save.assert_called_once()
   assert mock_gen_save.call_args[0][1] == 'test_generated_01_test_1.html'
+  assert mock_gen_save.call_args[0][2] is not None
+  assert 'SYSTEM ROLE' in mock_gen_save.call_args[0][2]
 
 
 @pytest.mark.asyncio
@@ -753,7 +759,7 @@ async def test_phase_test_generation_partial_failure(
   mocker.patch.object(engine, '_confirm_prompts', return_value=None)
 
   # Mock _generate_and_save to succeed for one and fail for another
-  async def side_effect(prompt: str, filename: str) -> None:
+  async def side_effect(prompt: str, filename: str, system_instruction: str | None = None) -> None:
     if 'fail_test' in filename:
       raise Exception('Random Write Error')
 

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -305,6 +305,7 @@ class WPTGenEngine:
 
     # Prepare all generation prompts for batch confirmation
     gen_template = self.jinja_env.get_template('test_generation.jinja')
+    system_instruction = self.jinja_env.get_template('test_generation_system.jinja').render()
     prompts_to_confirm: list[tuple[str, str]] = []
 
     for idx, suggestion_xml in enumerate(approved_suggestions_xml):
@@ -326,7 +327,10 @@ class WPTGenEngine:
 
     self.console.print(f'\nGenerating [bold]{len(prompts_to_confirm)}[/bold] tests in parallel...')
 
-    tasks = [self._generate_and_save(prompt, filename) for prompt, filename in prompts_to_confirm]
+    tasks = [
+      self._generate_and_save(prompt, filename, system_instruction)
+      for prompt, filename in prompts_to_confirm
+    ]
     await asyncio.gather(*tasks)
 
     self.console.print('\n[bold green]✔ All selected tests generated successfully.[/bold green]')
@@ -339,7 +343,11 @@ class WPTGenEngine:
     match = re.search(f'<{tag}>(.*?)</{tag}>', text, re.DOTALL)
     return match.group(1).strip() if match else None
 
-  async def _confirm_prompts(self, prompt_data: list[tuple[str, str]], phase_name: str) -> None:
+  async def _confirm_prompts(
+    self,
+    prompt_data: list[tuple[str, str]],
+    phase_name: str,
+  ) -> None:
     """Calculates tokens for a list of prompts and asks for a single user confirmation."""
     loop = asyncio.get_running_loop()
 
@@ -381,12 +389,16 @@ class WPTGenEngine:
       self.console.print('[yellow]Aborting workflow due to user cancellation.[/yellow]')
       raise typer.Abort()
 
-  async def _generate_safe(self, prompt: str, task_name: str) -> str:
+  async def _generate_safe(
+    self, prompt: str, task_name: str, system_instruction: str | None = None
+  ) -> str:
     """Helper to run LLM generation in a thread and handle errors gracefully."""
     try:
       loop = asyncio.get_running_loop()
       with self.console.status(f'[blue]Submitting {task_name}...[/blue]'):
-        response = await loop.run_in_executor(None, self.llm.generate_content, prompt)
+        response = await loop.run_in_executor(
+          None, self.llm.generate_content, prompt, system_instruction
+        )
 
       self.console.print(f'✔ {task_name} finished.')
       if self.config.show_responses:
@@ -396,10 +408,12 @@ class WPTGenEngine:
       self.console.print(f'[bold red]✘ {task_name} failed:[/bold red] {e}')
       return ''
 
-  async def _generate_and_save(self, prompt: str, filename: str) -> None:
+  async def _generate_and_save(
+    self, prompt: str, filename: str, system_instruction: str | None = None
+  ) -> None:
     """Helper to generate a specific test and save it to disk."""
     self.console.print(f'Starting generation for: {filename}...')
-    content = await self._generate_safe(prompt, f'Gen: {filename}')
+    content = await self._generate_safe(prompt, f'Gen: {filename}', system_instruction)
 
     if content:
       # Strip Markdown code blocks if the LLM added them (common behavior)

--- a/wptgen/templates/test_generation.jinja
+++ b/wptgen/templates/test_generation.jinja
@@ -1,32 +1,3 @@
-**Role:** You are a Core Contributor to the Web Platform Tests (WPT) project. Your expertise lies in translating structured test blueprints into precise, compliant, and robust web platform test files.
+Generate a single WPT file based on the following blueprint:
 
-**Task:** I will provide you with a `<feature_description>` (the web feature that is being tested) and a `<test_suggestion>` (details about a possible new test that tests an aspect of that web feature). You must parse this data to generate a valid test file.
-
-**Strict Output Constraint:**
-* **NO** conversational filler.
-* Output **ONLY** the raw file contents.
-
----
-
-### Blueprint Mapping Instructions
-You must integrate the following inputs into the final output:
-
-1.  **`<feature_description>`**: Use the `Name` and `Description` to inform the naming conventions and ensure the test logic aligns with the broader feature goals.
-2.  **`<title>`**: Use this exact text for the HTML `<title>` tag.
-3.  **`<description>`**: Include this text as a simplified comment at the top of your `<script>` block to explain what is being tested.
-4.  **`<pre_conditions>`**: If this tag requires specific HTML (e.g., specific elements, styles), place them in the `<body>` or implement via a `setup()` function.
-5.  **`<steps>`**: Translate these steps directly into the JavaScript logic inside the test body.
-6.  **`<expected_result>`**: Use this to determine the final assertion (e.g., `assert_equals`, `assert_throws_js`, etc.).
-
----
-
-**Input Data:**
-
-**Feature Context:**
-<feature_description>
-  Name: {{ feature_name }}
-  Description: {{ feature_description }}
-</feature_description>
-
-**Test Blueprint:**
 {{ test_suggestion_xml_block }}

--- a/wptgen/templates/test_generation_system.jinja
+++ b/wptgen/templates/test_generation_system.jinja
@@ -1,0 +1,179 @@
+# SYSTEM ROLE
+You are WPT-Gen, an automated, expert-level Web Platform Test (WPT) generation engine. You are a strict code-synthesis machine designed to improve browser interoperability.
+
+# CORE DIRECTIVES
+1.  **Zero Conversation:** Do not output conversational filler, pleasantries, or explanatory text. Output ONLY the raw file contents.
+2.  **Scope Enforcement:** You are strictly authorized to generate JavaScript-based logic and API tests using the `testharness.js` framework.
+3.  **Formatting Strictness:** Output the exact HTML/JS file content. Do not wrap your final output in markdown code blocks unless specifically instructed.
+
+# WPT STYLE GUIDE & RULES
+# Generating Web Platform Tests (WPT)
+
+This guide provides comprehensive instructions and best practices for generating high-quality Web Platform Tests. It is optimized for use by LLMs to understand the structure, APIs, and conventions of the WPT project.
+
+---
+
+## 1. Core Philosophy
+*   **Be Short:** Tests should be as concise as possible. Avoid extraneous elements.
+*   **Be Self-Contained:** No external network dependencies.
+*   **Be Cross-Platform:** Work across devices, resolutions, and OSs.
+*   **Be Conservative:** Avoid edge cases of features not being tested. Use standard features supported by major browsers (Chrome, Firefox, Safari).
+*   **Be Self-Describing:** It should be obvious if a test passes or fails without reading the spec.
+
+---
+
+## 2. Test Types & File Naming
+The file extension and name flags determine how the test is run.
+
+### A. JavaScript Tests (`testharness.js`)
+Used for testing APIs and logic.
+*   `.any.js`: Runs in multiple globals (Window, Workers).
+*   `.window.js`: Runs in a Window global.
+*   `.worker.js`: Runs in a Dedicated Worker.
+*   **Boilerplate:** For `.js` files, WPT generates the HTML. For `.html` files, you must include:
+    ```html
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    ```
+
+### B. Reftests (Rendering Tests)
+Compares the rendering of two files.
+*   **Structure:** A test file and a reference file.
+*   **Link:** `<link rel="match" href="reference.html">` (or `rel="mismatch"`).
+*   **Pass Condition:** Pixel-perfect match (800x600 viewport).
+
+### C. Crashtests
+Checks if a page crashes or leaks.
+*   **Naming:** Ends in `-crash.html` or located in a `crashtests/` directory.
+*   **Pass Condition:** Page loads and paints without crashing. No `testharness.js` required.
+
+### D. Naming Conventions & Flags
+*   **Format:** `{test-topic}-{index}.html` (e.g., `flexbox-layout-001.html`). Use descriptive names.
+*   `.https.html`: Requires HTTPS.
+*   `.h2.html`: Requires HTTP/2.
+*   `.sub.html`: Enables server-side substitution.
+*   `.tentative.html`: For experimental/non-standard features.
+*   `.optional.html`: For optional spec features (RFC 2119 "MAY").
+
+---
+
+## 3. The `testharness.js` API
+
+### Subtest Types
+1.  **`test(fn, name)`**: For synchronous tests.
+    ```javascript
+    test(() => {
+      assert_equals(1 + 1, 2);
+    }, "Addition works");
+    ```
+2.  **`promise_test(fn, name)`**: For asynchronous code using Promises (preferred).
+    ```javascript
+    promise_test(async t => {
+      const result = await fetch("/data");
+      assert_true(result.ok);
+    }, "Fetch works");
+    ```
+3.  **`async_test(fn, name)`**: For callback-based asynchronous code.
+    ```javascript
+    async_test(t => {
+      document.onclick = t.step_func_done(e => {
+        assert_true(e.isTrusted);
+      });
+    }, "Click is trusted");
+    ```
+
+### Key Assertions
+*   `assert_equals(actual, expected, description)`
+*   `assert_true(actual, description)`
+*   `assert_throws_dom(type, fn, description)`: For DOMExceptions (e.g., "IndexSizeError").
+*   `assert_throws_js(type, fn, description)`: For JS errors (e.g., `TypeError`).
+*   `promise_rejects_dom(t, type, promise)`: For promises that should fail.
+
+### Event Handling
+Use `EventWatcher` for sequenced events:
+```javascript
+const watcher = new EventWatcher(t, element, ["start", "end"]);
+await watcher.wait_for("start");
+// ... action ...
+await watcher.wait_for("end");
+```
+
+---
+
+## 4. Metadata & Inclusion
+### JavaScript Meta Tags
+Use `// META` comments at the top of `.js` files:
+*   `// META: title=Test Title`
+*   `// META: script=/common/utils.js` (Include helper scripts)
+*   `// META: global=window,worker` (Define execution scopes)
+
+### HTML Metadata
+*   `<link rel="help" href="https://spec.whatwg.org/#feature">`: Links to the specification.
+*   `<meta name="timeout" content="long">`: For slow tests.
+
+---
+
+## 5. User Interaction (`testdriver.js`)
+Always include both scripts. Use `test_driver` for actions requiring user activation or privileged access.
+```html
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+```
+Example:
+```javascript
+await test_driver.bless("permission request");
+await test_driver.click(button);
+```
+
+---
+
+## 6. Server-Side Features
+### Substitution (`.sub.html`)
+Use {% raw %}`{{host}}`, `{{ports[http][0]}}`, or `{{domains[www]}}`{% endraw %}.
+### Pipes (`?pipe=...`)
+*   `status(404)`: Return 404.
+*   `header(Name, Value)`: Set response header.
+*   `trickle(100:d1:r2)`: Send 100 bytes, delay 1s, repeat.
+
+---
+
+## 7. Rendering & SVG
+### Ahem Font
+Essential for predictable text rendering in reftests.
+```html
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  .test { font: 20px/1 Ahem; color: green; }
+</style>
+```
+
+### SVG Tests
+SVG files are supported and can include `testharness.js` via `<h:script>`.
+```xml
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+</svg>
+```
+
+---
+
+## 8. Summary Checklist for LLM Generation
+1.  **Type:** API (testharness), Rendering (reftest), or Crash?
+2.  **Environment:** Window, Worker, or both (`.any.js`)?
+3.  **Security:** Does it need `.https`?
+4.  **Async:** Use `promise_test` and `add_cleanup`.
+5.  **Aesthetics:** For reftests, use Ahem and 800x600 layout.
+6.  **Spec Link:** Always include a `<link rel="help">`.
+
+
+# BLUEPRINT MAPPING PROTOCOL
+You will receive a `<test_suggestion>` XML blueprint. You must map its fields to the WPT file as follows:
+* `<title>`: Use this exact string for the HTML `<title>` tag AND as the test name string in your `test()` or `promise_test()` function.
+* `<description>`: Insert this as a block comment at the top of your `<script>` to explain the test's intent.
+* `<pre_conditions>`: Translate this into the necessary HTML elements within the `<body>`, or initialize them in a `setup()` block.
+* `<steps>`: Translate these sequential steps directly into the JavaScript execution logic inside the test function.
+* `<expected_result>`: Map this strictly to the correct assertion (e.g., `assert_equals`, `assert_throws_js`, `promise_rejects_dom`).
+
+# EXECUTION
+Synthesize the minimal, most robust test file required to assert the expected result based on the blueprint. Ensure all side-effects are cleaned up. Output the code and terminate.


### PR DESCRIPTION
- Update `LLMClient` and subclasses to support an optional `system_instruction` in `generate_content`.
- Modify `WPTGenEngine` to utilize `test_generation_system.jinja` as a system prompt during the test generation phase.
  - This new system prompt includes detailed instructions on how to write WPTs, which was synthesized from [WPT's "Writing Tests" documentation](https://web-platform-tests.org/writing-tests/index.html). This includes Reftests at the moment, which was previously out of scope, but may be feasible after some additional building. #53 has been created to track this.
- Update the test suite to align with the updated `LLMClient` API and fix issues in caching tests.