### PR TITLE
Incorporate MDN documentation into requirements extraction

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -27,10 +27,52 @@ from wptgen.context import (
   extract_feature_metadata,
   fetch_and_extract_text,
   fetch_feature_yaml,
+  fetch_mdn_urls,
   find_feature_tests,
   gather_local_test_context,
   resolve_dependency_path,
 )
+
+
+def test_fetch_mdn_urls_success(mocker: MockerFixture) -> None:
+  """Test successfully fetching MDN URLs from the mapping JSON."""
+  mock_urlopen = mocker.patch('urllib.request.urlopen')
+  mock_response = mocker.MagicMock()
+  mock_response.read.return_value = (
+    b'{"fetch": [{"url": "https://developer.mozilla.org/en-US/docs/Web/API/fetch"}]}'
+  )
+  mock_urlopen.return_value.__enter__.return_value = mock_response
+
+  result = fetch_mdn_urls('fetch')
+
+  assert result == ['https://developer.mozilla.org/en-US/docs/Web/API/fetch']
+  mock_urlopen.assert_called_once()
+  request_obj = mock_urlopen.call_args[0][0]
+  assert 'mdn-docs.json' in request_obj.full_url
+
+
+def test_fetch_mdn_urls_not_found(mocker: MockerFixture) -> None:
+  """Test that if a feature ID is not in the mapping, it returns an empty list."""
+  mock_urlopen = mocker.patch('urllib.request.urlopen')
+  mock_response = mocker.MagicMock()
+  mock_response.read.return_value = b'{"fetch": [{"url": "https://example.com"}]}'
+  mock_urlopen.return_value.__enter__.return_value = mock_response
+
+  result = fetch_mdn_urls('unknown')
+
+  assert result == []
+
+
+def test_fetch_mdn_urls_error(mocker: MockerFixture) -> None:
+  """Test that HTTP errors during mapping fetch return an empty list."""
+  mock_urlopen = mocker.patch('urllib.request.urlopen')
+  mock_urlopen.side_effect = urllib.error.HTTPError(
+    url='', code=404, msg='Not Found', hdrs=Message(), fp=None
+  )
+
+  result = fetch_mdn_urls('fetch')
+
+  assert result == []
 
 
 def test_fetch_feature_yaml_success(mocker: MockerFixture) -> None:

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -92,6 +92,36 @@ async def test_run_context_assembly_success(mock_config: Config, mock_ui: MagicM
 
 
 @pytest.mark.asyncio
+async def test_run_context_assembly_with_mdn(mock_config: Config, mock_ui: MagicMock) -> None:
+  """Test context assembly with MDN documentation fetching."""
+  with (
+    patch('wptgen.phases.context_assembly.fetch_feature_yaml', return_value={'name': 'feat'}),
+    patch(
+      'wptgen.phases.context_assembly.extract_feature_metadata',
+      return_value=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    ),
+    patch('wptgen.phases.context_assembly.fetch_and_extract_text') as mock_fetch,
+    patch(
+      'wptgen.phases.context_assembly.fetch_mdn_urls', return_value=['http://mdn1', 'http://mdn2']
+    ),
+    patch('wptgen.phases.context_assembly.find_feature_tests', return_value=[]),
+    patch('wptgen.phases.context_assembly.gather_local_test_context', return_value=WPTContext()),
+  ):
+    mock_fetch.side_effect = ['Spec Content', 'MDN Content 1', 'MDN Content 2']
+
+    context = await run_context_assembly('feat-id', mock_config, mock_ui)
+
+    assert context is not None
+    assert isinstance(context.mdn_contents, list)
+    assert len(context.mdn_contents) == 2
+    assert 'MDN Content 1' in context.mdn_contents[0]
+    assert 'Documentation from http://mdn1' in context.mdn_contents[0]
+    assert 'MDN Content 2' in context.mdn_contents[1]
+    assert 'Documentation from http://mdn2' in context.mdn_contents[1]
+    assert mock_fetch.call_count == 3
+
+
+@pytest.mark.asyncio
 async def test_run_context_assembly_unregistered_with_params(
   mock_config: Config, mock_ui: MagicMock
 ) -> None:
@@ -225,6 +255,68 @@ async def test_run_requirements_extraction_success(
 
   assert res == '<reqs>generated</reqs>'
   assert context.requirements_xml == '<reqs>generated</reqs>'
+
+
+@pytest.mark.asyncio
+async def test_run_requirements_extraction_with_mdn(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Test that requirements extraction correctly passes mdn_contents to the template."""
+  mdn_list = ['MDN 1', 'MDN 2']
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    spec_contents='Spec',
+    mdn_contents=mdn_list,
+  )
+  jinja_env = MagicMock()
+  template_mock = MagicMock()
+  jinja_env.get_template.return_value = template_mock
+
+  mock_llm.generate_content.return_value = '<reqs>generated</reqs>'
+
+  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
+    await run_requirements_extraction(context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path)
+
+  # Verify render was called with mdn_contents for the main template
+  # It gets called twice: once for the prompt, once for the system prompt
+  prompt_call = next(
+    call for call in template_mock.render.call_args_list if 'mdn_contents' in call.kwargs
+  )
+  assert prompt_call.kwargs['mdn_contents'] == mdn_list
+  assert prompt_call.kwargs['spec_contents'] == 'Spec'
+
+
+@pytest.mark.asyncio
+async def test_run_requirements_extraction_iterative_with_mdn(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Test that iterative requirements extraction correctly passes mdn_contents."""
+  mdn_list = ['MDN 1', 'MDN 2']
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    spec_contents='Spec',
+    mdn_contents=mdn_list,
+  )
+  jinja_env = MagicMock()
+  template_mock = MagicMock()
+  jinja_env.get_template.return_value = template_mock
+
+  mock_llm.generate_content.return_value = (
+    '<requirements_list><status>EXHAUSTED</status></requirements_list>'
+  )
+
+  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
+    await run_requirements_extraction_iterative(
+      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
+    )
+
+  # Verify render was called with mdn_contents
+  prompt_call = next(
+    call for call in template_mock.render.call_args_list if 'mdn_contents' in call.kwargs
+  )
+  assert prompt_call.kwargs['mdn_contents'] == mdn_list
 
 
 @pytest.mark.asyncio

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import re
 import urllib.error
@@ -35,6 +36,8 @@ SCRIPT_DEPENDENCY_REGEX = re.compile(r'<script\s+[^>]*src=["\']([^"\']+)["\']')
 IMPORT_DEPENDENCY_REGEX = re.compile(
   r'(?:import|export)\s+(?:[^"\']+\s+from\s+)?["\']([^"\']+)["\']'
 )
+
+MDN_MAPPINGS_URL = 'https://raw.githubusercontent.com/web-platform-dx/web-features-mappings/main/mappings/mdn-docs.json'
 
 
 def fetch_feature_yaml(web_feature_id: str) -> dict[str, Any] | None:
@@ -64,6 +67,28 @@ def fetch_feature_yaml(web_feature_id: str) -> dict[str, Any] | None:
       return None
     # If it's a 500 error or rate limit, we want it to crash loudly so we know
     raise e
+
+
+def fetch_mdn_urls(web_feature_id: str) -> list[str]:
+  """
+  Fetches the MDN mapping for a given web feature ID from the
+  web-platform-dx/web-features-mappings repository.
+
+  Returns a list of MDN documentation URLs, or an empty list if not found.
+  """
+
+  try:
+    req = urllib.request.Request(MDN_MAPPINGS_URL)
+    with urllib.request.urlopen(req) as response:
+      json_content = response.read().decode('utf-8')
+      data = json.loads(json_content)
+
+      feature_mappings = data.get(web_feature_id, [])
+      return [item['url'] for item in feature_mappings if 'url' in item]
+
+  except (urllib.error.HTTPError, json.JSONDecodeError, KeyError) as e:
+    logger.warning(f'Could not fetch or parse MDN mapping: {e}')
+    return []
 
 
 def extract_feature_metadata(feature_data: dict[str, Any]) -> WebFeatureMetadata:

--- a/wptgen/models.py
+++ b/wptgen/models.py
@@ -43,3 +43,4 @@ class WorkflowContext:
   audit_response: str | None = None
   suggestions: list[str] = field(default_factory=list)
   approved_suggestions_xml: list[str] = field(default_factory=list)
+  mdn_contents: list[str] | None = None

--- a/wptgen/phases/context_assembly.py
+++ b/wptgen/phases/context_assembly.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+
 from rich.table import Table
 
 from wptgen.config import Config
@@ -20,6 +22,7 @@ from wptgen.context import (
   extract_feature_metadata,
   fetch_and_extract_text,
   fetch_feature_yaml,
+  fetch_mdn_urls,
   find_feature_tests,
   gather_local_test_context,
 )
@@ -80,8 +83,24 @@ async def run_context_assembly(
   test_paths = find_feature_tests(config.wpt_path, web_feature_id)
   wpt_context = gather_local_test_context(test_paths, config.wpt_path)
 
+  ui.print('Fetching MDN documentation...')
+  mdn_contents: list[str] | None = None
+  mdn_urls = fetch_mdn_urls(web_feature_id)
+  if mdn_urls:
+    with ui.status(f'[blue]Fetching {len(mdn_urls)} MDN pages...[/blue]'):
+      # Fetch all MDN pages asynchronously using to_thread for the synchronous fetch_and_extract_text
+      results = await asyncio.gather(
+        *[asyncio.to_thread(fetch_and_extract_text, url) for url in mdn_urls]
+      )
+      mdn_contents = [
+        f'# Documentation from {url}\n\n{res}'
+        for url, res in zip(mdn_urls, results, strict=True)
+        if res
+      ]
+
   ui.print(
     f'✔ Context gathered: {len(spec_contents)} chars of spec, '
+    f'{len(mdn_contents) if mdn_contents else 0} MDN pages, '
     f'{len(wpt_context.test_contents)} tests, '
     f'{len(wpt_context.dependency_contents)} dependency files.'
   )
@@ -90,5 +109,6 @@ async def run_context_assembly(
     feature_id=web_feature_id,
     metadata=metadata,
     spec_contents=spec_contents,
+    mdn_contents=mdn_contents,
     wpt_context=wpt_context,
   )

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -52,6 +52,7 @@ async def run_requirements_extraction(
       feature_description=context.metadata.description,
       spec_url=context.metadata.specs[0],
       spec_contents=context.spec_contents,
+      mdn_contents=context.mdn_contents,
     )
     extraction_system_prompt = jinja_env.get_template(
       'requirements_extraction_system.jinja'
@@ -123,6 +124,7 @@ async def run_requirements_extraction_iterative(
         feature_description=context.metadata.description,
         spec_url=context.metadata.specs[0],
         spec_contents=context.spec_contents,
+        mdn_contents=context.mdn_contents,
         existing_requirements_xml=existing_requirements_xml,
       )
       extraction_system_prompt = jinja_env.get_template(

--- a/wptgen/templates/requirements_extraction.jinja
+++ b/wptgen/templates/requirements_extraction.jinja
@@ -8,3 +8,11 @@ Extract the core normative test requirements for the following feature and speci
 <spec_document url="{{spec_url}}">
 {{spec_contents}}
 </spec_document>
+
+{% if mdn_contents -%}
+{% for content in mdn_contents -%}
+<mdn_document>
+{{content}}
+</mdn_document>
+{% endfor -%}
+{%- endif %}

--- a/wptgen/templates/requirements_extraction_iterative.jinja
+++ b/wptgen/templates/requirements_extraction_iterative.jinja
@@ -9,6 +9,14 @@ Extract the normative test requirements for the following feature and specificat
 {{spec_contents}}
 </spec_document>
 
+{% if mdn_contents -%}
+{% for content in mdn_contents -%}
+<mdn_document>
+{{content}}
+</mdn_document>
+{% endfor -%}
+{%- endif %}
+
 <existing_requirements>
 {{existing_requirements_xml}}
 </existing_requirements>

--- a/wptgen/templates/requirements_extraction_iterative_system.jinja
+++ b/wptgen/templates/requirements_extraction_iterative_system.jinja
@@ -15,12 +15,13 @@ You are a Principal Software Engineer in Test (SDET) and a W3C Specification Ana
 
 # INPUTS
 1. `<spec_document>`: The technical specification text.
-2. `<feature_definition>`: The scope of your analysis. You must ignore parts of the spec that fall outside this feature definition.
-3. `<existing_requirements>`: A list of requirements that have ALREADY been extracted. You must read these carefully to avoid duplication.
+2. `<mdn_document>` (Optional): Supplemental MDN documentation for the feature.
+3. `<feature_definition>`: The scope of your analysis. You must ignore parts of the spec that fall outside this feature definition.
+4. `<existing_requirements>`: A list of requirements that have ALREADY been extracted. You must read these carefully to avoid duplication.
 
 # EXTRACTION PROTOCOL
 
-Read the `<spec_document>` and extract every normative requirement that fits within the scope of the `<feature_definition>`.
+Read the `<spec_document>` (and `<mdn_document>` if available) and extract every normative requirement that fits within the scope of the `<feature_definition>`.
 
 Identify the Category for each rule:
 

--- a/wptgen/templates/requirements_extraction_system.jinja
+++ b/wptgen/templates/requirements_extraction_system.jinja
@@ -13,10 +13,11 @@ You are a Principal Software Engineer in Test (SDET) and a W3C Specification Ana
 
 # INPUTS
 1.  `<spec_document>`: The technical specification text.
-2.  `<feature_definition>`: The scope of your analysis. You must ignore parts of the spec that fall outside this feature definition.
+2.  `<mdn_document>` (Optional): Supplemental MDN documentation for the feature.
+3.  `<feature_definition>`: The scope of your analysis. You must ignore parts of the spec that fall outside this feature definition.
 
 # EXTRACTION PROTOCOL
-Read the `<spec_document>` and extract every normative requirement that fits within the scope of the `<feature_definition>`. Identify rules based on the following:
+Read the `<spec_document>` (and `<mdn_document>` if available) and extract every normative requirement that fits within the scope of the `<feature_definition>`. Identify rules based on the following:
 * **Existence:** Rules defining the feature's surface area (interfaces, methods, properties).
 * **Common Use Cases:** Rules defining successful behaviors, processing models, and realistic "happy paths."
 * **Error Scenarios:** Rules defining error conditions, thrown exceptions, and invalid states.


### PR DESCRIPTION
Fixes #46

This change enhances the requirements extraction phase by fetching and incorporating relevant MDN documentation. It uses a mapping from the `web-platform-dx/web-features-mappings` repository to identify MDN URLs associated with a given web feature ID.

Key changes:
- **Asynchronous Fetching**: MDN documentation pages are fetched and extracted asynchronously during the context assembly phase using `asyncio.gather` and `asyncio.to_thread` to minimize latency.
- **Workflow State**: Updated `WorkflowContext` to store MDN contents as a list of strings, preserving individual document boundaries.
- **Prompt Engineering**: Updated Jinja templates to iterate through the MDN document list, rendering each within its own `<mdn_document>` block with source URL attribution.
- **System Instructions**: Refined the requirements extraction system prompts to explicitly leverage MDN content as a supplemental normative source.
- **Validation**: Added comprehensive unit and integration tests covering mapping retrieval, asynchronous fetching logic, and template rendering integrity.