### PR TITLE
Add WPT style guides and categorize test suggestions by type

### DIFF
--- a/wptgen/templates/coverage_audit_system.jinja
+++ b/wptgen/templates/coverage_audit_system.jinja
@@ -52,6 +52,7 @@ R3: [Requirement Text] -> [COVERED by filename.html]
   <test_suggestion>
     <title>[The exact description text from the requirement]</title>
     <description>[The exact text taken from the requirement description]</description>
+    <test_type>[Explicitly categorize the test. e.g. "JavaScript test", "Reftest", "Crashtest"]</test_type>
     <pre_conditions><![CDATA[e.g., "None", HTML body with <div id='target'></div>]]></pre_conditions>
     <steps>
       <step>1. [First step...]</step>

--- a/wptgen/templates/resources/crashtest_style_guide.md
+++ b/wptgen/templates/resources/crashtest_style_guide.md
@@ -1,0 +1,160 @@
+# Crashtest Best Practices
+
+Crash tests are a vital part of the Web Platform Tests (WPT) suite. They ensure that the browser can load a document without crashing, hanging, or triggering low-level issues like assertions, memory leaks, or sanitizer failures.
+
+This guide provides a deep dive into the best practices for writing high-quality crashtests that conform to WPT standards.
+
+---
+
+## 1. Core Concepts
+
+A crashtest is the simplest type of test in WPT.
+- **Success Criteria**: The test passes if the document completes loading and finishing its initial paint without the browser terminating or hanging.
+- **No Harness Needed**: Unlike `testharness.js` tests, crashtests do **not** require any specialized unit testing framework. You do not need to include `testharness.js` or `testharnessreport.js`.
+
+---
+
+## 2. Naming and Location
+
+WPT identifies crashtests based on their filename or their directory.
+
+### Filename Convention
+Add the `-crash` suffix immediately before the file extension.
+- **Correct**: `css/css-foo/bar-crash.html`
+- **Incorrect**: `css/css-foo/bar-crash-001.html` (The suffix must be immediately before the extension).
+
+### Directory Convention
+Place the test inside a directory named `crashtests`.
+- **Example**: `css/css-foo/crashtests/bar.html`
+- Any file within a `crashtests` directory is treated as a crashtest, regardless of its filename.
+
+---
+
+## 3. Test Structure
+
+### Keep it Minimal
+The most effective crashtests are the most minimal. Avoid any extraneous HTML, CSS, or JavaScript that isn't directly related to triggering the crash.
+
+### Basic Template
+```html
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Short descriptive title of the crash scenario</title>
+<link rel="author" title="Your Name" href="mailto:your-email@example.com">
+<link rel="help" href="https://link-to-spec-or-bug-report">
+<meta name="assert" content="Detailed description of what should not crash.">
+
+<!-- Minimal markup to trigger the crash -->
+<div style="columns: 3;">
+  <span>Triggering content</span>
+</div>
+```
+
+---
+
+## 4. Handling Asynchrony
+
+By default, the test runner finishes a crashtest once the `load` event fires and the initial paint is complete. If your test needs to perform work after the initial load, use `test-wait`.
+
+### The `test-wait` Class
+Add the `test-wait` class to the root element (`<html>`). The test will remain active until this class is removed.
+
+```html
+<html class="test-wait">
+<script>
+  requestAnimationFrame(() => {
+    // Perform async work
+    document.documentElement.classList.remove("test-wait");
+  });
+</script>
+</html>
+```
+
+### The `TestRendered` Event
+The test runner fires a `TestRendered` event at the root element when it's ready to finish the test (after `load` and initial paint). Use this to perform modifications that must not be batched with the initial paint.
+
+```html
+<html class="test-wait">
+<script>
+  document.documentElement.addEventListener("TestRendered", () => {
+    // Modify the DOM after initial render
+    document.getElementById("target").style.display = "none";
+    document.documentElement.classList.remove("test-wait");
+  });
+</script>
+</html>
+```
+
+---
+
+## 5. Advanced Features
+
+### User Interactions (`testdriver.js`)
+If a crash is triggered by user interaction, use `testdriver.js`.
+
+```html
+<html class="test-wait">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<button id="btn">Click me</button>
+<script>
+  const btn = document.getElementById("btn");
+  btn.onclick = () => document.documentElement.classList.remove("test-wait");
+  test_driver.click(btn);
+</script>
+</html>
+```
+
+### File Name Flags
+You can use standard WPT filename flags with crashtests:
+- **HTTPS**: `foo-crash.https.html`
+- **Server Substitution**: `foo-crash.sub.html`
+- **HTTP/2**: `foo-crash.h2.html`
+
+---
+
+## 6. Best Practices Checklist
+
+- [ ] **Descriptive Filenames**: Use a concise, descriptive name (e.g., `flex-direction-change-crash.html`).
+- [ ] **UTF-8 Encoding**: Always include `<meta charset="utf-8">`.
+- [ ] **Cross-Browser Compatibility**: Ensure the test doesn't rely on features exclusive to one browser, unless testing that specific browser's behavior.
+- [ ] **Regressions**: If the test is a fix for a bug, include a `link` with `rel="help"` pointing to the bug report.
+- [ ] **CSS Metadata**: For tests in the `css/` directory, a `link` with `rel="help"` pointing to the relevant specification section is **required**.
+- [ ] **Lint Your Test**: Run `./wpt lint` before submitting to ensure your test follows all style and formatting rules.
+
+---
+
+## 7. Examples
+
+### Simple Static Crash
+Triggers a crash during the initial layout.
+```html
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid: Nested grid item crash</title>
+<link rel="help" href="https://drafts.csswg.org/css-grid/">
+<div style="display: grid;">
+  <div style="display: grid; grid-template-columns: repeat(100, 1fr);"></div>
+</div>
+```
+
+### Scripted Dynamic Crash
+Triggers a crash by modifying the DOM after load.
+```html
+<!DOCTYPE html>
+<html class="test-wait">
+<meta charset="utf-8">
+<title>DOM: removeChild on detached iframe</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-node-removechild">
+<iframe></iframe>
+<script>
+  const frame = document.querySelector("iframe");
+  const doc = frame.contentDocument;
+  const div = doc.createElement("div");
+  doc.body.appendChild(div);
+  frame.remove();
+  div.remove();
+  document.documentElement.classList.remove("test-wait");
+</script>
+</html>
+```

