### PR TITLE
Support LLM-specified file extensions and flags via mandatory partitioning

### DIFF
--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -168,13 +168,13 @@ async def test_run_test_evaluation_reftest_correction(
     (ref_path, 'original ref content', suggestion_xml),
   ]
 
-  # Mock LLM returning corrected content for BOTH files
+  # Mock LLM returning corrected content for BOTH files using suffixes
   mock_llm.generate_content.return_value = """
-[FILE_1: test.html]
+[FILE_1: .html]
 corrected test content
 [/FILE_1]
 
-[FILE_2: test-ref.html]
+[FILE_2: .html]
 corrected ref content
 [/FILE_2]
 """
@@ -186,3 +186,71 @@ corrected ref content
   assert ref_path.read_text() == 'corrected ref content'
   mock_ui.print.assert_any_call('[cyan]ℹ test.html was corrected and updated.[/cyan]')
   mock_ui.print.assert_any_call('[cyan]ℹ test-ref.html was corrected and updated.[/cyan]')
+
+
+@pytest.mark.asyncio
+async def test_run_test_evaluation_partitioning_logic(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Verify evaluation prompt formatting for reftests vs non-reftests."""
+  jinja_env = MagicMock()
+  eval_template_mock = MagicMock()
+  system_template_mock = MagicMock()
+
+  def get_template(name: str) -> MagicMock:
+    if name == 'evaluation.jinja':
+      return eval_template_mock
+    if name == 'evaluation_system.jinja':
+      return system_template_mock
+    return MagicMock()
+
+  jinja_env.get_template.side_effect = get_template
+
+  # 1. Non-Reftest (Single File)
+  js_test_path = tmp_path / 'feat-001.html'
+  js_test_path.write_text('js content')
+
+  generated_tests = [
+    (
+      js_test_path,
+      'js content',
+      '<test_suggestion><test_type>JavaScript Test</test_type></test_suggestion>',
+    )
+  ]
+
+  context = WorkflowContext(feature_id='feat')
+
+  with patch('wptgen.phases.evaluation.Path.read_text', return_value='Guide'):
+    with patch('wptgen.phases.evaluation.generate_safe', return_value='PASS'):
+      await run_test_evaluation(context, mock_config, mock_llm, mock_ui, jinja_env, generated_tests)
+
+  # Check eval prompt for non-reftest: should be raw content (no tags)
+  call_args = eval_template_mock.render.call_args.kwargs
+  assert call_args['generated_code_content'] == 'js content'
+
+  eval_template_mock.render.reset_mock()
+
+  # 2. Reftest (Multi File)
+  ref_test_path = tmp_path / 'feat-002.html'
+  ref_test_path.write_text('test content')
+  ref_ref_path = tmp_path / 'feat-002-ref.html'
+  ref_ref_path.write_text('ref content')
+
+  suggestion_xml = '<test_suggestion><test_type>Reftest</test_type></test_suggestion>'
+  generated_reftests = [
+    (ref_test_path, 'test content', suggestion_xml),
+    (ref_ref_path, 'ref content', suggestion_xml),
+  ]
+
+  with patch('wptgen.phases.evaluation.Path.read_text', return_value='Guide'):
+    with patch('wptgen.phases.evaluation.generate_safe', return_value='PASS'):
+      await run_test_evaluation(
+        context, mock_config, mock_llm, mock_ui, jinja_env, generated_reftests
+      )
+
+  # Check eval prompt for reftest: should have tags with suffixes
+  call_args = eval_template_mock.render.call_args.kwargs
+  assert '[FILE_1: .html]' in call_args['generated_code_content']
+  assert 'test content' in call_args['generated_code_content']
+  assert '[FILE_2: .html]' in call_args['generated_code_content']
+  assert 'ref content' in call_args['generated_code_content']

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -770,14 +770,10 @@ async def test_run_test_generation_dynamic_style_guides(
   # Call 2: Reftest
   assert calls[1].kwargs['test_type'] == 'Reftest'
   assert calls[1].kwargs['test_type_guide'] == 'Content of reftest_style_guide.md'
-  assert calls[1].kwargs['safe_filename'] == 'feat-002.html'
-  assert calls[1].kwargs['ref_filename'] == 'feat-002-ref.html'
 
   # Call 3: Crashtest
   assert calls[2].kwargs['test_type'] == 'Crashtest'
   assert calls[2].kwargs['test_type_guide'] == 'Content of crashtest_style_guide.md'
-  assert calls[2].kwargs['safe_filename'] == 'feat-003.html'
-  assert calls[2].kwargs['ref_filename'] is None
 
   # Also verify wpt_style_guide was passed to all
   for call in calls:
@@ -854,13 +850,13 @@ async def test_run_test_generation_reftest_multi_file(
 
   jinja_env.get_template.side_effect = get_template_side_effect
 
-  # Partitioned response from LLM
+  # Partitioned response from LLM using suffixes
   llm_response = """
-[FILE_1: feat-001.html]
+[FILE_1: .html]
 <link rel="match" href="feat-001-ref.html">
 [/FILE_1]
 
-[FILE_2: feat-001-ref.html]
+[FILE_2: .html]
 <p>Reference</p>
 [/FILE_2]
 """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -265,87 +265,84 @@ ref content
   assert parse_multi_file_response(raw_text) == expected
 
 
+def test_parse_multi_file_response_complex_suffixes() -> None:
+  from wptgen.utils import parse_multi_file_response
+
+  raw_text = """
+[FILE_1: .https.any.js]
+js content
+[/FILE_1]
+[FILE_2: .sub.html]
+html content
+[/FILE_2]
+"""
+  expected = [('.https.any.js', 'js content'), ('.sub.html', 'html content')]
+  assert parse_multi_file_response(raw_text) == expected
+
+
 def test_parse_multi_file_response_empty() -> None:
   from wptgen.utils import parse_multi_file_response
 
   assert parse_multi_file_response('no files') == []
 
 
-def test_get_next_available_filenames_basic(tmp_path: Path) -> None:
-  from wptgen.utils import get_next_available_filenames
+def test_get_next_available_root_basic(tmp_path: Path) -> None:
+  from wptgen.utils import get_next_available_root
 
   used_names: set[str] = set()
-  test_file, ref_file = get_next_available_filenames('feat', tmp_path, False, used_names)
+  root = get_next_available_root('feat', tmp_path, used_names)
 
-  assert test_file == 'feat-001.html'
-  assert ref_file is None
-  assert 'feat-001.html' in used_names
+  assert root == 'feat-001'
+  assert 'feat-001' in used_names
 
 
-def test_get_next_available_filenames_increment(tmp_path: Path) -> None:
-  from wptgen.utils import get_next_available_filenames
+def test_get_next_available_root_increment(tmp_path: Path) -> None:
+  from wptgen.utils import get_next_available_root
 
   # Existing file feat-001.html
   (tmp_path / 'feat-001.html').touch()
 
   used_names: set[str] = set()
-  test_file, _ = get_next_available_filenames('feat', tmp_path, False, used_names)
-  assert test_file == 'feat-002.html'
+  root = get_next_available_root('feat', tmp_path, used_names)
+  assert root == 'feat-002'
 
-  # Add feat-002.html to used_names manually to simulate another test in same run
-  test_file_3, _ = get_next_available_filenames('feat', tmp_path, False, used_names)
-  assert test_file_3 == 'feat-003.html'
-
-
-def test_get_next_available_filenames_reftest(tmp_path: Path) -> None:
-  from wptgen.utils import get_next_available_filenames
-
-  used_names: set[str] = set()
-  test_file, ref_file = get_next_available_filenames('feat', tmp_path, True, used_names)
-
-  assert test_file == 'feat-001.html'
-  assert ref_file == 'feat-001-ref.html'
-  assert 'feat-001.html' in used_names
-  assert 'feat-001-ref.html' in used_names
+  # Add feat-002 manually to used_names
+  root_3 = get_next_available_root('feat', tmp_path, used_names)
+  assert root_3 == 'feat-003'
 
 
-def test_get_next_available_filenames_collision_with_ref(tmp_path: Path) -> None:
-  from wptgen.utils import get_next_available_filenames
+def test_get_next_available_root_collision_with_other_ext(tmp_path: Path) -> None:
+  from wptgen.utils import get_next_available_root
 
-  # Existing ref file feat-001-ref.html
-  (tmp_path / 'feat-001-ref.html').touch()
+  # Existing JS file feat-001.any.js
+  (tmp_path / 'feat-001.any.js').touch()
 
   used_names: set[str] = set()
-  # Even if it's NOT a reftest, it should skip 001 because 001-ref exists
-  test_file, _ = get_next_available_filenames('feat', tmp_path, False, used_names)
-  assert test_file == 'feat-002.html'
+  root = get_next_available_root('feat', tmp_path, used_names)
+  assert root == 'feat-002'
 
 
-def test_get_next_available_filenames_max_length(tmp_path: Path) -> None:
-  from wptgen.utils import get_next_available_filenames
+def test_get_next_available_root_max_length(tmp_path: Path) -> None:
+  from wptgen.utils import get_next_available_root
 
   long_feat = 'a' * 200
   used_names: set[str] = set()
-  # Max length 150. Suffix is -001.html (9 chars) or -001-ref.html (13 chars).
-  # We should truncate to fit the longest suffix (13 chars) -> 137 chars.
-  test_file, ref_file = get_next_available_filenames(long_feat, tmp_path, True, used_names)
+  # Max length 150. Suffix buffer is 35. -4 for -001.
+  # 150 - 35 - 4 = 111 chars for feature id.
+  root = get_next_available_root(long_feat, tmp_path, used_names)
 
-  assert test_file is not None
-  assert ref_file is not None
-  assert len(test_file) <= 150
-  assert len(ref_file) <= 150
-  assert test_file.startswith('a' * 137)
-  assert test_file.endswith('-001.html')
-  assert ref_file.endswith('-001-ref.html')
+  assert len(root) <= 150
+  assert root.startswith('a' * 111)
+  assert root.endswith('-001')
 
 
-def test_get_next_available_filenames_large_number(tmp_path: Path) -> None:
-  from wptgen.utils import get_next_available_filenames
+def test_get_next_available_root_large_number(tmp_path: Path) -> None:
+  from wptgen.utils import get_next_available_root
 
   used_names: set[str] = set()
   # Manually simulate 999 tests existing
   for n in range(1, 1000):
-    used_names.add(f'feat-{n:03d}.html')
+    used_names.add(f'feat-{n:03d}')
 
-  test_file, _ = get_next_available_filenames('feat', tmp_path, False, used_names)
-  assert test_file == 'feat-1000.html'
+  root = get_next_available_root('feat', tmp_path, used_names)
+  assert root == 'feat-1000'

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -66,33 +66,34 @@ async def run_test_evaluation(
     guide_filename = STYLE_GUIDE_MAP.get(test_type_enum, 'javascript_html_style_guide.md')
     test_type_guide = (resources_path / guide_filename).read_text(encoding='utf-8')
 
-    # Determine filenames for reftests to pass to the system instruction
-    safe_filename = None
-    ref_filename = None
-    if test_type_enum == TestType.REFTEST:
-      for p, _ in group:
-        if p.name.endswith('-ref.html'):
-          ref_filename = p.name
-        else:
-          safe_filename = p.name
-    elif len(group) == 1:
-      safe_filename = group[0][0].name
-
     # Render the system instruction with both general and type-specific rules
     system_instruction = system_template.render(
       wpt_style_guide=wpt_style_guide,
       test_type=test_type_enum.value,
       test_type_guide=test_type_guide,
-      safe_filename=safe_filename,
-      ref_filename=ref_filename,
     )
 
-    # Format the code content, using multi-file partitioning for Reftests
-    if len(group) > 1:
-      generated_code_content = ''
-      for i, (p, c) in enumerate(group, 1):
-        generated_code_content += f'[FILE_{i}: {p.name}]\n{c}\n[/FILE_{i}]\n\n'
+    # Format the code content, using multi-file partitioning for Reftests ONLY
+    if test_type_enum == TestType.REFTEST and len(group) > 1:
+      # Sort to ensure FILE_1 is test and FILE_2 is ref
+      test_item = next((item for item in group if '-ref.' not in item[0].name), None)
+      ref_item = next((item for item in group if '-ref.' in item[0].name), None)
+
+      if test_item and ref_item:
+        p_test, c_test = test_item
+        p_ref, c_ref = ref_item
+        # Suffix is everything from the first dot
+        suffix_test = '.' + p_test.name.split('.', 1)[1] if '.' in p_test.name else '.html'
+        suffix_ref = '.' + p_ref.name.split('.', 1)[1] if '.' in p_ref.name else '.html'
+
+        generated_code_content = (
+          f'[FILE_1: {suffix_test}]\n{c_test}\n[/FILE_1]\n\n'
+          f'[FILE_2: {suffix_ref}]\n{c_ref}\n[/FILE_2]'
+        )
+      else:
+        generated_code_content = '\n\n'.join([c for p, c in group])
     else:
+      # For non-reftests, pass raw content without tags
       generated_code_content = group[0][1]
 
     prompt = evaluation_template.render(
@@ -141,14 +142,24 @@ async def _evaluate_and_update(
     # Check if we have multiple files in the response
     multi_files = parse_multi_file_response(clean_response)
     if multi_files:
-      for fname, fcontent in multi_files:
-        # Find the matching path from our input files
-        for path, _ in files:
-          if path.name == fname:
-            clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
-            path.write_text(clean_content, encoding='utf-8')
-            ui.print(f'[cyan]ℹ {path.name} was corrected and updated.[/cyan]')
-            break
+      # For Reftests, we expect FILE_1 to be test and FILE_2 to be ref
+      # We need to find which path is which
+      test_path_item = next((item for item in files if '-ref.' not in item[0].name), None)
+      ref_path_item = next((item for item in files if '-ref.' in item[0].name), None)
+
+      if len(multi_files) >= 1 and test_path_item:
+        p, _ = test_path_item
+        _, fcontent = multi_files[0]
+        clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
+        p.write_text(clean_content, encoding='utf-8')
+        ui.print(f'[cyan]ℹ {p.name} was corrected and updated.[/cyan]')
+
+      if len(multi_files) >= 2 and ref_path_item:
+        p, _ = ref_path_item
+        _, fcontent = multi_files[1]
+        clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
+        p.write_text(clean_content, encoding='utf-8')
+        ui.print(f'[cyan]ℹ {p.name} was corrected and updated.[/cyan]')
     else:
       # If it's a single file correction
       if len(files) == 1:

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -26,7 +26,7 @@ from wptgen.ui import UIProvider
 from wptgen.utils import (
   MARKDOWN_CODE_BLOCK_RE,
   extract_xml_tag,
-  get_next_available_filenames,
+  get_next_available_root,
   parse_multi_file_response,
   parse_suggestions,
 )
@@ -111,10 +111,8 @@ async def run_test_generation(
         test_type_enum = member
         break
 
-    # Generate filenames using the new convention: {feature_id}-{num}.html
-    safe_filename, ref_filename = get_next_available_filenames(
-      context.feature_id, output_dir, test_type_enum == TestType.REFTEST, used_names
-    )
+    # Generate the root filename: {feature_id}-{num}
+    root_name = get_next_available_root(context.feature_id, output_dir, used_names)
 
     # Load the specific style guide for this test type
     guide_filename = STYLE_GUIDE_MAP.get(test_type_enum, 'javascript_html_style_guide.md')
@@ -125,8 +123,6 @@ async def run_test_generation(
       wpt_style_guide=wpt_style_guide,
       test_type=test_type_enum.value,
       test_type_guide=test_type_guide,
-      safe_filename=safe_filename,
-      ref_filename=ref_filename,
     )
 
     final_prompt = gen_template.render(
@@ -135,13 +131,11 @@ async def run_test_generation(
       test_suggestion_xml_block=suggestion_xml,
     )
 
-    # For confirmation, show both filenames if it's a reftest
-    display_filename = f'{safe_filename} (+ reference)' if ref_filename else safe_filename
-    prompts_to_confirm.append((final_prompt, display_filename, suggestion_xml, system_instruction))
+    prompts_to_confirm.append((final_prompt, root_name, suggestion_xml, system_instruction))
 
   # Single confirmation for ALL tests
   await confirm_prompts(
-    [(p, f) for p, f, s, si in prompts_to_confirm],
+    [(p, f'{r}.*') for p, r, s, si in prompts_to_confirm],
     f'Generate {len(prompts_to_confirm)} Tests',
     llm,
     ui,
@@ -153,9 +147,9 @@ async def run_test_generation(
 
   tasks = [
     _generate_and_save(
-      prompt, filename, suggestion_xml, llm, ui, config, system_instruction, temperature=0.1
+      prompt, root_name, suggestion_xml, llm, ui, config, system_instruction, temperature=0.1
     )
-    for prompt, filename, suggestion_xml, system_instruction in prompts_to_confirm
+    for prompt, root_name, suggestion_xml, system_instruction in prompts_to_confirm
   ]
   results = await asyncio.gather(*tasks)
 
@@ -183,7 +177,7 @@ async def run_test_generation(
 
 async def _generate_and_save(
   prompt: str,
-  filename: str,
+  root_name: str,
   suggestion_xml: str,
   llm: LLMClient,
   ui: UIProvider,
@@ -192,11 +186,11 @@ async def _generate_and_save(
   temperature: float | None = None,
 ) -> list[tuple[Path, str, str]]:
   """Helper to generate specific test file(s) and save to disk."""
-  ui.print(f'Starting generation for: [bold]{filename}[/bold]...')
+  ui.print(f'Starting generation for: [bold]{root_name}[/bold]...')
 
   content = await generate_safe(
     prompt,
-    f'Gen: {filename}',
+    f'Gen: {root_name}',
     llm,
     ui,
     config,
@@ -215,18 +209,26 @@ async def _generate_and_save(
   # Check if we have multiple files (Reftests)
   multi_files = parse_multi_file_response(content)
   if multi_files:
-    for fname, fcontent in multi_files:
+    for i, (suffix, fcontent) in enumerate(multi_files, 1):
+      # Handle reftest naming: FILE_2 gets -ref
+      if i == 2:
+        # Assuming FILE_2 is always the ref for reftests
+        fname = f'{root_name}-ref{suffix}'
+      else:
+        # For FILE_1 (test) and any other potential files, just use root + suffix
+        fname = f'{root_name}{suffix}'
+
       clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
       output_path = output_dir / fname
       output_path.write_text(clean_content, encoding='utf-8')
       ui.print(f'[green]✔ Saved:[/green] {output_path.absolute()}')
       results.append((output_path, clean_content, suggestion_xml))
   else:
-    # Single file fallback
+    # Single file fallback - if the LLM failed to use partitioning tags, default to .html
     clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', content).strip()
-    output_path = output_dir / filename
+    output_path = output_dir / f'{root_name}.html'
     output_path.write_text(clean_content, encoding='utf-8')
-    ui.print(f'[green]✔ Saved:[/green] {output_path.absolute()}')
+    ui.print(f'[green]✔ Saved (fallback):[/green] {output_path.absolute()}')
     results.append((output_path, clean_content, suggestion_xml))
 
   return results

--- a/wptgen/templates/evaluation_system.jinja
+++ b/wptgen/templates/evaluation_system.jinja
@@ -10,18 +10,23 @@ You will be given a source blueprint, a style guide, rules, evaluation criteria,
 # {{ test_type }} STYLE GUIDE & RULES
 {{ test_type_guide }}
 
-{% if test_type == "Reftest" %}
+{% if test_type == "Reftest" -%}
 # MULTI-FILE PARTITIONING
 If you need to provide corrections, you MUST provide both the test file and the reference file.
 You MUST partition them using the following tags exactly:
 
-[FILE_1: {{ safe_filename }}]
+[FILE_1: .flags_and_extension]
 (Test file HTML/CSS here)
 [/FILE_1]
 
-[FILE_2: {{ ref_filename }}]
+[FILE_2: .flags_and_extension]
 (Reference file HTML/CSS here)
 [/FILE_2]
+
+## Filename Suffix Guidelines (.flags_and_extension)
+Specify only the suffix of the filename, starting with a dot.
+1. **Extensions**: `.html`, `.window.js`, `.worker.js`, `.any.js`.
+2. **Flags**: `.https`, `.h2`, `.sub`.
 {% endif -%}
 
 # EVALUATION CRITERIA
@@ -43,7 +48,12 @@ If the code passes all criteria flawlessly and perfectly aligns with the bluepri
 PASS
 
 SCENARIO B: THE CODE HAS FLAWS
-If the code fails any criteria, or if you can optimize it to better fit the style guides, you must fix it. Output ONLY the raw, fully corrected file contents.
+If the code fails any criteria, or if you can optimize it to better fit the style guides, you must fix it.
+{%- if test_type == "Reftest" %}
+Output the corrected files using the MULTI-FILE PARTITIONING format above.
+{%- else %}
+Output ONLY the raw, fully corrected file contents.
+{%- endif %}
 * DO NOT explain your changes.
 * DO NOT output conversational filler or pleasantries.
 * DO NOT wrap the output in markdown code blocks (e.g., ```html). Output the raw file content only.

--- a/wptgen/templates/test_generation_system.jinja
+++ b/wptgen/templates/test_generation_system.jinja
@@ -19,19 +19,26 @@ You will receive a `<test_suggestion>` XML blueprint. You must map its fields to
 # {{ test_type }} STYLE GUIDE & RULES
 {{ test_type_guide }}
 
-{% if test_type == "Reftest" %}
-# MULTI-FILE PARTITIONING (REFTEST ONLY)
-You must generate exactly two files: the test file and the reference file.
-You MUST partition them using the following tags exactly:
+# OUTPUT FORMAT
+{% if test_type == "Reftest" -%}
+You MUST generate exactly two files: the test file and the reference file.
+Choose the appropriate suffix (flags + extension) for each file based on the style guides (e.g., `.https.html`, `.html`).
 
-[FILE_1: {{ safe_filename }}]
-(Test file HTML/CSS here)
+[FILE_1: .your_chosen_suffix_for_test]
+(Test file content here)
 [/FILE_1]
 
-[FILE_2: {{ ref_filename }}]
-(Reference file HTML/CSS here)
+[FILE_2: .your_chosen_suffix_for_reference]
+(Reference file content here)
 [/FILE_2]
-{% endif -%}
+{% else -%}
+You MUST provide the generated file within the following tags.
+Choose the appropriate suffix (flags + extension) based on the style guides (e.g., `.https.html`, `.any.js`, `.sub.html`).
+
+[FILE_1: .your_chosen_suffix]
+(File content here)
+[/FILE_1]
+{%- endif %}
 
 # EXECUTION
 Synthesize the minimal, most robust test file required to assert the expected result based on the blueprint. Ensure all side-effects are cleaned up. Output the code and terminate.

--- a/wptgen/utils.py
+++ b/wptgen/utils.py
@@ -63,54 +63,55 @@ def parse_multi_file_response(raw_text: str) -> list[tuple[str, str]]:
   return files
 
 
-def get_next_available_filenames(
+def get_next_available_root(
   feature_id: str,
   output_dir: Path,
-  is_reftest: bool,
   used_names: set[str],
   max_len: int = 150,
-) -> tuple[str, str | None]:
-  """Finds the next available filename(s) using the {feature_id}-{num} convention.
+) -> str:
+  """Finds the next available root filename using the {feature_id}-{num} convention.
 
   Args:
     feature_id: The ID of the web feature.
     output_dir: The directory where tests are saved.
-    is_reftest: Whether the test is a reftest.
-    used_names: A set of filenames already planned to be used in this run.
-    max_len: The maximum allowed length for the filename.
+    used_names: A set of root names already planned to be used in this run.
+    max_len: The maximum allowed length for the filename (including potential suffixes).
 
   Returns:
-    A tuple of (test_filename, ref_filename). ref_filename is None if not a reftest.
+    The available root filename (e.g., 'feature-001').
   """
   safe_feature_id = FILENAME_SANITIZATION_RE.sub('_', feature_id.lower())
