### PR TITLE
Set temperature to 0.1 for test generation

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -776,7 +776,12 @@ async def test_phase_test_generation_partial_failure(
   mocker.patch.object(engine, '_confirm_prompts', return_value=None)
 
   # Mock _generate_and_save to succeed for one and fail for another
-  async def side_effect(prompt: str, filename: str, system_instruction: str | None = None) -> None:
+  async def side_effect(
+    prompt: str,
+    filename: str,
+    system_instruction: str | None = None,
+    temperature: float | None = None,
+  ) -> None:
     if 'fail_test' in filename:
       raise Exception('Random Write Error')
 

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -340,7 +340,7 @@ class WPTGenEngine:
     self.console.print(f'\nGenerating [bold]{len(prompts_to_confirm)}[/bold] tests in parallel...')
 
     tasks = [
-      self._generate_and_save(prompt, filename, system_instruction)
+      self._generate_and_save(prompt, filename, system_instruction, temperature=0.1)
       for prompt, filename in prompts_to_confirm
     ]
     await asyncio.gather(*tasks)
@@ -425,11 +425,15 @@ class WPTGenEngine:
       return ''
 
   async def _generate_and_save(
-    self, prompt: str, filename: str, system_instruction: str | None = None
+    self,
+    prompt: str,
+    filename: str,
+    system_instruction: str | None = None,
+    temperature: float | None = None,
   ) -> None:
     """Helper to generate a specific test and save it to disk."""
     self.console.print(f'Starting generation for: {filename}...')
-    content = await self._generate_safe(prompt, f'Gen: {filename}', system_instruction)
+    content = await self._generate_safe(prompt, f'Gen: {filename}', system_instruction, temperature)
 
     if content:
       # Strip Markdown code blocks if the LLM added them (common behavior)


### PR DESCRIPTION
Adjusted the LLM temperature setting to 0.1 during the test generation phase to improve the determinism and reliability of the generated code.

- Updated `_generate_and_save` in `wptgen/engine.py` to accept a `temperature` parameter.
- Set temperature to 0.1 in the `_phase_test_generation` workflow.
- Updated `tests/test_engine.py` to match the new method signature in mock side effects.