### PR TITLE
Implement iterative requirements extraction phase

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -19,7 +19,7 @@ import pytest
 
 from wptgen.config import Config
 from wptgen.models import WebFeatureMetadata, WorkflowContext
-from wptgen.phases.requirements_extraction import run_requirements_extraction
+from wptgen.phases.requirements_extraction import run_requirements_extraction_iterative
 
 
 @pytest.fixture
@@ -38,6 +38,7 @@ def mock_config(tmp_path: Path) -> Config:
       'requirements_extraction': 'reasoning',
       'coverage_audit': 'reasoning',
       'generation': 'lightweight',
+      'evaluation': 'lightweight',
     },
     yes_tokens=True,
     cache_path=str(tmp_path / '.wpt-gen-cache'),
@@ -76,21 +77,28 @@ async def test_requirements_cache_miss(
   cache_dir = tmp_path / 'cache'
   cache_dir.mkdir()
 
-  mock_llm.generate_content.return_value = '<requirements_list>New Requirements</requirements_list>'
+  mock_llm.generate_content.side_effect = [
+    '<requirements_list><requirement id="R_NEW_1"><description>New Requirements</description></requirement></requirements_list>',
+    '<requirements_list><status>EXHAUSTED</status></requirements_list>',
+  ]
   jinja_env = MagicMock()
   jinja_env.get_template.return_value.render.return_value = 'Prompt'
 
   with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
-    result = await run_requirements_extraction(
+    result = await run_requirements_extraction_iterative(
       context, mock_config, mock_llm, mock_ui, jinja_env, cache_dir
     )
 
-  assert result == '<requirements_list>New Requirements</requirements_list>'
+  assert result is not None
+  assert '<requirement id="R1">' in result
+  assert 'New Requirements' in result
 
   # Verify cache file was created
   cache_file = cache_dir / 'test-feat__requirements.xml'
   assert cache_file.exists()
-  assert cache_file.read_text() == '<requirements_list>New Requirements</requirements_list>'
+  cache_content = cache_file.read_text()
+  assert '<requirement id="R1">' in cache_content
+  assert 'New Requirements' in cache_content
 
 
 @pytest.mark.asyncio
@@ -112,7 +120,7 @@ async def test_requirements_cache_hit_accept(
   # User accepts cache
   mock_ui.confirm.return_value = True
 
-  result = await run_requirements_extraction(
+  result = await run_requirements_extraction_iterative(
     context, mock_config, mock_llm, mock_ui, MagicMock(), cache_dir
   )
 
@@ -143,19 +151,26 @@ async def test_requirements_cache_hit_reject(
 
   # User rejects cache
   mock_ui.confirm.return_value = False
-  mock_llm.generate_content.return_value = '<requirements_list>New Requirements</requirements_list>'
+  mock_llm.generate_content.side_effect = [
+    '<requirements_list><requirement id="R_NEW_1"><description>New Requirements</description></requirement></requirements_list>',
+    '<requirements_list><status>EXHAUSTED</status></requirements_list>',
+  ]
   jinja_env = MagicMock()
   jinja_env.get_template.return_value.render.return_value = 'Prompt'
 
   with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
-    result = await run_requirements_extraction(
+    result = await run_requirements_extraction_iterative(
       context, mock_config, mock_llm, mock_ui, jinja_env, cache_dir
     )
 
-  assert result == '<requirements_list>New Requirements</requirements_list>'
+  assert result is not None
+  assert '<requirement id="R1">' in result
+  assert 'New Requirements' in result
 
-  # LLM should have been called once.
-  assert mock_llm.generate_content.call_count == 1
+  # LLM should have been called twice (one for data, one for exhaustion).
+  assert mock_llm.generate_content.call_count == 2
 
   # Cache file should be updated.
-  assert cache_file.read_text() == '<requirements_list>New Requirements</requirements_list>'
+  cache_content = cache_file.read_text()
+  assert '<requirement id="R1">' in cache_content
+  assert 'New Requirements' in cache_content

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -138,6 +138,19 @@ def test_validate_output_dir_permission_error(tmp_path: Path) -> None:
     restricted_dir.chmod(0o777)  # Clean up
 
 
+def test_load_config_detailed_requirements(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Test that detailed_requirements flag is correctly loaded."""
+  monkeypatch.setenv('GEMINI_API_KEY', 'mock-key')
+
+  # Case 1: Default (False)
+  config = load_config(config_path='non_existent_dummy.yaml')
+  assert config.detailed_requirements is False
+
+  # Case 2: Override to True
+  config = load_config(config_path='non_existent_dummy.yaml', detailed_requirements_override=True)
+  assert config.detailed_requirements is True
+
+
 def test_get_default_cache_path_windows(monkeypatch: pytest.MonkeyPatch) -> None:
   """Test default cache path on Windows."""
   monkeypatch.setattr('sys.platform', 'win32')

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -86,6 +86,9 @@ async def test_run_async_workflow_full_path(engine: WPTGenEngine, mocker: Mocker
   mock_extraction = mocker.patch(
     'wptgen.engine.run_requirements_extraction', return_value=requirements
   )
+  mock_extraction_iterative = mocker.patch(
+    'wptgen.engine.run_requirements_extraction_iterative', return_value=requirements
+  )
   mock_audit = mocker.patch('wptgen.engine.run_coverage_audit', return_value=audit)
   mock_gen = mocker.patch('wptgen.engine.run_test_generation', return_value=generated_tests)
   mock_eval = mocker.patch('wptgen.engine.run_test_evaluation', return_value=None)
@@ -94,6 +97,7 @@ async def test_run_async_workflow_full_path(engine: WPTGenEngine, mocker: Mocker
 
   mock_assembly.assert_called_once()
   mock_extraction.assert_called_once()
+  mock_extraction_iterative.assert_not_called()
   mock_audit.assert_called_once()
   mock_gen.assert_called_once()
   mock_eval.assert_called_once()
@@ -144,6 +148,31 @@ async def test_run_async_workflow_suggestions_only(
 
   mock_provide.assert_called_once()
   mock_gen.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_async_workflow_detailed_requirements(
+  engine: WPTGenEngine, mocker: MockerFixture
+) -> None:
+  """Verifies that run_requirements_extraction_iterative is called when config.detailed_requirements is True."""
+  engine.config.detailed_requirements = True
+  context = WorkflowContext(feature_id='feat-id')
+  requirements = 'reqs'
+
+  mocker.patch('wptgen.engine.run_context_assembly', return_value=context)
+  mock_extraction = mocker.patch(
+    'wptgen.engine.run_requirements_extraction', return_value=requirements
+  )
+  mock_extraction_iterative = mocker.patch(
+    'wptgen.engine.run_requirements_extraction_iterative', return_value=requirements
+  )
+  mocker.patch('wptgen.engine.run_coverage_audit', return_value='audit')
+  mocker.patch('wptgen.engine.run_test_generation', return_value=[])
+
+  await engine._run_async_workflow('feat-id')
+
+  mock_extraction.assert_not_called()
+  mock_extraction_iterative.assert_called_once()
 
 
 def test_engine_init(engine: WPTGenEngine, mock_config: Config) -> None:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -37,6 +37,7 @@ def gemini_config() -> Config:
       'requirements_extraction': 'reasoning',
       'coverage_audit': 'reasoning',
       'generation': 'lightweight',
+      'evaluation': 'lightweight',
     },
   )
 
@@ -57,6 +58,7 @@ def openai_config() -> Config:
       'requirements_extraction': 'reasoning',
       'coverage_audit': 'reasoning',
       'generation': 'lightweight',
+      'evaluation': 'lightweight',
     },
   )
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,6 +42,7 @@ def mock_config() -> Config:
       'requirements_extraction': 'reasoning',
       'coverage_audit': 'reasoning',
       'generation': 'lightweight',
+      'evaluation': 'lightweight',
     },
     max_retries=3,
   )
@@ -90,6 +91,7 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     max_retries_override=3,
     spec_urls_override=None,
     feature_description_override=None,
+    detailed_requirements_override=False,
   )
   mock_engine_class.assert_called_once()
   # Verify config was passed correctly
@@ -117,6 +119,7 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     max_retries_override=3,
     spec_urls_override=None,
     feature_description_override=None,
+    detailed_requirements_override=False,
   )
 
 
@@ -140,6 +143,7 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     max_retries_override=3,
     spec_urls_override=None,
     feature_description_override=None,
+    detailed_requirements_override=False,
   )
 
 
@@ -163,6 +167,7 @@ def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -
     max_retries_override=3,
     spec_urls_override=None,
     feature_description_override=None,
+    detailed_requirements_override=False,
   )
 
 
@@ -186,6 +191,31 @@ def test_generate_max_retries(mocker: MockerFixture, mock_config: Config) -> Non
     max_retries_override=5,
     spec_urls_override=None,
     feature_description_override=None,
+    detailed_requirements_override=False,
+  )
+
+
+def test_generate_detailed_requirements(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test that the --detailed-requirements flag is correctly passed to load_config."""
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+  mocker.patch('wptgen.main.WPTGenEngine')
+
+  # Run with --detailed-requirements
+  result = runner.invoke(app, ['generate', 'grid', '--detailed-requirements'])
+
+  assert result.exit_code == 0
+  mock_load_config.assert_called_once_with(
+    config_path=DEFAULT_CONFIG_PATH,
+    provider_override=None,
+    wpt_dir_override=None,
+    output_dir_override=None,
+    show_responses=False,
+    yes_tokens_override=False,
+    suggestions_only=False,
+    max_retries_override=3,
+    spec_urls_override=None,
+    feature_description_override=None,
+    detailed_requirements_override=True,
   )
 
 
@@ -240,6 +270,7 @@ def test_generate_spec_urls(mocker: MockerFixture, mock_config: Config) -> None:
     max_retries_override=3,
     spec_urls_override=['https://url1.com', 'https://url2.com'],
     feature_description_override=None,
+    detailed_requirements_override=False,
   )
 
 
@@ -263,6 +294,7 @@ def test_generate_description(mocker: MockerFixture, mock_config: Config) -> Non
     max_retries_override=3,
     spec_urls_override=None,
     feature_description_override='Test Description',
+    detailed_requirements_override=False,
   )
 
 

--- a/tests/test_phase_utils.py
+++ b/tests/test_phase_utils.py
@@ -49,7 +49,12 @@ def mock_config() -> Config:
     api_key='key',
     wpt_path='/fake',
     categories={'reasoning': 'test-model', 'lightweight': 'test-model'},
-    phase_model_mapping={},
+    phase_model_mapping={
+      'requirements_extraction': 'reasoning',
+      'coverage_audit': 'reasoning',
+      'generation': 'lightweight',
+      'evaluation': 'lightweight',
+    },
     yes_tokens=False,
     show_responses=False,
   )

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -22,7 +22,10 @@ from wptgen.models import WebFeatureMetadata, WorkflowContext, WPTContext
 from wptgen.phases.context_assembly import run_context_assembly
 from wptgen.phases.coverage_audit import run_coverage_audit
 from wptgen.phases.generation import run_test_generation
-from wptgen.phases.requirements_extraction import run_requirements_extraction
+from wptgen.phases.requirements_extraction import (
+  run_requirements_extraction,
+  run_requirements_extraction_iterative,
+)
 
 
 @pytest.fixture
@@ -198,6 +201,30 @@ async def test_run_requirements_extraction_cached(
 
   assert res == '<reqs>cached</reqs>'
   assert context.requirements_xml == '<reqs>cached</reqs>'
+
+
+@pytest.mark.asyncio
+async def test_run_requirements_extraction_success(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Test successful requirements extraction (single pass)."""
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    spec_contents='Spec',
+  )
+  jinja_env = MagicMock()
+  jinja_env.get_template.return_value.render.return_value = 'Prompt'
+
+  mock_llm.generate_content.return_value = '<reqs>generated</reqs>'
+
+  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
+    res = await run_requirements_extraction(
+      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
+    )
+
+  assert res == '<reqs>generated</reqs>'
+  assert context.requirements_xml == '<reqs>generated</reqs>'
 
 
 @pytest.mark.asyncio
@@ -390,3 +417,190 @@ async def test_run_test_generation_failure(
 
   assert res == []
   mock_ui.print.assert_any_call('\n[bold red]✘ No tests were successfully generated.[/bold red]')
+
+
+@pytest.mark.asyncio
+async def test_run_requirements_extraction_iterative_success(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Test iterative requirements extraction success."""
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    spec_contents='Spec',
+  )
+  jinja_env = MagicMock()
+  jinja_env.get_template.return_value.render.return_value = 'Prompt'
+
+  # Mock sequence of responses: 1. some reqs, 2. EXHAUSTED
+  mock_llm.generate_content.side_effect = [
+    '<requirements_list><requirement id="R_NEW_1"><description>Req 1</description></requirement></requirements_list>',
+    '<requirements_list><status>EXHAUSTED</status></requirements_list>',
+  ]
+
+  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
+    res = await run_requirements_extraction_iterative(
+      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
+    )
+
+  assert res is not None
+  assert '<requirement id="R1">' in res
+  assert 'Req 1' in res
+  assert context.requirements_xml == res
+  assert mock_llm.generate_content.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_requirements_extraction_iterative_reindexing(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Test that requirements are correctly re-indexed across iterations."""
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    spec_contents='Spec',
+  )
+  jinja_env = MagicMock()
+  jinja_env.get_template.return_value.render.return_value = 'Prompt'
+
+  mock_llm.generate_content.side_effect = [
+    '<requirements_list><requirement id="R_NEW_1"><description>Req A</description></requirement></requirements_list>',
+    '<requirements_list><requirement id="R_NEW_1"><description>Req B</description></requirement></requirements_list>',
+    '<requirements_list><status>EXHAUSTED</status></requirements_list>',
+  ]
+
+  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
+    res = await run_requirements_extraction_iterative(
+      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
+    )
+
+  assert res is not None
+  assert '<requirement id="R1">' in res
+  assert '<requirement id="R2">' in res
+  assert 'Req A' in res
+  assert 'Req B' in res
+
+
+@pytest.mark.asyncio
+async def test_run_requirements_extraction_iterative_max_iterations(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Test iterative extraction stops at max iterations."""
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    spec_contents='Spec',
+  )
+  jinja_env = MagicMock()
+  jinja_env.get_template.return_value.render.return_value = 'Prompt'
+
+  # Return 1 req every time (10 iterations)
+  mock_llm.generate_content.return_value = '<requirements_list><requirement id="R_NEW_1"><description>Req</description></requirement></requirements_list>'
+
+  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
+    res = await run_requirements_extraction_iterative(
+      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
+    )
+
+  assert res is not None
+  assert mock_llm.generate_content.call_count == 10
+  assert '<requirement id="R10">' in res
+
+
+@pytest.mark.asyncio
+async def test_run_requirements_extraction_iterative_no_new_reqs(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Test iterative extraction stops if no new requirements are found in an iteration."""
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    spec_contents='Spec',
+  )
+  jinja_env = MagicMock()
+  jinja_env.get_template.return_value.render.return_value = 'Prompt'
+
+  # Iteration 1: Req found. Iteration 2: No req found (not EXHAUSTED though).
+  mock_llm.generate_content.side_effect = [
+    '<requirements_list><requirement id="R1"><description>R</description></requirement></requirements_list>',
+    '<requirements_list></requirements_list>',
+  ]
+
+  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
+    res = await run_requirements_extraction_iterative(
+      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
+    )
+
+  assert res is not None
+  assert mock_llm.generate_content.call_count == 2
+  assert '<requirement id="R1">' in res
+
+
+@pytest.mark.asyncio
+async def test_run_requirements_extraction_iterative_failure(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Test iterative extraction stops if generate_safe returns empty string."""
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    spec_contents='Spec',
+  )
+  jinja_env = MagicMock()
+  jinja_env.get_template.return_value.render.return_value = 'Prompt'
+
+  with patch('wptgen.phases.requirements_extraction.generate_safe', return_value=''):
+    res = await run_requirements_extraction_iterative(
+      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
+    )
+
+  assert res is None
+
+
+@pytest.mark.asyncio
+async def test_run_requirements_extraction_iterative_cached(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Test iterative extraction uses cache if available."""
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+  )
+  cache_dir = tmp_path
+  cache_file = cache_dir / 'feat__requirements.xml'
+  cache_file.write_text('<reqs>cached</reqs>')
+
+  mock_ui.confirm.return_value = True
+
+  res = await run_requirements_extraction_iterative(
+    context, mock_config, mock_llm, mock_ui, MagicMock(), cache_dir
+  )
+
+  assert res == '<reqs>cached</reqs>'
+  assert mock_llm.generate_content.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_run_requirements_extraction_iterative_no_reqs_at_all(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Test iterative extraction returns None if no requirements are ever found."""
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    spec_contents='Spec',
+  )
+  jinja_env = MagicMock()
+  jinja_env.get_template.return_value.render.return_value = 'Prompt'
+
+  # First response is EXHAUSTED
+  mock_llm.generate_content.return_value = (
+    '<requirements_list><status>EXHAUSTED</status></requirements_list>'
+  )
+
+  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
+    res = await run_requirements_extraction_iterative(
+      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
+    )
+
+  assert res is None

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -39,6 +39,7 @@ class Config:
   cache_path: str | None = None
   spec_urls: list[str] | None = None
   feature_description: str | None = None
+  detailed_requirements: bool = False
 
   def get_model_for_phase(self, phase_name: str) -> str | None:
     """Resolves the model name for a given workflow phase."""
@@ -100,6 +101,7 @@ def load_config(
   max_retries_override: int | None = None,
   spec_urls_override: list[str] | None = None,
   feature_description_override: str | None = None,
+  detailed_requirements_override: bool = False,
 ) -> Config:
   """
   Loads configuration from YAML and environment variables.
@@ -154,6 +156,9 @@ def load_config(
   show_responses = show_responses or yaml_data.get('show_responses', False)
   yes_tokens = yes_tokens_override or yaml_data.get('yes_tokens', False)
   suggestions_only = suggestions_only or yaml_data.get('suggestions_only', False)
+  detailed_requirements = detailed_requirements_override or yaml_data.get(
+    'detailed_requirements', False
+  )
   max_retries = max_retries_override or yaml_data.get('max_retries', 3)
   cache_path = yaml_data.get('cache_path') or _get_default_cache_path()
 
@@ -185,4 +190,5 @@ def load_config(
     cache_path=cache_path,
     spec_urls=spec_urls_override,
     feature_description=feature_description_override,
+    detailed_requirements=detailed_requirements,
   )

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -23,13 +23,17 @@ from wptgen.phases.context_assembly import run_context_assembly
 from wptgen.phases.coverage_audit import provide_coverage_report, run_coverage_audit
 from wptgen.phases.evaluation import run_test_evaluation
 from wptgen.phases.generation import run_test_generation
-from wptgen.phases.requirements_extraction import run_requirements_extraction
+from wptgen.phases.requirements_extraction import (
+  run_requirements_extraction,
+  run_requirements_extraction_iterative,
+)
 from wptgen.ui import UIProvider
 
 __all__ = [
   'WPTGenEngine',
   'run_context_assembly',
   'run_requirements_extraction',
+  'run_requirements_extraction_iterative',
   'run_coverage_audit',
   'provide_coverage_report',
   'run_test_generation',
@@ -62,9 +66,14 @@ class WPTGenEngine:
       return
 
     # Phase 2: Requirements Extraction
-    requirements_xml = await run_requirements_extraction(
-      context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
-    )
+    if self.config.detailed_requirements:
+      requirements_xml = await run_requirements_extraction_iterative(
+        context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
+      )
+    else:
+      requirements_xml = await run_requirements_extraction(
+        context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
+      )
     if not requirements_xml:
       return
 

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -113,6 +113,13 @@ def generate(
       help='Manually provide a description for the web feature.',
     ),
   ] = None,
+  detailed_requirements: Annotated[
+    bool,
+    typer.Option(
+      '--detailed-requirements',
+      help='Use a more detailed, iterative requirements extraction process.',
+    ),
+  ] = False,
 ) -> None:
   """
   Generate Web Platform Tests for a specific web feature.
@@ -150,6 +157,7 @@ def generate(
       max_retries_override=max_retries,
       spec_urls_override=spec_urls_list,
       feature_description_override=description,
+      detailed_requirements_override=detailed_requirements,
     )
 
     config_info = Text.assemble(

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from pathlib import Path
 
 from jinja2 import Environment
@@ -78,6 +79,113 @@ async def run_requirements_extraction(
 
     if not requirements_xml:
       return None
+
+    # Save to cache
+    cache_file.write_text(requirements_xml, encoding='utf-8')
+
+  context.requirements_xml = requirements_xml
+  return requirements_xml
+
+
+async def run_requirements_extraction_iterative(
+  context: WorkflowContext,
+  config: Config,
+  llm: LLMClient,
+  ui: UIProvider,
+  jinja_env: Environment,
+  cache_dir: Path,
+) -> str | None:
+  ui.rule('Phase 2: Requirements Extraction (Iterative)')
+
+  assert context.metadata is not None
+
+  web_feature_id = context.feature_id
+  cache_file = cache_dir / f'{web_feature_id}__requirements.xml'
+  requirements_xml = None
+
+  if cache_file.exists():
+    ui.print(f'[yellow]Found cached requirements for {web_feature_id}.[/yellow]')
+    if ui.confirm('Use cached requirements?'):
+      requirements_xml = cache_file.read_text(encoding='utf-8')
+      ui.print('✔ Using cached requirements.')
+
+  if not requirements_xml:
+    all_requirements: list[str] = []
+    iteration = 1
+    max_iterations = 10
+    requirement_counter = 1
+
+    while iteration <= max_iterations:
+      existing_requirements_xml = '\n'.join(all_requirements)
+
+      extraction_prompt = jinja_env.get_template('requirements_extraction_iterative.jinja').render(
+        feature_name=context.metadata.name,
+        feature_description=context.metadata.description,
+        spec_url=context.metadata.specs[0],
+        spec_contents=context.spec_contents,
+        existing_requirements_xml=existing_requirements_xml,
+      )
+      extraction_system_prompt = jinja_env.get_template(
+        'requirements_extraction_iterative_system.jinja'
+      ).render()
+
+      if iteration == 1:
+        await confirm_prompts(
+          [(extraction_prompt, 'Requirements Extraction (Iterative)')],
+          'Requirements Extraction',
+          llm,
+          ui,
+          config,
+          model=config.get_model_for_phase('requirements_extraction'),
+        )
+
+      response = await generate_safe(
+        extraction_prompt,
+        f'Requirements Extraction (Iteration {iteration})',
+        llm,
+        ui,
+        config,
+        system_instruction=extraction_system_prompt,
+        temperature=0.0,
+        model=config.get_model_for_phase('requirements_extraction'),
+      )
+
+      if not response:
+        break
+
+      if '<status>EXHAUSTED</status>' in response:
+        ui.print(f'✔ Extraction complete: LLM signaled exhaustion at iteration {iteration}.')
+        break
+
+      # Extract individual <requirement> blocks.
+      new_reqs = re.findall(r'(<requirement.*?>.*?</requirement>)', response, re.DOTALL)
+
+      if not new_reqs:
+        ui.print('[yellow]No new requirements found in this iteration. Stopping.[/yellow]')
+        break
+
+      ui.print(f'  - Found {len(new_reqs)} new requirements.')
+
+      # Re-index requirements as they come out
+      for req in new_reqs:
+        re_indexed = re.sub(
+          r'(<requirement[^>]*?)id="[^"]+"', f'\\1id="R{requirement_counter}"', req
+        )
+        all_requirements.append(re_indexed)
+        requirement_counter += 1
+
+      iteration += 1
+    else:
+      if iteration > max_iterations:
+        ui.print(f'[yellow]Reached maximum iterations ({max_iterations}).[/yellow]')
+
+    if not all_requirements:
+      ui.print('[red]No requirements extracted.[/red]')
+      return None
+
+    requirements_xml = (
+      '<requirements_list>\n  ' + '\n  '.join(all_requirements) + '\n</requirements_list>'
+    )
 
     # Save to cache
     cache_file.write_text(requirements_xml, encoding='utf-8')

--- a/wptgen/templates/requirements_extraction_iterative.jinja
+++ b/wptgen/templates/requirements_extraction_iterative.jinja
@@ -1,0 +1,14 @@
+Extract the normative test requirements for the following feature and specification.
+
+<feature_definition>
+  <feature_name>{{feature_name}}</feature_name>
+  <feature_description>{{feature_description}}</feature_description>
+</feature_definition>
+
+<spec_document url="{{spec_url}}">
+{{spec_contents}}
+</spec_document>
+
+<existing_requirements>
+{{existing_requirements_xml}}
+</existing_requirements>

--- a/wptgen/templates/requirements_extraction_iterative_system.jinja
+++ b/wptgen/templates/requirements_extraction_iterative_system.jinja
@@ -1,0 +1,53 @@
+# SYSTEM ROLE
+You are a Principal Software Engineer in Test (SDET) and a W3C Specification Analyst. Your exclusive job is to read W3C specifications and extract a highly-focused list of core interoperability test requirements.
+
+# CORE DIRECTIVES
+1. **Zero Conversation:** Output strictly the XML structure defined below. No pleasantries or conversational filler.
+2. **Normative Only:** You are extracting *normative* rules (MUST, SHALL, REQUIRED).
+3. **Principle-Based Exclusions:** You must IGNORE and DO NOT EXTRACT rules related to the following platform-level behaviors:
+  * **Non-Absolute Directives:** Ignore behaviors labeled "MAY", "SHOULD", or "OPTIONAL". Only extract absolute "MUST" or "SHALL" requirements.
+  * **Standard WebIDL Bindings:** Ignore implicit type conversions (e.g., passing a string to a boolean parameter) unless the spec defines a custom Exception for it.
+  * **User Agent UI:** Ignore visual browser behaviors, user prompts, or system dialogs.
+  * **Memory & Hardware:** Ignore Garbage Collection timing, memory limits, or non-deterministic OS constraints.
+4. **Atomic Descriptions:** Each requirement must be a single, testable assertion. Do not combine multiple behaviors. The description must read like a test objective (e.g., "If the dictionary member is missing, it must default to false.").
+5. **Strict Deduplication:** Do not extract any rule that shares the same underlying logical behavior or tests the same API surface as anything in the `<existing_requirements>`. Look at the core behavior, not just the wording.
+7. **The Exhaustion Principle:** You are limited to a maximum of 10 new requirements per run. However, it is a sign of SUCCESS to output fewer than 10. If the spec only contains 2 new high-value requirements, output exactly 2. If ALL high-value requirements are already in the `<existing_requirements>`, you MUST output exactly 0 requirements. Do not invent edge cases to pad your list.
+
+# INPUTS
+1. `<spec_document>`: The technical specification text.
+2. `<feature_definition>`: The scope of your analysis. You must ignore parts of the spec that fall outside this feature definition.
+3. `<existing_requirements>`: A list of requirements that have ALREADY been extracted. You must read these carefully to avoid duplication.
+
+# EXTRACTION PROTOCOL
+
+Read the `<spec_document>` and extract every normative requirement that fits within the scope of the `<feature_definition>`.
+
+Identify the Category for each rule:
+
+* **Existence:** Rules defining the feature's surface area (interfaces, methods, properties).
+* **Common Use Cases:** Rules defining successful behaviors, processing models, and realistic "happy paths."
+* **Error Scenarios:** Rules defining error conditions, thrown exceptions, and invalid states.
+* **Invalidation:** Rules regarding caching, state changes, and dynamic updates, if any.
+* **Integration:** Rules defining mandatory interactions with other platform features, if any.
+
+# STRICT OUTPUT FORMAT
+
+Your entire response must be a single `<requirements_list>` XML block. Do not wrap your response in markdown blocks.
+
+SCENARIO A: NO NEW REQUIREMENTS FOUND
+If all core normative requirements are already in the `<existing_requirements>`, output EXACTLY and ONLY:
+<requirements_list>
+  <status>EXHAUSTED</status>
+</requirements_list>
+
+SCENARIO B: NEW REQUIREMENTS FOUND (MAX 10)
+<requirements_list>
+  <requirement id="R_NEW_1">
+    <category>Existence</category>
+    <description>[Detailed explanation of the specific behavior that must be tested]</description>
+  </requirement>
+  <requirement id="R_NEW_2">
+    <category>Error Scenario</category>
+    <description>[Detailed explanation of the specific behavior that must be tested]</description>
+  </requirement>
+</requirements_list>


### PR DESCRIPTION
This change adds a new extraction phase version that iteratively generates requirements. The hope for this is that we can avoid the requirements generated topping out at ~20 or so for larger web features.

- Add `run_requirements_extraction_iterative` to `wptgen/phases/requirements_extraction.py` for multi-turn extraction with deduplication.
- `wptgen/main.py`: Added the `--detailed-requirements` flag to the generate command, which switches to the iterative requirements generation when added.
- Update `WPTGenEngine` to use the iterative extraction phase as the default for Phase 2.
- Implement incremental re-indexing of requirement IDs (e.g., R1, R2, ...) during extraction iterations.
- Add comprehensive test coverage for the iterative phase, including edge cases for max iterations, exhaustion, and caching.
- Update existing engine and caching tests to align with the new iterative workflow.