+
+  # We reserve some space for suffixes like '.https.any.js' (~20 chars)
+  # and potentially '-ref' for reftests (4 chars).
+  suffix_buffer = 25
+  allowed_feature_id_len = max_len - suffix_buffer - 4  # -4 for '-001'
+
+  truncated_feature_id = safe_feature_id[:allowed_feature_id_len]
 
   n = 1
   while True:
     num_str = f'{n:03d}' if n < 1000 else str(n)
-    test_suffix = f'-{num_str}.html'
-    ref_suffix = f'-{num_str}-ref.html'
+    root_name = f'{truncated_feature_id}-{num_str}'
 
-    # We check both test and ref suffixes for length to be safe.
-    max_suffix_len = max(len(test_suffix), len(ref_suffix))
-    allowed_feature_id_len = max_len - max_suffix_len
+    # Collision check:
+    # 1. Check if we've already used this root in this run.
+    if root_name in used_names:
+      n += 1
+      continue
 
-    truncated_feature_id = safe_feature_id[:allowed_feature_id_len]
-    test_filename = f'{truncated_feature_id}{test_suffix}'
-    ref_filename_to_check = f'{truncated_feature_id}{ref_suffix}'
+    # 2. Check if any file in the output directory starts with this root name.
+    # This is conservative but ensures we don't collide regardless of extension/flags.
+    collision = False
+    if output_dir.exists():
+      for path in output_dir.iterdir():
+        if path.name.startswith(root_name):
+          collision = True
+          break
 
