### PR TITLE
Implement new test file naming convention with collision detection

### DIFF
--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -436,7 +436,7 @@ async def test_run_test_generation_success(
   ):
     res = await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
 
-  expected_file = tmp_path / 't1__GENERATED_01_.html'
+  expected_file = tmp_path / 'feat-001.html'
   assert expected_file.exists()
 
   # The suggestion_xml in the result should have the spec_url injected
@@ -770,13 +770,13 @@ async def test_run_test_generation_dynamic_style_guides(
   # Call 2: Reftest
   assert calls[1].kwargs['test_type'] == 'Reftest'
   assert calls[1].kwargs['test_type_guide'] == 'Content of reftest_style_guide.md'
-  assert calls[1].kwargs['safe_filename'] == 'ref_test__GENERATED_02_.html'
-  assert calls[1].kwargs['ref_filename'] == 'ref_test__GENERATED_02_-ref.html'
+  assert calls[1].kwargs['safe_filename'] == 'feat-002.html'
+  assert calls[1].kwargs['ref_filename'] == 'feat-002-ref.html'
 
   # Call 3: Crashtest
   assert calls[2].kwargs['test_type'] == 'Crashtest'
   assert calls[2].kwargs['test_type_guide'] == 'Content of crashtest_style_guide.md'
-  assert calls[2].kwargs['safe_filename'] == 'crash_test__GENERATED_03_.html'
+  assert calls[2].kwargs['safe_filename'] == 'feat-003.html'
   assert calls[2].kwargs['ref_filename'] is None
 
   # Also verify wpt_style_guide was passed to all
@@ -856,11 +856,11 @@ async def test_run_test_generation_reftest_multi_file(
 
   # Partitioned response from LLM
   llm_response = """
-[FILE_1: multi_file_ref__GENERATED_01_.html]
-<link rel="match" href="multi_file_ref__GENERATED_01_-ref.html">
+[FILE_1: feat-001.html]
+<link rel="match" href="feat-001-ref.html">
 [/FILE_1]
 
-[FILE_2: multi_file_ref__GENERATED_01_-ref.html]
+[FILE_2: feat-001-ref.html]
 <p>Reference</p>
 [/FILE_2]
 """
@@ -873,8 +873,8 @@ async def test_run_test_generation_reftest_multi_file(
 
   assert len(res) == 2
 
-  test_file = Path(mock_config.output_dir) / 'multi_file_ref__GENERATED_01_.html'
-  ref_file = Path(mock_config.output_dir) / 'multi_file_ref__GENERATED_01_-ref.html'
+  test_file = Path(mock_config.output_dir) / 'feat-001.html'
+  ref_file = Path(mock_config.output_dir) / 'feat-001-ref.html'
 
   assert test_file.exists()
   assert ref_file.exists()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -267,3 +269,83 @@ def test_parse_multi_file_response_empty() -> None:
   from wptgen.utils import parse_multi_file_response
 
   assert parse_multi_file_response('no files') == []
+
+
+def test_get_next_available_filenames_basic(tmp_path: Path) -> None:
+  from wptgen.utils import get_next_available_filenames
+
+  used_names: set[str] = set()
+  test_file, ref_file = get_next_available_filenames('feat', tmp_path, False, used_names)
+
+  assert test_file == 'feat-001.html'
+  assert ref_file is None
+  assert 'feat-001.html' in used_names
+
+
+def test_get_next_available_filenames_increment(tmp_path: Path) -> None:
+  from wptgen.utils import get_next_available_filenames
+
+  # Existing file feat-001.html
+  (tmp_path / 'feat-001.html').touch()
+
+  used_names: set[str] = set()
+  test_file, _ = get_next_available_filenames('feat', tmp_path, False, used_names)
+  assert test_file == 'feat-002.html'
+
+  # Add feat-002.html to used_names manually to simulate another test in same run
+  test_file_3, _ = get_next_available_filenames('feat', tmp_path, False, used_names)
+  assert test_file_3 == 'feat-003.html'
+
+
+def test_get_next_available_filenames_reftest(tmp_path: Path) -> None:
+  from wptgen.utils import get_next_available_filenames
+
+  used_names: set[str] = set()
+  test_file, ref_file = get_next_available_filenames('feat', tmp_path, True, used_names)
+
+  assert test_file == 'feat-001.html'
+  assert ref_file == 'feat-001-ref.html'
+  assert 'feat-001.html' in used_names
+  assert 'feat-001-ref.html' in used_names
+
+
+def test_get_next_available_filenames_collision_with_ref(tmp_path: Path) -> None:
+  from wptgen.utils import get_next_available_filenames
+
+  # Existing ref file feat-001-ref.html
+  (tmp_path / 'feat-001-ref.html').touch()
+
+  used_names: set[str] = set()
+  # Even if it's NOT a reftest, it should skip 001 because 001-ref exists
+  test_file, _ = get_next_available_filenames('feat', tmp_path, False, used_names)
+  assert test_file == 'feat-002.html'
+
+
+def test_get_next_available_filenames_max_length(tmp_path: Path) -> None:
+  from wptgen.utils import get_next_available_filenames
+
+  long_feat = 'a' * 200
+  used_names: set[str] = set()
+  # Max length 150. Suffix is -001.html (9 chars) or -001-ref.html (13 chars).
+  # We should truncate to fit the longest suffix (13 chars) -> 137 chars.
+  test_file, ref_file = get_next_available_filenames(long_feat, tmp_path, True, used_names)
+
+  assert test_file is not None
+  assert ref_file is not None
+  assert len(test_file) <= 150
+  assert len(ref_file) <= 150
+  assert test_file.startswith('a' * 137)
+  assert test_file.endswith('-001.html')
+  assert ref_file.endswith('-001-ref.html')
+
+
+def test_get_next_available_filenames_large_number(tmp_path: Path) -> None:
+  from wptgen.utils import get_next_available_filenames
+
+  used_names: set[str] = set()
+  # Manually simulate 999 tests existing
+  for n in range(1, 1000):
+    used_names.add(f'feat-{n:03d}.html')
+
+  test_file, _ = get_next_available_filenames('feat', tmp_path, False, used_names)
+  assert test_file == 'feat-1000.html'

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -24,9 +24,9 @@ from wptgen.models import STYLE_GUIDE_MAP, TestType, WorkflowContext
 from wptgen.phases.utils import confirm_prompts, generate_safe
 from wptgen.ui import UIProvider
 from wptgen.utils import (
-  FILENAME_SANITIZATION_RE,
   MARKDOWN_CODE_BLOCK_RE,
   extract_xml_tag,
+  get_next_available_filenames,
   parse_multi_file_response,
   parse_suggestions,
 )
@@ -92,7 +92,11 @@ async def run_test_generation(
   spec_url = context.metadata.specs[0] if context.metadata and context.metadata.specs else None
   prompts_to_confirm: list[tuple[str, str, str, str]] = []
 
-  for idx, suggestion_xml in enumerate(approved_suggestions_xml):
+  # Keep track of filenames used in this run to avoid collisions
+  used_names: set[str] = set()
+  output_dir = Path(config.output_dir or '.')
+
+  for suggestion_xml in approved_suggestions_xml:
     # Inject specification URL if available
     if spec_url:
       suggestion_xml = suggestion_xml.replace(
@@ -107,12 +111,9 @@ async def run_test_generation(
         test_type_enum = member
         break
 
-    # Generate filenames
-    raw_title = extract_xml_tag(suggestion_xml, 'title') or 'file'
-    slug = FILENAME_SANITIZATION_RE.sub('_', raw_title.lower())
-    safe_filename = f'{slug}__GENERATED_{idx + 1:02d}_.html'
-    ref_filename = (
-      f'{slug}__GENERATED_{idx + 1:02d}_-ref.html' if test_type_enum == TestType.REFTEST else None
+    # Generate filenames using the new convention: {feature_id}-{num}.html
+    safe_filename, ref_filename = get_next_available_filenames(
+      context.feature_id, output_dir, test_type_enum == TestType.REFTEST, used_names
     )
 
     # Load the specific style guide for this test type

--- a/wptgen/utils.py
+++ b/wptgen/utils.py
@@ -17,6 +17,7 @@ import re
 import time
 from collections.abc import Callable
 from functools import wraps
+from pathlib import Path
 from typing import ParamSpec, TypeVar
 
 T = TypeVar('T')
@@ -60,6 +61,58 @@ def parse_multi_file_response(raw_text: str) -> list[tuple[str, str]]:
     content = match.group(3).strip()
     files.append((filename, content))
   return files
+
+
+def get_next_available_filenames(
+  feature_id: str,
+  output_dir: Path,
+  is_reftest: bool,
+  used_names: set[str],
+  max_len: int = 150,
+) -> tuple[str, str | None]:
+  """Finds the next available filename(s) using the {feature_id}-{num} convention.
+
+  Args:
+    feature_id: The ID of the web feature.
+    output_dir: The directory where tests are saved.
+    is_reftest: Whether the test is a reftest.
+    used_names: A set of filenames already planned to be used in this run.
+    max_len: The maximum allowed length for the filename.
+
+  Returns:
+    A tuple of (test_filename, ref_filename). ref_filename is None if not a reftest.
+  """
+  safe_feature_id = FILENAME_SANITIZATION_RE.sub('_', feature_id.lower())
+
+  n = 1
+  while True:
+    num_str = f'{n:03d}' if n < 1000 else str(n)
+    test_suffix = f'-{num_str}.html'
+    ref_suffix = f'-{num_str}-ref.html'
+
+    # We check both test and ref suffixes for length to be safe.
+    max_suffix_len = max(len(test_suffix), len(ref_suffix))
+    allowed_feature_id_len = max_len - max_suffix_len
+
+    truncated_feature_id = safe_feature_id[:allowed_feature_id_len]
+    test_filename = f'{truncated_feature_id}{test_suffix}'
+    ref_filename_to_check = f'{truncated_feature_id}{ref_suffix}'
+
+    # Collision check: neither the test file nor the potential reference file should exist.
+    test_exists = (output_dir / test_filename).exists() or test_filename in used_names
+    ref_exists = (
+      output_dir / ref_filename_to_check
+    ).exists() or ref_filename_to_check in used_names
+
+    if not test_exists and not ref_exists:
+      # Found an available number.
+      used_names.add(test_filename)
+      if is_reftest:
+        used_names.add(ref_filename_to_check)
+        return test_filename, ref_filename_to_check
+      return test_filename, None
+
+    n += 1
 
 
 def retry(


### PR DESCRIPTION
Update the test file naming logic to follow the `{web_feature_id}-{3_digit_number}` pattern, improving consistency and preventing accidental file overwrites.

Some additional logic still needs to be added to determine the correct file extension and [possible addition of name flags](https://web-platform-tests.org/writing-tests/general-guidelines.html#file-paths-and-names).

Key changes:
- Implement `get_next_available_filenames` in `wptgen/utils.py` to handle the new naming algorithm, including:
    - Collision detection against existing files in the output directory.
    - Intra-run collision avoidance using a shared `used_names` set.
    - 3-digit zero-padding for test numbers (e.g., `001`, `002`), expanding for 1000+ tests.
    - Automatic truncation of long feature IDs to respect a 150-character filename limit.
- Integrate the naming utility into `run_test_generation` in `wptgen/phases/generation.py`.
- Add comprehensive unit tests in `tests/test_utils.py` covering basic naming, incrementing, reftest pairing, collision handling, and maximum length constraints.
- Update existing generation tests in `tests/test_phases.py` to align with the new naming convention.