--- a/wptgen/templates/resources/javascript_html_style_guide.md
+++ b/wptgen/templates/resources/javascript_html_style_guide.md
@@ -1,0 +1,204 @@
+# WPT JavaScript & HTML Test Best Practices
+
+This guide provides a comprehensive overview of best practices for writing JavaScript and HTML tests in Web Platform Tests (WPT) using the `testharness.js` framework.
+
+---
+
+## 1. Introduction to `testharness.js`
+
+`testharness.js` is the standard framework for testing APIs and logic in WPT. It provides a convenient API for making assertions and supports synchronous, asynchronous, and promise-based tests.
+
+Each test document is considered a "test," and individual `test()`, `promise_test()`, or `async_test()` calls within it are referred to as "subtests."
+
+---
+
+## 2. Choosing a Test Format
+
+WPT supports several ways to structure your tests. Prefer the simplest format that meets your needs.
+
+### 2.1 JavaScript-Only Tests (Recommended)
+These formats automatically generate the necessary HTML boilerplate, making tests cleaner and easier to maintain.
+
+*   **`.window.js`**: Runs in a standard Window environment.
+*   **`.worker.js`**: Runs in a Dedicated Worker.
+*   **`.any.js`**: Runs in multiple global scopes (default: Window and Dedicated Worker). You can customize this using metadata.
+
+**Example (`example.window.js`):**
+```javascript
+test(() => {
+  assert_true(true);
+}, "A simple window test");
+```
+
+### 2.2 HTML Tests
+Use this format if you need specific HTML structure (e.g., custom DOM elements) or if the test is complex.
+
+**Example (`example.html`):**
+```html
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Example Test</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  assert_equals(document.title, "Example Test");
+}, "Check document title");
+</script>
+```
+
+---
+
+## 3. Metadata and File Naming
+
+Metadata and file names communicate critical information to the WPT server and runners.
+
+### 3.1 File Name Flags
+*   `.https`: Loads the test over HTTPS.
+*   `.h2`: Loads the test over HTTP/2.
+*   `.sub`: Enables server-side substitution (e.g., using `{{host}}`).
+*   `.tentative`: Indicates the test is for a feature still under discussion or not yet standardized.
+
+### 3.2 `// META` Comments (for `.js` files)
+*   `// META: title=Test Title`: Sets the document title.
+*   `// META: script=/common/utils.js`: Includes external scripts.
+*   `// META: global=window,worker`: Specifies which globals to run in (for `.any.js`).
+*   `// META: timeout=long`: Increases the test timeout (standard is 10s, long is 60s).
+*   `// META: variant=?wss`: Defines test variants.
+
+---
+
+## 4. Defining Tests
+
+### 4.1 Synchronous Tests (`test`)
+Use for logic that completes immediately.
+```javascript
+test(() => {
+  const result = 1 + 1;
+  assert_equals(result, 2);
+}, "Simple addition test");
+```
+
+### 4.2 Promise-Based Tests (`promise_test`) - **Preferred**
+Use for asynchronous logic. Returning a promise allows the harness to manage the test lifecycle automatically.
+```javascript
+promise_test(async t => {
+  const response = await fetch("data.json");
+  assert_true(response.ok);
+}, "Fetch data test");
+```
+
+### 4.3 Asynchronous Tests (`async_test`)
+Use for callback-based APIs. You must manually manage `step`, `done`, and `step_func`.
+```javascript
+async_test(t => {
+  document.addEventListener("DOMContentLoaded", t.step_func_done(e => {
+    assert_true(e.bubbles);
+  }));
+}, "DOMContentLoaded event");
+```
+
+---
+
+## 5. Assertions and Exception Testing
+
+### 5.1 Common Assertions
+*   `assert_equals(actual, expected, message)`: Check for equality.
+*   `assert_true(actual, message)` / `assert_false(actual, message)`: Check boolean values.
+*   `assert_unreached(message)`: Fail if this point is reached.
+
+### 5.2 Testing for Exceptions
+*   **Synchronous**: `assert_throws_js(ErrorType, () => { ... })` or `assert_throws_dom("IndexSizeError", () => { ... })`.
+*   **Promises**: `promise_rejects_js(t, ErrorType, promise)` or `promise_rejects_dom(t, "NetworkError", promise)`.
+
+---
+
+## 6. Core Best Practices
+
+### 6.1 State Cleanup
+Always clean up global state (DOM, cookies, storage) to ensure test independence. Use `add_cleanup()`.
+```javascript
+promise_test(async t => {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  t.add_cleanup(() => el.remove());
+
+  assert_true(document.body.contains(el));
+}, "DOM cleanup example");
+```
+
+### 6.2 Avoid Timers
+Never use `setTimeout` with a hardcoded delay to "wait" for something.
+*   **Wait for an event**: Use `EventWatcher` or a Promise.
+*   **Check a condition**: Use `t.step_wait(() => condition)`.
+*   **Necessary delays**: Use `t.step_timeout(callback, delay)`.
+
+### 6.3 Cross-Platform & Conservative
+*   **UTF-8**: Always use UTF-8 (and `<meta charset=utf-8>` in HTML).
+*   **Independence**: Tests should not rely on external network resources or specific fonts (use [Ahem](/docs/writing-tests/ahem.md) for font testing).
+*   **Short & Focused**: Keep tests as concise as possible. Avoid testing unrelated features.
+
+---
+
+## 7. Automation with `testdriver.js`
+
+For actions that cannot be performed via standard APIs (e.g., mouse clicks, key presses, permissions), use `test_driver`.
+
+**Setup (HTML):**
+```html
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+```
+
+**Example:**
+```javascript
+promise_test(async t => {
+  const button = document.getElementById("myButton");
+  await test_driver.click(button);
+  // Verify click result
+}, "User click automation");
+```
+
+---
+
+## 8. IDL Testing with `idlharness.js`
+
+For testing Web IDL interfaces, use `idlharness.js`. This ensures that your implementation matches the specification's IDL (attributes, methods, types, etc.).
+
+**Example (`idlharness.window.js`):**
+```javascript
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+idl_test(
+  ['my-spec'],
+  ['dom', 'html'], // dependencies
+  idl_array => {
+    idl_array.add_objects({
+      MyInterface: ['new MyInterface()']
+    });
+  }
+);
+```
+
+---
+
+## 9. Advanced Server Features
+
+WPT's server (`wptserve`) provides powerful features for tests that need more than static files.
+
+### 9.1 Server-Side Substitution (`.sub`)
+Use `.sub` in the filename to use `{{ }}` placeholders.
+*   `{{host}}`: The main host.
+*   `{{hosts[alt][www]}}`: Cross-origin host.
+*   `{{ports[http][0]}}`: The first HTTP port.
+
+### 9.2 Custom Headers (`.headers`)
+Create a file with the same name as your test but ending in `.headers` to specify custom HTTP headers.
+```text
+Content-Type: text/html; charset=big5
+Cache-Control: no-cache
+```
+
+### 9.3 Static Responses (`.asis`)
+Use `.asis` files for byte-for-byte literal HTTP responses (including status line and headers). This is useful for testing invalid or edge-case HTTP responses.

