### PR TITLE
Upgrade to Gemini 3.1 Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ show_responses: false              # Set to true to see raw LLM outputs by defau
 
 providers:
   gemini:
-    default_model: gemini-3-pro-preview
+    default_model: gemini-3.1-pro-preview
     categories:
       lightweight: gemini-3-flash-preview
-      reasoning: gemini-3-pro-preview
+      reasoning: gemini-3.1-pro-preview
   openai:
     default_model: gpt-5.2-high
     categories:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,11 +29,11 @@ def test_load_config_default_gemini_happy_path(monkeypatch: pytest.MonkeyPatch) 
 
   assert isinstance(config, Config)
   assert config.provider == 'gemini'
-  assert config.default_model == 'gemini-3-pro-preview'
+  assert config.default_model == 'gemini-3.1-pro-preview'
   assert config.api_key == 'mock-gemini-key-123'
   assert config.categories == {
     'lightweight': 'gemini-3-flash-preview',
-    'reasoning': 'gemini-3-pro-preview',
+    'reasoning': 'gemini-3.1-pro-preview',
   }
   assert config.phase_model_mapping == {
     'requirements_extraction': 'reasoning',

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -26,12 +26,12 @@ def gemini_config() -> Config:
   """Provides a valid Gemini configuration."""
   return Config(
     provider='gemini',
-    default_model='gemini-3-pro-preview',
+    default_model='gemini-3.1-pro-preview',
     api_key='mock-gemini-key',
     wpt_path=os.path.join('..', 'wpt'),
     categories={
       'lightweight': 'gemini-3-flash-preview',
-      'reasoning': 'gemini-3-pro-preview',
+      'reasoning': 'gemini-3.1-pro-preview',
     },
     phase_model_mapping={
       'requirements_extraction': 'reasoning',
@@ -70,7 +70,7 @@ def test_get_llm_client_gemini(mocker: MockerFixture, gemini_config: Config) -> 
 
   client = get_llm_client(gemini_config)
   assert isinstance(client, GeminiClient)
-  assert client.model == 'gemini-3-pro-preview'
+  assert client.model == 'gemini-3.1-pro-preview'
 
 
 def test_get_llm_client_openai(mocker: MockerFixture, openai_config: Config) -> None:
@@ -119,7 +119,7 @@ def test_gemini_generate_content(mocker: MockerFixture, gemini_config: Config) -
 
   # Verify the internal SDK method was called with the correct model and prompt
   call_kwargs = mock_instance.models.generate_content.call_args.kwargs
-  assert call_kwargs['model'] == 'gemini-3-pro-preview'
+  assert call_kwargs['model'] == 'gemini-3.1-pro-preview'
   assert call_kwargs['contents'] == 'Test prompt'
   assert call_kwargs['config'].system_instruction == 'Test instruction'
   assert call_kwargs['config'].temperature == 0.7
@@ -186,7 +186,7 @@ def test_gemini_count_tokens(mocker: MockerFixture, gemini_config: Config) -> No
 
   assert token_count == 42
   mock_instance.models.count_tokens.assert_called_once_with(
-    model='gemini-3-pro-preview', contents='Hello world'
+    model='gemini-3.1-pro-preview', contents='Hello world'
   )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,11 +31,11 @@ def mock_config() -> Config:
   """Provides a dummy configuration object for successful test runs."""
   return Config(
     provider='gemini',
-    default_model='gemini-3-pro-preview',
+    default_model='gemini-3.1-pro-preview',
     api_key='fake-key',
     wpt_path=os.path.join('..', 'wpt'),
     categories={
-      'lightweight': 'gemini-3-flash-preview',
+      'lightweight': 'gemini-3.1-pro-preview',
       'reasoning': 'gemini-3-pro-preview',
     },
     phase_model_mapping={

--- a/wpt-gen.yml
+++ b/wpt-gen.yml
@@ -3,10 +3,10 @@ default_provider: gemini
 wpt_path: ../wpt
 providers:
   gemini:
-    default_model: gemini-3-pro-preview
+    default_model: gemini-3.1-pro-preview
     categories:
       lightweight: gemini-3-flash-preview
-      reasoning: gemini-3-pro-preview
+      reasoning: gemini-3.1-pro-preview
   openai:
     default_model: gpt-5.2-high
     categories:

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -125,11 +125,11 @@ def load_config(
 
   # Provide sensible defaults if the YAML is missing the specific provider block
   if active_provider == 'gemini':
-    default_model_name = 'gemini-3-pro-preview'
+    default_model_name = 'gemini-3.1-pro-preview'
     env_var_name = 'GEMINI_API_KEY'
     default_categories = {
       'lightweight': 'gemini-3-flash-preview',
-      'reasoning': 'gemini-3-pro-preview',
+      'reasoning': 'gemini-3.1-pro-preview',
     }
   elif active_provider == 'openai':
     default_model_name = 'gpt-5.2-high'


### PR DESCRIPTION
Gemini 3.0 will be discontinued from the Gemini API on March 9th.