### PR TITLE
Add reftest compatibility to generation and evaluation phases

### DIFF
--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -145,3 +145,44 @@ async def test_run_test_evaluation_no_response(
   mock_ui.print.assert_any_call(
     f'[yellow]⚠ No response for evaluation of {test_path.name}. Keeping original.[/yellow]'
   )
+
+
+@pytest.mark.asyncio
+async def test_run_test_evaluation_reftest_correction(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  context = WorkflowContext(feature_id='feat')
+  jinja_env = MagicMock()
+
+  # Mock style guide and templates
+  style_guide_content = 'Style Guide Content'
+
+  test_path = tmp_path / 'test.html'
+  ref_path = tmp_path / 'test-ref.html'
+  test_path.write_text('original test content')
+  ref_path.write_text('original ref content')
+
+  suggestion_xml = '<test_suggestion><test_type>Reftest</test_type></test_suggestion>'
+  generated_tests = [
+    (test_path, 'original test content', suggestion_xml),
+    (ref_path, 'original ref content', suggestion_xml),
+  ]
+
+  # Mock LLM returning corrected content for BOTH files
+  mock_llm.generate_content.return_value = """
+[FILE_1: test.html]
+corrected test content
+[/FILE_1]
+
+[FILE_2: test-ref.html]
+corrected ref content
+[/FILE_2]
+"""
+
+  with patch('wptgen.phases.evaluation.Path.read_text', return_value=style_guide_content):
+    await run_test_evaluation(context, mock_config, mock_llm, mock_ui, jinja_env, generated_tests)
+
+  assert test_path.read_text() == 'corrected test content'
+  assert ref_path.read_text() == 'corrected ref content'
+  mock_ui.print.assert_any_call('[cyan]ℹ test.html was corrected and updated.[/cyan]')
+  mock_ui.print.assert_any_call('[cyan]ℹ test-ref.html was corrected and updated.[/cyan]')

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -761,10 +761,14 @@ async def test_run_test_generation_dynamic_style_guides(
   # Call 2: Reftest
   assert calls[1].kwargs['test_type'] == 'Reftest'
   assert calls[1].kwargs['test_type_guide'] == 'Content of reftest_style_guide.md'
+  assert calls[1].kwargs['safe_filename'] == 'ref_test__GENERATED_02_.html'
+  assert calls[1].kwargs['ref_filename'] == 'ref_test__GENERATED_02_-ref.html'
 
   # Call 3: Crashtest
   assert calls[2].kwargs['test_type'] == 'Crashtest'
   assert calls[2].kwargs['test_type_guide'] == 'Content of crashtest_style_guide.md'
+  assert calls[2].kwargs['safe_filename'] == 'crash_test__GENERATED_03_.html'
+  assert calls[2].kwargs['ref_filename'] is None
 
   # Also verify wpt_style_guide was passed to all
   for call in calls:
@@ -806,6 +810,63 @@ async def test_run_test_generation_normalization(
 
   # Should normalize "javascript test" to "JavaScript Test" from the Enum
   assert system_template_mock.render.call_args.kwargs['test_type'] == 'JavaScript Test'
+
+
+@pytest.mark.asyncio
+async def test_run_test_generation_reftest_multi_file(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Verify that reftests correctly parse and save multiple files."""
+  suggestion_xml = """
+<test_suggestion>
+  <title>Multi File Ref</title>
+  <test_type>Reftest</test_type>
+</test_suggestion>
+"""
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    audit_response=suggestion_xml,
+  )
+
+  jinja_env = MagicMock()
+  system_template_mock = MagicMock()
+  gen_template_mock = MagicMock()
+
+  def get_template_side_effect(name: str) -> MagicMock:
+    if name == 'test_generation_system.jinja':
+      return system_template_mock
+    return gen_template_mock
+
+  jinja_env.get_template.side_effect = get_template_side_effect
+
+  # Partitioned response from LLM
+  llm_response = """
+[FILE_1: multi_file_ref__GENERATED_01_.html]
+<link rel="match" href="multi_file_ref__GENERATED_01_-ref.html">
+[/FILE_1]
+
+[FILE_2: multi_file_ref__GENERATED_01_-ref.html]
+<p>Reference</p>
+[/FILE_2]
+"""
+  mock_config.output_dir = str(tmp_path / 'output')
+
+  with patch('wptgen.phases.generation.Path.read_text', return_value='Guide'):
+    with patch('wptgen.phases.generation.confirm_prompts', return_value=None):
+      with patch('wptgen.phases.generation.generate_safe', return_value=llm_response):
+        res = await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
+
+  assert len(res) == 2
+
+  test_file = Path(mock_config.output_dir) / 'multi_file_ref__GENERATED_01_.html'
+  ref_file = Path(mock_config.output_dir) / 'multi_file_ref__GENERATED_01_-ref.html'
+
+  assert test_file.exists()
+  assert ref_file.exists()
+
+  assert '<link rel="match"' in test_file.read_text()
+  assert '<p>Reference</p>' in ref_file.read_text()
 
 
 @pytest.mark.asyncio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -239,3 +239,31 @@ def test_retry_errors() -> None:
 
   with pytest.raises(ValueError, match='max_attempts must be an integer >= 1'):
     invalid_attempts()
+
+
+def test_parse_suggestions_empty() -> None:
+  from wptgen.utils import parse_suggestions
+
+  assert parse_suggestions('no suggestions') == []
+
+
+def test_parse_multi_file_response() -> None:
+  from wptgen.utils import parse_multi_file_response
+
+  raw_text = """
+[FILE_1: test.html]
+test content
+[/FILE_1]
+Random text
+[FILE_2: ref.html]
+ref content
+[/FILE_2]
+"""
+  expected = [('test.html', 'test content'), ('ref.html', 'ref content')]
+  assert parse_multi_file_response(raw_text) == expected
+
+
+def test_parse_multi_file_response_empty() -> None:
+  from wptgen.utils import parse_multi_file_response
+
+  assert parse_multi_file_response('no files') == []

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+from collections import defaultdict
 from pathlib import Path
 
 from jinja2 import Environment
@@ -22,7 +23,7 @@ from wptgen.llm import LLMClient
 from wptgen.models import STYLE_GUIDE_MAP, TestType, WorkflowContext
 from wptgen.phases.utils import generate_safe
 from wptgen.ui import UIProvider
-from wptgen.utils import MARKDOWN_CODE_BLOCK_RE, extract_xml_tag
+from wptgen.utils import MARKDOWN_CODE_BLOCK_RE, extract_xml_tag, parse_multi_file_response
 
 
 async def run_test_evaluation(
@@ -35,7 +36,13 @@ async def run_test_evaluation(
 ) -> None:
   """Runs the evaluation phase for generated tests."""
   ui.rule('Phase 5: Evaluation')
-  ui.print(f'Evaluating [bold]{len(generated_tests)}[/bold] tests...')
+
+  # Group tests by their suggestion XML to handle multi-file tests (Reftests) together
+  grouped_tests: dict[str, list[tuple[Path, str]]] = defaultdict(list)
+  for path, content, suggestion_xml in generated_tests:
+    grouped_tests[suggestion_xml].append((path, content))
+
+  ui.print(f'Evaluating [bold]{len(grouped_tests)}[/bold] test suggestions...')
 
   # Load the general style guide
   resources_path = Path(__file__).parent.parent / 'templates' / 'resources'
@@ -46,7 +53,7 @@ async def run_test_evaluation(
   system_template = jinja_env.get_template('evaluation_system.jinja')
 
   tasks = []
-  for path, content, suggestion_xml in generated_tests:
+  for suggestion_xml, group in grouped_tests.items():
     # Extract and normalize test type
     raw_test_type = extract_xml_tag(suggestion_xml, 'test_type') or 'JavaScript Test'
     test_type_enum = TestType.JAVASCRIPT
@@ -59,37 +66,60 @@ async def run_test_evaluation(
     guide_filename = STYLE_GUIDE_MAP.get(test_type_enum, 'javascript_html_style_guide.md')
     test_type_guide = (resources_path / guide_filename).read_text(encoding='utf-8')
 
+    # Determine filenames for reftests to pass to the system instruction
+    safe_filename = None
+    ref_filename = None
+    if test_type_enum == TestType.REFTEST:
+      for p, _ in group:
+        if p.name.endswith('-ref.html'):
+          ref_filename = p.name
+        else:
+          safe_filename = p.name
+    elif len(group) == 1:
+      safe_filename = group[0][0].name
+
     # Render the system instruction with both general and type-specific rules
     system_instruction = system_template.render(
       wpt_style_guide=wpt_style_guide,
       test_type=test_type_enum.value,
       test_type_guide=test_type_guide,
+      safe_filename=safe_filename,
+      ref_filename=ref_filename,
     )
+
+    # Format the code content, using multi-file partitioning for Reftests
+    if len(group) > 1:
+      generated_code_content = ''
+      for i, (p, c) in enumerate(group, 1):
+        generated_code_content += f'[FILE_{i}: {p.name}]\n{c}\n[/FILE_{i}]\n\n'
+    else:
+      generated_code_content = group[0][1]
 
     prompt = evaluation_template.render(
       test_suggestion_xml=suggestion_xml,
-      generated_code_content=content,
+      generated_code_content=generated_code_content.strip(),
     )
-    tasks.append(_evaluate_and_update(path, prompt, llm, ui, config, system_instruction))
+    tasks.append(_evaluate_and_update(group, prompt, llm, ui, config, system_instruction))
 
   await asyncio.gather(*tasks)
   ui.print('\n[bold green]✔ Evaluation phase complete.[/bold green]')
 
 
 async def _evaluate_and_update(
-  path: Path,
+  files: list[tuple[Path, str]],
   prompt: str,
   llm: LLMClient,
   ui: UIProvider,
   config: Config,
   system_instruction: str,
 ) -> None:
-  """Evaluates a single test and updates the file if needed."""
-  ui.print(f'Evaluating: [bold]{path.name}[/bold]...')
+  """Evaluates a single test (or multi-file test) and updates the file(s) if needed."""
+  display_names = ', '.join([p.name for p, _ in files])
+  ui.print(f'Evaluating: [bold]{display_names}[/bold]...')
 
   response = await generate_safe(
     prompt,
-    f'Eval: {path.name}',
+    f'Eval: {display_names}',
     llm,
     ui,
     config,
@@ -99,16 +129,34 @@ async def _evaluate_and_update(
   )
 
   if not response:
-    ui.print(f'[yellow]⚠ No response for evaluation of {path.name}. Keeping original.[/yellow]')
+    ui.print(f'[yellow]⚠ No response for evaluation of {display_names}. Keeping original.[/yellow]')
     return
 
   clean_response = response.strip()
 
   if clean_response == 'PASS':
-    ui.print(f'[green]✔ {path.name} passed evaluation.[/green]')
+    ui.print(f'[green]✔ {display_names} passed evaluation.[/green]')
   else:
     # If it's not PASS, it should be the corrected file content
-    # Strip Markdown code blocks if the LLM added them
-    clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', clean_response).strip()
-    path.write_text(clean_content, encoding='utf-8')
-    ui.print(f'[cyan]ℹ {path.name} was corrected and updated.[/cyan]')
+    # Check if we have multiple files in the response
+    multi_files = parse_multi_file_response(clean_response)
+    if multi_files:
+      for fname, fcontent in multi_files:
+        # Find the matching path from our input files
+        for path, _ in files:
+          if path.name == fname:
+            clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
+            path.write_text(clean_content, encoding='utf-8')
+            ui.print(f'[cyan]ℹ {path.name} was corrected and updated.[/cyan]')
+            break
+    else:
+      # If it's a single file correction
+      if len(files) == 1:
+        path = files[0][0]
+        clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', clean_response).strip()
+        path.write_text(clean_content, encoding='utf-8')
+        ui.print(f'[cyan]ℹ {path.name} was corrected and updated.[/cyan]')
+      else:
+        ui.print(
+          f'[yellow]⚠ Received single-file correction for multi-file test {display_names}. Skipping.[/yellow]'
+        )

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -27,6 +27,7 @@ from wptgen.utils import (
   FILENAME_SANITIZATION_RE,
   MARKDOWN_CODE_BLOCK_RE,
   extract_xml_tag,
+  parse_multi_file_response,
   parse_suggestions,
 )
 
@@ -99,6 +100,14 @@ async def run_test_generation(
         test_type_enum = member
         break
 
+    # Generate filenames
+    raw_title = extract_xml_tag(suggestion_xml, 'title') or 'file'
+    slug = FILENAME_SANITIZATION_RE.sub('_', raw_title.lower())
+    safe_filename = f'{slug}__GENERATED_{idx + 1:02d}_.html'
+    ref_filename = (
+      f'{slug}__GENERATED_{idx + 1:02d}_-ref.html' if test_type_enum == TestType.REFTEST else None
+    )
+
     # Load the specific style guide for this test type
     guide_filename = STYLE_GUIDE_MAP.get(test_type_enum, 'javascript_html_style_guide.md')
     test_type_guide = (resources_path / guide_filename).read_text(encoding='utf-8')
@@ -108,6 +117,8 @@ async def run_test_generation(
       wpt_style_guide=wpt_style_guide,
       test_type=test_type_enum.value,
       test_type_guide=test_type_guide,
+      safe_filename=safe_filename,
+      ref_filename=ref_filename,
     )
 
     final_prompt = gen_template.render(
@@ -116,12 +127,9 @@ async def run_test_generation(
       test_suggestion_xml_block=suggestion_xml,
     )
 
-    raw_title = extract_xml_tag(suggestion_xml, 'title') or 'file'
-    # Include index to prevent filename collisions
-    slug = FILENAME_SANITIZATION_RE.sub('_', raw_title.lower())
-    safe_filename = f'{slug}__GENERATED_{idx + 1:02d}_.html'
-
-    prompts_to_confirm.append((final_prompt, safe_filename, suggestion_xml, system_instruction))
+    # For confirmation, show both filenames if it's a reftest
+    display_filename = f'{safe_filename} (+ reference)' if ref_filename else safe_filename
+    prompts_to_confirm.append((final_prompt, display_filename, suggestion_xml, system_instruction))
 
   # Single confirmation for ALL tests
   await confirm_prompts(
@@ -143,8 +151,8 @@ async def run_test_generation(
   ]
   results = await asyncio.gather(*tasks)
 
-  # Filter out None values and show a final summary for this phase
-  final_results = [r for r in results if r is not None]
+  # Flatten the list of lists (each task returns a list of files)
+  final_results = [r for sublist in results for r in sublist]
 
   if final_results:
     summary_table = Table(
@@ -174,9 +182,10 @@ async def _generate_and_save(
   config: Config,
   system_instruction: str | None = None,
   temperature: float | None = None,
-) -> tuple[Path, str, str] | None:
-  """Helper to generate a specific test and save it to disk."""
+) -> list[tuple[Path, str, str]]:
+  """Helper to generate specific test file(s) and save to disk."""
   ui.print(f'Starting generation for: [bold]{filename}[/bold]...')
+
   content = await generate_safe(
     prompt,
     f'Gen: {filename}',
@@ -188,12 +197,28 @@ async def _generate_and_save(
     model=config.get_model_for_phase('generation'),
   )
 
-  if content:
-    # Strip Markdown code blocks if the LLM added them (common behavior)
+  if not content:
+    return []
+
+  results = []
+  output_dir = Path(config.output_dir or '.')
+  output_dir.mkdir(parents=True, exist_ok=True)
+
+  # Check if we have multiple files (Reftests)
+  multi_files = parse_multi_file_response(content)
+  if multi_files:
+    for fname, fcontent in multi_files:
+      clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
+      output_path = output_dir / fname
+      output_path.write_text(clean_content, encoding='utf-8')
+      ui.print(f'[green]✔ Saved:[/green] {output_path.absolute()}')
+      results.append((output_path, clean_content, suggestion_xml))
+  else:
+    # Single file fallback
     clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', content).strip()
-    output_path = Path(config.output_dir or '.') / filename
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / filename
     output_path.write_text(clean_content, encoding='utf-8')
     ui.print(f'[green]✔ Saved:[/green] {output_path.absolute()}')
-    return output_path, clean_content, suggestion_xml
-  return None
+    results.append((output_path, clean_content, suggestion_xml))
+
+  return results

--- a/wptgen/templates/evaluation_system.jinja
+++ b/wptgen/templates/evaluation_system.jinja
@@ -10,6 +10,20 @@ You will be given a source blueprint, a style guide, rules, evaluation criteria,
 # {{ test_type }} STYLE GUIDE & RULES
 {{ test_type_guide }}
 
+{% if test_type == "Reftest" %}
+# MULTI-FILE PARTITIONING
+If you need to provide corrections, you MUST provide both the test file and the reference file.
+You MUST partition them using the following tags exactly:
+
+[FILE_1: {{ safe_filename }}]
+(Test file HTML/CSS here)
+[/FILE_1]
+
+[FILE_2: {{ ref_filename }}]
+(Reference file HTML/CSS here)
+[/FILE_2]
+{% endif -%}
+
 # EVALUATION CRITERIA
 You must evaluate the provided `<generated_code>` against the WPT Style Guide above, and specifically check the following:
 
@@ -18,11 +32,8 @@ You must evaluate the provided `<generated_code>` against the WPT Style Guide ab
   * Does the code hallucinate APIs, properties, or methods that are not explicitly mandated by the blueprint?
   * Is the `<title>` from the blueprint correctly used as the test name?
 2. WPT Standards Compliance:
-  * Does it properly include `/resources/testharness.js` and `/resources/testharnessreport.js`?
-  * Does it use the correct asynchronous testing patterns (e.g., `promise_test` instead of `async_test` for modern APIs)?
-  * Are proper `testharness` assertions used (e.g., `assert_equals`, `assert_throws_js`)?
-3. State Management:
-  * Are all DOM modifications, appended elements, and global state changes properly cleaned up using `t.add_cleanup()`?
+  * Does it properly follow the principles laid out in the WPT GENERAL STYLE GUIDE?
+  * Does it properly follow the principles laid out in the {{ test_type }} STYLE_GUIDE & RULES?
 
 # OUTPUT PROTOCOL
 You are a machine in an automated pipeline. You have two possible outputs:
@@ -32,8 +43,8 @@ If the code passes all criteria flawlessly and perfectly aligns with the bluepri
 PASS
 
 SCENARIO B: THE CODE HAS FLAWS
-If the code fails any criteria, or if you can optimize it to better fit WPT standards, you must fix it. Output ONLY the raw, fully corrected HTML/JS file contents.
+If the code fails any criteria, or if you can optimize it to better fit the style guides, you must fix it. Output ONLY the raw, fully corrected file contents.
 * DO NOT explain your changes.
 * DO NOT output conversational filler or pleasantries.
 * DO NOT wrap the output in markdown code blocks (e.g., ```html). Output the raw file content only.
-* STRICT COMMENT PRESERVATION: You MUST preserve all original HTML and JavaScript comments from the input exactly as they appeared. Do not delete, move, or rewrite them.
+* STRICT COMMENT PRESERVATION: You MUST preserve all original code comments from the input exactly as they appeared. Do not delete, move, or rewrite them.

--- a/wptgen/templates/test_generation_system.jinja
+++ b/wptgen/templates/test_generation_system.jinja
@@ -19,5 +19,19 @@ You will receive a `<test_suggestion>` XML blueprint. You must map its fields to
 # {{ test_type }} STYLE GUIDE & RULES
 {{ test_type_guide }}
 
+{% if test_type == "Reftest" %}
+# MULTI-FILE PARTITIONING (REFTEST ONLY)
+You must generate exactly two files: the test file and the reference file.
+You MUST partition them using the following tags exactly:
+
+[FILE_1: {{ safe_filename }}]
+(Test file HTML/CSS here)
+[/FILE_1]
+
+[FILE_2: {{ ref_filename }}]
+(Reference file HTML/CSS here)
+[/FILE_2]
+{% endif -%}
+
 # EXECUTION
 Synthesize the minimal, most robust test file required to assert the expected result based on the blueprint. Ensure all side-effects are cleaned up. Output the code and terminate.

--- a/wptgen/utils.py
+++ b/wptgen/utils.py
@@ -26,6 +26,7 @@ P = ParamSpec('P')
 SUGGESTION_BLOCK_RE = re.compile(r'<test_suggestion>.*?</test_suggestion>', re.DOTALL)
 FILENAME_SANITIZATION_RE = re.compile(r'[^a-z0-9_\-]')
 MARKDOWN_CODE_BLOCK_RE = re.compile(r'^```html\s*|^```\s*|\s*```$', re.MULTILINE)
+MULTI_FILE_RE = re.compile(r'\[FILE_(\d+):\s*(.*?)\](.*?)\[/FILE_\1\]', re.DOTALL)
 
 # Maximum delay between retries in seconds
 MAX_DELAY = 60.0
@@ -43,6 +44,22 @@ def extract_xml_tag(text: str, tag: str) -> str | None:
 def parse_suggestions(raw_text: str) -> list[str]:
   """Extracts all test suggestion blocks from a raw LLM response."""
   return SUGGESTION_BLOCK_RE.findall(raw_text)
+
+
+def parse_multi_file_response(raw_text: str) -> list[tuple[str, str]]:
+  """Extracts multiple files from a partitioned LLM response.
+
+  Expected format:
+  [FILE_1: filename.html]
+  content
+  [/FILE_1]
+  """
+  files = []
+  for match in MULTI_FILE_RE.finditer(raw_text):
+    filename = match.group(2).strip()
+    content = match.group(3).strip()
+    files.append((filename, content))
+  return files
 
 
 def retry(


### PR DESCRIPTION
Fixes #53

This change updates the test generation and evaluation prompts to handle reftests. Since reftests require 2 separate files, the logic adds some conditional information to the LLM if it needs to generate a reftest. Additionally, the evaluation phase adds additional instruction to the LLM if its evaluating a reftest.

- Update generation phase to support multi-file output for reftests using partitioned tags.
- Refactor evaluation phase to group test files by suggestion blueprint.
- Update evaluation system prompt with conditional instructions for reftests.
- Implement multi-file correction handling in the evaluation phase to sync updates back to disk for both test and reference files.
- Add unit tests for grouped reftest evaluation and correction.