### PR TITLE
Implement dynamic, test-type-specific style guides for test file generation

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -29,7 +29,6 @@ def mock_config(tmp_path: Path) -> Config:
     provider='llmbargainbin',
     default_model='discountmodel',
     api_key='fake-key',
-    wpt_path='/fake/wpt',
     categories={
       'lightweight': 'fast-model',
       'reasoning': 'smart-model',
@@ -41,7 +40,9 @@ def mock_config(tmp_path: Path) -> Config:
       'evaluation': 'lightweight',
     },
     yes_tokens=True,
+    wpt_path=str(tmp_path / 'wpt'),
     cache_path=str(tmp_path / '.wpt-gen-cache'),
+    output_dir=str(tmp_path / 'output'),
   )
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -31,7 +30,6 @@ def mock_config(tmp_path: Path) -> Config:
     provider='llmbargainbin',
     default_model='discountmodel',
     api_key='fake-key',
-    wpt_path=os.path.abspath(os.sep + 'fake' + os.sep + 'wpt'),
     categories={
       'lightweight': 'fastmodel',
       'reasoning': 'smartmodel',
@@ -43,7 +41,9 @@ def mock_config(tmp_path: Path) -> Config:
       'evaluation': 'lightweight',
     },
     yes_tokens=False,
+    wpt_path=str(tmp_path / 'wpt'),
     cache_path=str(tmp_path / '.wpt-gen-cache'),
+    output_dir=str(tmp_path / 'output'),
   )
 
 

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -31,13 +31,12 @@ def mock_ui() -> MagicMock:
 
 
 @pytest.fixture
-def mock_config() -> Config:
+def mock_config(tmp_path: Path) -> Config:
   """Fixture that provides a basic test configuration."""
   return Config(
     provider='test',
     default_model='test-model',
     api_key='test-key',
-    wpt_path='/fake/wpt',
     categories={'lightweight': 'test-model', 'reasoning': 'test-model'},
     phase_model_mapping={
       'requirements_extraction': 'reasoning',
@@ -45,7 +44,9 @@ def mock_config() -> Config:
       'generation': 'lightweight',
       'evaluation': 'lightweight',
     },
-    cache_path='/tmp/cache',
+    wpt_path=str(tmp_path / 'wpt'),
+    cache_path=str(tmp_path / 'cache'),
+    output_dir=str(tmp_path / 'output'),
   )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from importlib.metadata import version
+from pathlib import Path
 
 import pytest
 from pytest_mock import MockerFixture
@@ -27,13 +27,12 @@ runner = CliRunner()
 
 
 @pytest.fixture
-def mock_config() -> Config:
+def mock_config(tmp_path: Path) -> Config:
   """Provides a dummy configuration object for successful test runs."""
   return Config(
     provider='gemini',
     default_model='gemini-3.1-pro-preview',
     api_key='fake-key',
-    wpt_path=os.path.join('..', 'wpt'),
     categories={
       'lightweight': 'gemini-3.1-pro-preview',
       'reasoning': 'gemini-3-pro-preview',
@@ -44,6 +43,9 @@ def mock_config() -> Config:
       'generation': 'lightweight',
       'evaluation': 'lightweight',
     },
+    wpt_path=str(tmp_path / 'wpt'),
+    cache_path=str(tmp_path / 'cache'),
+    output_dir=str(tmp_path / 'output'),
     max_retries=3,
   )
 

--- a/tests/test_phase_utils.py
+++ b/tests/test_phase_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -41,13 +42,12 @@ def mock_llm() -> MagicMock:
 
 
 @pytest.fixture
-def mock_config() -> Config:
+def mock_config(tmp_path: Path) -> Config:
   """Fixture that provides a basic test configuration."""
   return Config(
     provider='test',
     default_model='test-model',
     api_key='key',
-    wpt_path='/fake',
     categories={'reasoning': 'test-model', 'lightweight': 'test-model'},
     phase_model_mapping={
       'requirements_extraction': 'reasoning',
@@ -55,6 +55,9 @@ def mock_config() -> Config:
       'generation': 'lightweight',
       'evaluation': 'lightweight',
     },
+    wpt_path=str(tmp_path / 'wpt'),
+    cache_path=str(tmp_path / 'cache'),
+    output_dir=str(tmp_path / 'output'),
     yes_tokens=False,
     show_responses=False,
   )

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -37,13 +37,12 @@ def mock_ui() -> MagicMock:
 
 
 @pytest.fixture