--- a/wptgen/templates/resources/reftest_style_guide.md
+++ b/wptgen/templates/resources/reftest_style_guide.md
@@ -1,0 +1,173 @@
+# Reftest Best Practices
+
+Reftests (reference tests) are one of the primary tools in Web Platform Tests (WPT) for verifying rendering and layout. They work by comparing the visual output of a **test file** against one or more **reference files**. If the pixels match (or mismatch, as specified), the test passes.
+
+This guide provides a comprehensive overview of best practices for writing high-quality, maintainable, and robust reftests.
+
+## 1. Anatomy of a Reftest
+
+A reftest consists of at least two files: the test file and the reference file.
+
+### The Test File
+The test file employs the technology being tested. It must include a `<link>` element that points to the reference file.
+
+```html
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid: basic template-areas</title>
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#grid-template-areas-property">
+<link rel="match" href="grid-template-areas-ref.html">
+<meta name="assert" content="Basic check that grid-template-areas correctly positions items.">
+
+<p>Test passes if there is a green square below and no red.</p>
+<div style="display: grid; grid-template-areas: 'a'; width: 100px; height: 100px;">
+  <div style="grid-area: a; background: green; width: 100%; height: 100%;"></div>
+</div>
+```
+
+### The Reference File
+The reference file describes the *expected* output. **Crucially, it should not use the technology under test.** It should be as simple as possible so that it renders correctly even in browsers with poor support for newer features.
+
+```html
+<!-- grid-template-areas-ref.html -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid: basic template-areas reference</title>
+<p>Test passes if there is a green square below and no red.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>
+```
+
+### Match vs. Mismatch
+- `<link rel="match" href="...">`: The test passes if it renders **pixel-for-pixel identically** to the reference.
+- `<link rel="mismatch" href="...">`: The test passes if it renders **differently** from the reference.
+
+## 2. Naming and Organization
+
+- **File Names**: Use descriptive names. A common pattern is `feature-subfeature-001.html`.
+- **Reference Suffix**: For references specific to one test, use the `-ref` suffix: `my-test.html` -> `my-test-ref.html`.
+- **Shared References**: If a reference is shared across many tests, place it in a `references` directory (either local or at the top level for generic references).
+- **Path Lengths**: Keep paths under 150 characters relative to the test root to avoid Windows limitations.
+- **CSS Uniqueness**: In the `css/` directory, filenames must be unique across the entire `css/` tree.
+
+## 3. The Golden Rule of References
+
+**References must be simple.** If you are testing CSS Grid, your reference should use absolute positioning, floats, or simple block layout to achieve the same visual result. This ensures that a failure in the reference doesn't cause a false positive or negative in the test.
+
+## 4. Visual Patterns for Success and Failure
+
+Tests should be "self-describing" so a human can easily verify them.
+
+- **The Green Square**: A very common pattern. The test passes if it produces a 100x100 green square.
+- **Color Meanings**:
+    - **Green**: Success.
+    - **Red**: Failure. Often placed *under* the test content so it only appears if something is misaligned.
+    - **Black**: Descriptive text.
+    - **Silver/Gray**: Irrelevant filler content.
+- **No Scrollbars**: Avoid scrollbars at an 800x600 window size unless testing scrolling itself.
+
+### Example: The Red-Under-Green Pattern
+```html
+<div style="width: 100px; height: 100px; background: red;">
+  <!-- This green box should perfectly cover the red box -->
+  <div style="width: 100px; height: 100px; background: green; margin-top: -100px;"></div>
+</div>
+```
+
+## 5. Using the Ahem Font
+
+When testing text layout, standard fonts are unreliable due to platform differences. Use the **Ahem font**, which has precise, square metrics.
+
+- **Link the stylesheet**: `<link rel="stylesheet" href="/fonts/ahem.css">`
+- **Sizing**: Use a multiple of 5px (20px or 25px is recommended).
+- **Line-Height**: Use an explicit `line-height` (e.g., `1` or a value where `line-height - font-size` is divisible by 2).
+- **Shorthand**: Use the `font` shorthand to ensure default values for weight/style.
+
+```css
+.test {
+  font: 25px/1 Ahem;
+}
+```
+
+## 6. Advanced Reftest Features
+
+### Asynchronous Tests (`reftest-wait`)
+If your test requires DOM manipulation or animation before the screenshot, use the `reftest-wait` class on the root element.
+
+```html
+<html class="reftest-wait">
+<link rel="match" href="ref.html">
+<script>
+  // The harness fires a 'TestRendered' event when it's ready.
+  document.documentElement.addEventListener('TestRendered', () => {
+    document.getElementById('target').style.background = 'green';
+    document.documentElement.classList.remove('reftest-wait');
+  });
+</script>
+```
+The harness follows this sequence:
+1. Wait for `load` and fonts.
+2. Fire `TestRendered` on the root element.
+3. Wait for `reftest-wait` class to be removed.
+4. Wait for pending paints to complete.
+5. Screenshot the viewport.
+
+### Fuzzy Matching
+If subtle anti-aliasing differences are expected, use the `fuzzy` meta tag.
+
+```html
+<!-- Allow up to 15 per-channel color difference and 300 total different pixels -->
+<meta name="fuzzy" content="maxDifference=15;totalPixels=300">
+```
+
+### Multiple References
+- If multiple `rel="match"` links are present, the test passes if **at least one** matches.
+- If multiple `rel="mismatch"` links are present, the test passes if **all** mismatch.
+
+## 7. Print Reftests
+
+Print reftests verify paginated output.
+- **Naming**: Use the `-print` suffix or place in a `print/` directory.
+- **Comparison**: Pages are compared one-by-one.
+- **Page Size**: The default page size is 12.7 cm by 7.62 cm (5x3 inches) with 12.7 mm (0.5 inch) margins.
+- **Page Range**: Use `<meta name="reftest-pages" content="1-2, 5">` to limit comparison.
+
+## 8. General Requirements and Metadata
+
+### Essential Metadata
+- **Charset**: Always include `<meta charset="utf-8">`.
+- **Conciseness**: Omit `<html>` and `<head>` tags if possible to keep the test focused.
+- **Specification Links**:
+    - **Required for CSS tests**, recommended for others.
+    - Use `<link rel="help" href="...">` to link to the relevant spec section.
+    - List the primary section being tested first.
+- **Test Assertions**:
+    - Use `<meta name="assert" content="...">` to describe exactly what the test is proving.
+    - Avoid repeating the title; be specific (e.g., "Checks that 'text-indent' affects only the first line of a block container").
+
+### Requirement Flags (CSS-Specific)
+For CSS tests, you can use `<meta name="flags" content="...">` to specify requirements. Common tokens include:
+- `asis`: The test cannot be re-serialized (formatting is critical).
+- `may`: Testing optional behavior.
+- `should`: Testing recommended behavior.
+- `paged`: Only valid for paged media.
+- `scroll`: Only valid for scrolling media.
+
+Example:
+```html
+<meta name="flags" content="may paged">
+```
+
+### Avoiding Global Dependencies
+- **Avoid Edge Cases**: Don't rely on unrelated features that might fail in some browsers.
+- **No External Resources**: Tests must be self-contained; do not link to external CDNs or images.
+- **Cross-Platform**: Ensure the test doesn't rely on specific screen resolutions or installed system fonts (use Ahem instead).
+
+## 9. Validation and Running
+
+- **Linting**: Always run `./wpt lint` before submitting. It catches metadata errors, trailing whitespace, and more.
+- **Running**: Use `wpt run <browser> <path/to/test>` to verify your test locally.
+  ```bash
+  python ./wpt run chrome html/semantics/text-level-semantics/the-bdo-element/rtl.html
+  ```
+
+By following these best practices, you ensure your reftests are a reliable part of the Web Platform Tests suite.


### PR DESCRIPTION
This change introduces detailed WPT style guides as resources for the generation engine and enhances the coverage audit phase to explicitly categorize proposed tests. These guides will be used for test generation in a subsequent PR.

- Added comprehensive style guides for Crashtests, Reftests, and JavaScript/HTML tests in `wptgen/templates/resources/`. These guides provide the LLM with standardized best practices and templates for generating high-quality Web Platform Tests.
- Updated `coverage_audit_system.jinja` to include a `<test_type>` field in the `<test_suggestion>` block. This enables the audit phase to explicitly identify the most appropriate test format (e.g., "JavaScript test", "Reftest", "Crashtest") for each identified requirement gap.