-    # Collision check: neither the test file nor the potential reference file should exist.
-    test_exists = (output_dir / test_filename).exists() or test_filename in used_names
-    ref_exists = (
-      output_dir / ref_filename_to_check
-    ).exists() or ref_filename_to_check in used_names
-
-    if not test_exists and not ref_exists:
-      # Found an available number.
-      used_names.add(test_filename)
-      if is_reftest:
-        used_names.add(ref_filename_to_check)
-        return test_filename, ref_filename_to_check
-      return test_filename, None
+    if not collision:
+      used_names.add(root_name)
+      return root_name
 
     n += 1
 


### PR DESCRIPTION
- Update `test_generation_system.jinja` to require multi-file partitioning (`[FILE_1: .suffix]`) for all test types.
- Provide clear guidelines in the system prompt for available WPT extensions and flags.
- Refactor `wptgen/utils.py` to generate stable root filenames (`feature-001`) and improve collision detection across all extensions.
- Update `wptgen/phases/generation.py` to reconstruct full filenames by combining the stable root with LLM-provided suffixes.
- Automatically handle reftest reference naming by inserting the `-ref` marker.
- Update `evaluation.jinja` and `evaluation_system.jinja` to align with the new suffix convention.
- Ensure multi-file partitioning tags are only used for reftests in the evaluation prompt.
- Update `wptgen/phases/evaluation.py` to correctly map LLM corrections back to files using partitioning indices for reftests and raw content for other test types.
- Update related unit tests to reflect the new naming and partitioning logic in both generation and evaluation phases.