-def mock_config() -> Config:
+def mock_config(tmp_path: Path) -> Config:
   """Fixture that provides a basic test configuration."""
   return Config(
     provider='test',
     default_model='test-model',
     api_key='test-key',
-    wpt_path='/fake/wpt',
     categories={
       'lightweight': 'fast-model',
       'reasoning': 'smart-model',
@@ -54,7 +53,9 @@ def mock_config() -> Config:
       'generation': 'lightweight',
       'evaluation': 'lightweight',
     },
-    cache_path='/tmp/cache',
+    wpt_path=str(tmp_path / 'wpt'),
+    cache_path=str(tmp_path / 'cache'),
+    output_dir=str(tmp_path / 'output'),
   )
 
 
@@ -696,3 +697,169 @@ async def test_run_requirements_extraction_iterative_no_reqs_at_all(
     )
 
   assert res is None
+
+
+@pytest.mark.asyncio
+async def test_run_test_generation_dynamic_style_guides(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock
+) -> None:
+  """Verify that different test types load different style guides."""
+  suggestions_xml = """
+<test_suggestions>
+  <test_suggestion>
+    <title>JS Test</title>
+    <description>JS Desc</description>
+    <test_type>JavaScript Test</test_type>
+  </test_suggestion>
+  <test_suggestion>
+    <title>Ref Test</title>
+    <description>Ref Desc</description>
+    <test_type>Reftest</test_type>
+  </test_suggestion>
+  <test_suggestion>
+    <title>Crash Test</title>
+    <description>Crash Desc</description>
+    <test_type>Crashtest</test_type>
+  </test_suggestion>
+</test_suggestions>
+"""
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    audit_response=suggestions_xml,
+  )
+
+  jinja_env = MagicMock()
+  system_template_mock = MagicMock()
+  gen_template_mock = MagicMock()
+
+  def get_template_side_effect(name: str) -> MagicMock:
+    if name == 'test_generation_system.jinja':
+      return system_template_mock
+    return gen_template_mock
+
+  jinja_env.get_template.side_effect = get_template_side_effect
+
+  # We need to mock Path.read_text to avoid actually reading files during test.
+  # Using autospec=True or patching at the class level is better for methods.
+  with patch('wptgen.phases.generation.Path.read_text', autospec=True) as mock_read:
+    mock_read.side_effect = lambda self, encoding='utf-8': f'Content of {self.name}'
+
+    with patch('wptgen.phases.generation.confirm_prompts', return_value=None):
+      with patch('wptgen.phases.generation.generate_safe', return_value='<html></html>'):
+        await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
+
+  # Check that system_template_mock.render was called 3 times with different style guides
+  assert system_template_mock.render.call_count == 3
+
+  calls = system_template_mock.render.call_args_list
+
+  # Call 1: JS Test
+  assert calls[0].kwargs['test_type'] == 'JavaScript Test'
+  assert calls[0].kwargs['test_type_guide'] == 'Content of javascript_html_style_guide.md'
+
+  # Call 2: Reftest
+  assert calls[1].kwargs['test_type'] == 'Reftest'
+  assert calls[1].kwargs['test_type_guide'] == 'Content of reftest_style_guide.md'
+
+  # Call 3: Crashtest
+  assert calls[2].kwargs['test_type'] == 'Crashtest'
+  assert calls[2].kwargs['test_type_guide'] == 'Content of crashtest_style_guide.md'
+
+  # Also verify wpt_style_guide was passed to all
+  for call in calls:
+    assert call.kwargs['wpt_style_guide'] == 'Content of wpt_style_guide.md'
+
+
+@pytest.mark.asyncio
+async def test_run_test_generation_normalization(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock
+) -> None:
+  """Verify that test type string normalization works."""
+  suggestions_xml = """
+<test_suggestion>
+  <title>Lower JS</title>
+  <test_type>javascript test</test_type>
+</test_suggestion>
+"""
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    audit_response=suggestions_xml,
+  )
+
+  jinja_env = MagicMock()
+  system_template_mock = MagicMock()
+  gen_template_mock = MagicMock()
+
+  def get_template_side_effect(name: str) -> MagicMock:
+    if name == 'test_generation_system.jinja':
+      return system_template_mock
+    return gen_template_mock
+
+  jinja_env.get_template.side_effect = get_template_side_effect
+
+  with patch('wptgen.phases.generation.Path.read_text', return_value='Guide Content'):
+    with patch('wptgen.phases.generation.confirm_prompts', return_value=None):
+      with patch('wptgen.phases.generation.generate_safe', return_value='<html></html>'):
+        await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
+
+  # Should normalize "javascript test" to "JavaScript Test" from the Enum
+  assert system_template_mock.render.call_args.kwargs['test_type'] == 'JavaScript Test'
+
+
+@pytest.mark.asyncio
+async def test_run_test_evaluation_dynamic_style_guides(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock
+) -> None:
+  """Verify that different test types load different style guides during evaluation."""
+  generated_tests = [
+    (
+      Path('js_test.html'),
+      'content',
+      '<test_suggestion><test_type>JavaScript Test</test_type></test_suggestion>',
+    ),
+    (
+      Path('ref_test.html'),
+      'content',
+      '<test_suggestion><test_type>Reftest</test_type></test_suggestion>',
+    ),
+    (
+      Path('crash_test.html'),
+      'content',
+      '<test_suggestion><test_type>Crashtest</test_type></test_suggestion>',
+    ),
+  ]
+  context = WorkflowContext(feature_id='feat')
+
+  jinja_env = MagicMock()
+  system_template_mock = MagicMock()
+  eval_template_mock = MagicMock()
+
+  def get_template_side_effect(name: str) -> MagicMock:
+    if name == 'evaluation_system.jinja':
+      return system_template_mock
+    return eval_template_mock
+
+  jinja_env.get_template.side_effect = get_template_side_effect
+
+  with patch('wptgen.phases.evaluation.Path.read_text', autospec=True) as mock_read:
+    mock_read.side_effect = lambda self, encoding='utf-8': f'Content of {self.name}'
+
+    with patch('wptgen.phases.evaluation.generate_safe', return_value='PASS'):
+      from wptgen.phases.evaluation import run_test_evaluation
+
+      await run_test_evaluation(context, mock_config, mock_llm, mock_ui, jinja_env, generated_tests)
+
+  # Check that system_template_mock.render was called 3 times with different style guides
+  assert system_template_mock.render.call_count == 3
+  calls = system_template_mock.render.call_args_list
+
+  assert calls[0].kwargs['test_type'] == 'JavaScript Test'
+  assert calls[0].kwargs['test_type_guide'] == 'Content of javascript_html_style_guide.md'
+
+  assert calls[1].kwargs['test_type'] == 'Reftest'
+  assert calls[1].kwargs['test_type_guide'] == 'Content of reftest_style_guide.md'
+
+  assert calls[2].kwargs['test_type'] == 'Crashtest'
+  assert calls[2].kwargs['test_type_guide'] == 'Content of crashtest_style_guide.md'

--- a/wptgen/models.py
+++ b/wptgen/models.py
@@ -13,6 +13,21 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
+from enum import Enum
+
+
+class TestType(Enum):
+  JAVASCRIPT = 'JavaScript Test'
+  REFTEST = 'Reftest'
+  CRASHTEST = 'Crashtest'
+
+
+# Map test types to their corresponding style guide resource files
+STYLE_GUIDE_MAP = {
+  TestType.JAVASCRIPT: 'javascript_html_style_guide.md',
+  TestType.REFTEST: 'reftest_style_guide.md',
+  TestType.CRASHTEST: 'crashtest_style_guide.md',
+}
 
 
 @dataclass

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -19,10 +19,10 @@ from jinja2 import Environment
 
 from wptgen.config import Config
 from wptgen.llm import LLMClient
-from wptgen.models import WorkflowContext
+from wptgen.models import STYLE_GUIDE_MAP, TestType, WorkflowContext
 from wptgen.phases.utils import generate_safe
 from wptgen.ui import UIProvider
-from wptgen.utils import MARKDOWN_CODE_BLOCK_RE
+from wptgen.utils import MARKDOWN_CODE_BLOCK_RE, extract_xml_tag
 
 
 async def run_test_evaluation(
@@ -37,19 +37,35 @@ async def run_test_evaluation(
   ui.rule('Phase 5: Evaluation')
   ui.print(f'Evaluating [bold]{len(generated_tests)}[/bold] tests...')
 
-  # Load the style guide
-  style_guide_path = Path(__file__).parent.parent / 'templates' / 'resources' / 'wpt_style_guide.md'
-  style_guide = style_guide_path.read_text(encoding='utf-8')
+  # Load the general style guide
+  resources_path = Path(__file__).parent.parent / 'templates' / 'resources'
+  wpt_style_guide = (resources_path / 'wpt_style_guide.md').read_text(encoding='utf-8')
 
-  # Prepare system instruction
-  system_instruction = jinja_env.get_template('evaluation_system.jinja').render(
-    wpt_style_guide=style_guide
-  )
-
+  # Prepare templates
   evaluation_template = jinja_env.get_template('evaluation.jinja')
+  system_template = jinja_env.get_template('evaluation_system.jinja')
 
   tasks = []
   for path, content, suggestion_xml in generated_tests:
+    # Extract and normalize test type
+    raw_test_type = extract_xml_tag(suggestion_xml, 'test_type') or 'JavaScript Test'
+    test_type_enum = TestType.JAVASCRIPT
+    for member in TestType:
+      if member.value.lower() == raw_test_type.lower():
+        test_type_enum = member
+        break
+
+    # Load the specific style guide for this test type
+    guide_filename = STYLE_GUIDE_MAP.get(test_type_enum, 'javascript_html_style_guide.md')
+    test_type_guide = (resources_path / guide_filename).read_text(encoding='utf-8')
+
+    # Render the system instruction with both general and type-specific rules
+    system_instruction = system_template.render(
+      wpt_style_guide=wpt_style_guide,
+      test_type=test_type_enum.value,
+      test_type_guide=test_type_guide,
+    )
+
     prompt = evaluation_template.render(
       test_suggestion_xml=suggestion_xml,
       generated_code_content=content,

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -20,7 +20,7 @@ from rich.table import Table
 
 from wptgen.config import Config
 from wptgen.llm import LLMClient
-from wptgen.models import WorkflowContext
+from wptgen.models import STYLE_GUIDE_MAP, TestType, WorkflowContext
 from wptgen.phases.utils import confirm_prompts, generate_safe
 from wptgen.ui import UIProvider
 from wptgen.utils import (
@@ -80,19 +80,36 @@ async def run_test_generation(
     ui.print('[yellow]No tests selected. Exiting.[/yellow]')
     return []
 
-  # Load the style guide
-  style_guide_path = Path(__file__).parent.parent / 'templates' / 'resources' / 'wpt_style_guide.md'
-  style_guide = style_guide_path.read_text(encoding='utf-8')
+  # Load the general style guide
+  resources_path = Path(__file__).parent.parent / 'templates' / 'resources'
+  wpt_style_guide = (resources_path / 'wpt_style_guide.md').read_text(encoding='utf-8')
 
-  # Prepare all generation prompts for batch confirmation
+  # Prepare templates
   gen_template = jinja_env.get_template('test_generation.jinja')
-  system_instruction = jinja_env.get_template('test_generation_system.jinja').render(
-    wpt_style_guide=style_guide
-  )
+  system_template = jinja_env.get_template('test_generation_system.jinja')
 
-  prompts_to_confirm: list[tuple[str, str, str]] = []
+  prompts_to_confirm: list[tuple[str, str, str, str]] = []
 
   for idx, suggestion_xml in enumerate(approved_suggestions_xml):
+    # Extract and normalize test type
+    raw_test_type = extract_xml_tag(suggestion_xml, 'test_type') or 'JavaScript Test'
+    test_type_enum = TestType.JAVASCRIPT
+    for member in TestType:
+      if member.value.lower() == raw_test_type.lower():
+        test_type_enum = member
+        break
+
+    # Load the specific style guide for this test type
+    guide_filename = STYLE_GUIDE_MAP.get(test_type_enum, 'javascript_html_style_guide.md')
+    test_type_guide = (resources_path / guide_filename).read_text(encoding='utf-8')
+
+    # Render the system instruction with both general and type-specific rules
+    system_instruction = system_template.render(
+      wpt_style_guide=wpt_style_guide,
+      test_type=test_type_enum.value,
+      test_type_guide=test_type_guide,
+    )
+
     final_prompt = gen_template.render(
       feature_name=context.metadata.name,
       feature_description=context.metadata.description,
@@ -104,11 +121,11 @@ async def run_test_generation(
     slug = FILENAME_SANITIZATION_RE.sub('_', raw_title.lower())
     safe_filename = f'{slug}__GENERATED_{idx + 1:02d}_.html'
 
-    prompts_to_confirm.append((final_prompt, safe_filename, suggestion_xml))
+    prompts_to_confirm.append((final_prompt, safe_filename, suggestion_xml, system_instruction))
 
   # Single confirmation for ALL tests
   await confirm_prompts(
-    [(p, f) for p, f, s in prompts_to_confirm],
+    [(p, f) for p, f, s, si in prompts_to_confirm],
     f'Generate {len(prompts_to_confirm)} Tests',
     llm,
     ui,
@@ -122,7 +139,7 @@ async def run_test_generation(
     _generate_and_save(
       prompt, filename, suggestion_xml, llm, ui, config, system_instruction, temperature=0.1
     )
-    for prompt, filename, suggestion_xml in prompts_to_confirm
+    for prompt, filename, suggestion_xml, system_instruction in prompts_to_confirm
   ]
   results = await asyncio.gather(*tasks)
 

--- a/wptgen/templates/evaluation_system.jinja
+++ b/wptgen/templates/evaluation_system.jinja
@@ -4,8 +4,11 @@ You are an automated Web Platform Tests (WPT) code validator that operates under
 # TASK
 You will be given a source blueprint, a style guide, rules, evaluation criteria, and generated code. Your task is to evaluate the generated code against these rules and either approve it or correct it.
 
-# WPT STYLE GUIDE & RULES
+# WPT GENERAL STYLE GUIDE
 {{ wpt_style_guide }}
+
+# {{ test_type }} STYLE GUIDE & RULES
+{{ test_type_guide }}
 
 # EVALUATION CRITERIA
 You must evaluate the provided `<generated_code>` against the WPT Style Guide above, and specifically check the following:

--- a/wptgen/templates/resources/crashtest_style_guide.md
+++ b/wptgen/templates/resources/crashtest_style_guide.md
@@ -1,5 +1,3 @@
-# Crashtest Best Practices
-
 Crash tests are a vital part of the Web Platform Tests (WPT) suite. They ensure that the browser can load a document without crashing, hanging, or triggering low-level issues like assertions, memory leaks, or sanitizer failures.
 
 This guide provides a deep dive into the best practices for writing high-quality crashtests that conform to WPT standards.

--- a/wptgen/templates/resources/javascript_html_style_guide.md
+++ b/wptgen/templates/resources/javascript_html_style_guide.md
@@ -1,5 +1,3 @@
-# WPT JavaScript & HTML Test Best Practices
-
 This guide provides a comprehensive overview of best practices for writing JavaScript and HTML tests in Web Platform Tests (WPT) using the `testharness.js` framework.
 
 ---

--- a/wptgen/templates/resources/reftest_style_guide.md
+++ b/wptgen/templates/resources/reftest_style_guide.md
@@ -1,5 +1,3 @@
-# Reftest Best Practices
-
 Reftests (reference tests) are one of the primary tools in Web Platform Tests (WPT) for verifying rendering and layout. They work by comparing the visual output of a **test file** against one or more **reference files**. If the pixels match (or mismatch, as specified), the test passes.
 
 This guide provides a comprehensive overview of best practices for writing high-quality, maintainable, and robust reftests.

--- a/wptgen/templates/resources/wpt_style_guide.md
+++ b/wptgen/templates/resources/wpt_style_guide.md
@@ -1,156 +1,109 @@
-This guide provides comprehensive instructions and best practices for generating high-quality Web Platform Tests. It is optimized for use by LLMs to understand the structure, APIs, and conventions of the WPT project.
+This guide provides a detailed overview of the best practices that apply in Web Platform Tests (WPT).
+
+Following these guidelines ensures that your tests are robust, cross-platform, and maintainable.
 
 ---
 
-## 1. Core Philosophy
-*   **Be Short:** Tests should be as concise as possible. Avoid extraneous elements.
-*   **Be Self-Contained:** No external network dependencies.
-*   **Be Cross-Platform:** Work across devices, resolutions, and OSs.
-*   **Be Conservative:** Avoid edge cases of features not being tested. Use standard features supported by major browsers (Chrome, Firefox, Safari).
-*   **Be Self-Describing:** It should be obvious if a test passes or fails without reading the spec.
+## 1. File Organization and Naming
+
+WPT uses file names and directory structures to determine how tests are run.
+
+### 1.1 Descriptive Naming
+Files should have descriptive names that reflect the feature being tested. Avoid generic names like `test1.html`.
+*   **Format**: `test-topic-###.html` (e.g., `flexbox-layout-001.html`).
+*   **Path Length**: Ensure the test path is less than **150 characters** relative to the test root directory to avoid Windows path length limitations.
+
+### 1.2 Universal Filename Flags
+Flags are added to the filename to enable specific server features. These apply to all three test types:
+*   `.https`: Loads the test over HTTPS (e.g., `my-test.https.html`).
+*   `.h2`: Loads the test over HTTP/2.
+*   `.sub`: Enables [server-side substitution](https://web-platform-tests.org/writing-tests/server-pipes.html#sub), allowing placeholders like `{{host}}`.
+*   `.tentative`: Indicates the test is for a feature not yet fully standardized.
+
+### 1.3 Support Files
+Place auxiliary files (images, scripts, etc.) in directories named `resources`, `support`, or in common areas like `/common/`, `/media/`, or `/css/support/`.
 
 ---
 
-## 2. Test Types & File Naming
-The file extension and name flags determine how the test is run.
+## 2. Core Metadata
 
-### A. JavaScript Tests (`testharness.js`)
-Used for testing APIs and logic.
-*   `.any.js`: Runs in multiple globals (Window, Workers).
-*   `.window.js`: Runs in a Window global.
-*   `.worker.js`: Runs in a Dedicated Worker.
-*   **Boilerplate:** For `.js` files, WPT generates the HTML. For `.html` files, you must include:
-    ```html
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-    ```
+Every test file should contain metadata to describe its purpose and requirements.
 
-### B. Reftests (Rendering Tests)
-Compares the rendering of two files.
-*   **Structure:** A test file and a reference file.
-*   **Link:** `<link rel="match" href="reference.html">` (or `rel="mismatch"`).
-*   **Pass Condition:** Pixel-perfect match (800x600 viewport).
+### 2.1 Character Encoding
+All tests must be encoded in **UTF-8**.
+*   **Requirement**: Include `<meta charset="utf-8">` as the first tag in the `<head>` of HTML files.
 
-### C. Crashtests
-Checks if a page crashes or leaks.
-*   **Naming:** Ends in `-crash.html` or located in a `crashtests/` directory.
-*   **Pass Condition:** Page loads and paints without crashing. No `testharness.js` required.
+### 2.2 Documentation Links
+Link to the relevant specification using `<link rel="help">`. This is required for CSS tests and highly recommended for all others.
+```html
+<link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-direction-property">
+```
 
-### D. Naming Conventions & Flags
-*   **Format:** `{test-topic}-{index}.html` (e.g., `flexbox-layout-001.html`). Use descriptive names.
-*   `.https.html`: Requires HTTPS.
-*   `.h2.html`: Requires HTTP/2.
-*   `.sub.html`: Enables server-side substitution.
-*   `.tentative.html`: For experimental/non-standard features.
-*   `.optional.html`: For optional spec features (RFC 2119 "MAY").
-
----
-
-## 3. The `testharness.js` API
-
-### Subtest Types
-1.  **`test(fn, name)`**: For synchronous tests.
-    ```javascript
-    test(() => {
-      assert_equals(1 + 1, 2);
-    }, "Addition works");
-    ```
-2.  **`promise_test(fn, name)`**: For asynchronous code using Promises (preferred).
-    ```javascript
-    promise_test(async t => {
-      const result = await fetch("/data");
-      assert_true(result.ok);
-    }, "Fetch works");
-    ```
-3.  **`async_test(fn, name)`**: For callback-based asynchronous code.
-    ```javascript
-    async_test(t => {
-      document.onclick = t.step_func_done(e => {
-        assert_true(e.isTrusted);
-      });
-    }, "Click is trusted");
-    ```
-
-### Key Assertions
-*   `assert_equals(actual, expected, description)`
-*   `assert_true(actual, description)`
-*   `assert_throws_dom(type, fn, description)`: For DOMExceptions (e.g., "IndexSizeError").
-*   `assert_throws_js(type, fn, description)`: For JS errors (e.g., `TypeError`).
-*   `promise_rejects_dom(t, type, promise)`: For promises that should fail.
-
-### Event Handling
-Use `EventWatcher` for sequenced events:
-```javascript
-const watcher = new EventWatcher(t, element, ["start", "end"]);
-await watcher.wait_for("start");
-// ... action ...
-await watcher.wait_for("end");
+### 2.3 Test Assertions
+Use a `<meta name="assert">` tag to provide a concise description of what the test is verifying.
+```html
+<meta name="assert" content="Checks that flex-direction: row-reverse correctly mirrors the main axis.">
 ```
 
 ---
 
-## 4. Metadata & Inclusion
-### JavaScript Meta Tags
-Use `// META` comments at the top of `.js` files:
-*   `// META: title=Test Title`
-*   `// META: script=/common/utils.js` (Include helper scripts)
-*   `// META: global=window,worker` (Define execution scopes)
+## 3. General Principles
 
-### HTML Metadata
-*   `<link rel="help" href="https://spec.whatwg.org/#feature">`: Links to the specification.
-*   `<meta name="timeout" content="long">`: For slow tests.
+### 3.1 Be Short and Focused
+Tests should be as minimal as possible.
+*   Avoid extraneous HTML tags (like `<html>` or `<body>` if they aren't strictly necessary).
+*   Ensure the test only verifies the specific feature intended.
+
+### 3.2 Be Conservative
+Avoid depending on edge-case behavior of unrelated features.
+*   Ensure there are **no parse errors**.
+*   Only use features that are broadly supported across major browser engines (Safari, Chrome, Firefox) unless they are the subject of the test.
+
+### 3.3 Be Cross-Platform
+Assume the following defaults:
+*   Viewport dimensions of at least 800px by 600px.
+*   Canvas background is `white`, and initial `color` is `black`.
+*   No specific system fonts are installed. Use the **Ahem font** for tests requiring precise text metrics.
+
+### 3.4 Be Self-Contained
+Tests **must not** depend on external network resources. Use local support files or WPT's cross-origin host features if multiple domains are needed.
+
+### 3.5 Be Self-Describing
+It should be obvious to a human reviewer whether the test passed or failed.
 
 ---
 
-## 5. User Interaction (`testdriver.js`)
-Always include both scripts. Use `test_driver` for actions requiring user activation or privileged access.
+## 4. Automation with `testdriver.js`
+
+For tests requiring user interaction (clicks, key presses, etc.) that cannot be triggered via standard APIs, use `testdriver.js`. This is supported by JS tests, reftests, and crashtests.
+
+### 4.1 Setup
+Include the following scripts in your HTML:
 ```html
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 ```
-Example:
-```javascript
-await test_driver.bless("permission request");
-await test_driver.click(button);
-```
 
----
-
-## 6. Server-Side Features
-### Substitution (`.sub.html`)
-Use {% raw %}`{{host}}`, `{{ports[http][0]}}`, or `{{domains[www]}}`{% endraw %}.
-### Pipes (`?pipe=...`)
-*   `status(404)`: Return 404.
-*   `header(Name, Value)`: Set response header.
-*   `trickle(100:d1:r2)`: Send 100 bytes, delay 1s, repeat.
-
----
-
-## 7. Rendering & SVG
-### Ahem Font
-Essential for predictable text rendering in reftests.
+### 4.2 Usage Example
 ```html
-<link rel="stylesheet" href="/fonts/ahem.css">
-<style>
-  .test { font: 20px/1 Ahem; color: green; }
-</style>
+<script>
+  async function performAction() {
+    const button = document.getElementById("target");
+    await test_driver.click(button);
+    // Continue with test logic or remove wait classes
+  }
+  performAction();
+</script>
 ```
-
-### SVG Tests
-SVG files are supported and can include `testharness.js` via `<h:script>`.
-```xml
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
-  <h:script src="/resources/testharness.js"/>
-  <h:script src="/resources/testharnessreport.js"/>
-</svg>
-```
+*Note: While the automation API is universal, each test type has its own specific mechanism for managing asynchrony and signaling test completion.*
 
 ---
 
-## 8. Summary Checklist for LLM Generation
-1.  **Type:** API (testharness), Rendering (reftest), or Crash?
-2.  **Environment:** Window, Worker, or both (`.any.js`)?
-3.  **Security:** Does it need `.https`?
-4.  **Async:** Use `promise_test` and `add_cleanup`.
-5.  **Aesthetics:** For reftests, use Ahem and 800x600 layout.
-6.  **Spec Link:** Always include a `<link rel="help">`.
+## 5. Style and Linting
+
+Consistent style is enforced across the entire WPT repository.
+
+### 5.1 Formatting Rules
+*   **Indentation**: Use spaces, not tabs.
+*   **Whitespace**: No trailing whitespace.
+*   **Line Endings**: Use UNIX-style (LF) line endings.

--- a/wptgen/templates/test_generation_system.jinja
+++ b/wptgen/templates/test_generation_system.jinja
@@ -3,12 +3,7 @@ You are WPT-Gen, an automated, expert-level Web Platform Test (WPT) generation e
 
 # CORE DIRECTIVES
 1.  **Zero Conversation:** Do not output conversational filler, pleasantries, or explanatory text. Output ONLY the raw file contents.
-2.  **Scope Enforcement:** You are strictly authorized to generate JavaScript-based logic and API tests using the `testharness.js` framework.
-3.  **Formatting Strictness:** Output the exact HTML/JS file content. Do not wrap your final output in markdown code blocks unless specifically instructed.
-
-# WPT STYLE GUIDE & RULES
-{{ wpt_style_guide }}
-
+2.  **Formatting Strictness:** Output the exact HTML/JS file content. Do not wrap your final output in markdown code blocks unless specifically instructed.
 
 # BLUEPRINT MAPPING PROTOCOL
 You will receive a `<test_suggestion>` XML blueprint. You must map its fields to the WPT file as follows:
@@ -17,6 +12,12 @@ You will receive a `<test_suggestion>` XML blueprint. You must map its fields to
 * `<pre_conditions>`: Translate this into the necessary HTML elements within the `<body>`, or initialize them in a `setup()` block.
 * `<steps>`: Translate these sequential steps directly into the JavaScript execution logic inside the test function.
 * `<expected_result>`: Map this strictly to the correct assertion (e.g., `assert_equals`, `assert_throws_js`, `promise_rejects_dom`).
+
+# WPT GENERAL STYLE GUIDE
+{{ wpt_style_guide }}
+
+# {{ test_type }} STYLE GUIDE & RULES
+{{ test_type_guide }}
 
 # EXECUTION
 Synthesize the minimal, most robust test file required to assert the expected result based on the blueprint. Ensure all side-effects are cleaned up. Output the code and terminate.


### PR DESCRIPTION
This change updates the test generation and evaluation phases to dynamically include specialized WPT style guides based on the detected test type (JavaScript Test, Reftest, or Crashtest). Additionally, the general WPT style guide has been updated with only information that is relevant to all main 3 test types.

Basically, this change provides the LLM with type-specific test guidelines on how to write the test.

Key Changes:
- **Model Enhancements**: Added `TestType` enum and `STYLE_GUIDE_MAP` to `wptgen/models.py` to centralize the mapping of test categories to their respective style guide resources.
- **Dynamic System Prompts**: Refactored `run_test_generation` and `run_test_evaluation` to extract the `<test_type>` from test suggestion XML blocks and render unique system instructions per test.
- **Template Generalization**: Updated `test_generation_system.jinja` and `evaluation_system.jinja` to support dynamic placeholders for both general WPT rules and type-specific guidance.
- **Test Robustness**: Updated all `mock_config` fixtures across the test suite (`tests/test_phases.py`, `tests/test_main.py`, `tests/test_engine.py`, etc.) to use `tmp_path` for `wpt_path`, `cache_path`, and `output_dir`. This prevents rogue files from being created in the repository during test execution.
- **Verification**: Added comprehensive unit tests in `tests/test_phases.py` to verify style guide selection logic, test type normalization, and evaluation-specific dynamic prompts.