### PR TITLE
Improve prompt consistency and UX visibility in the generation workflow

### DIFF
--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -781,6 +781,38 @@ async def test_run_test_generation_dynamic_style_guides(
 
 
 @pytest.mark.asyncio
+async def test_run_test_generation_displays_worksheet(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock
+) -> None:
+  """Verify that the audit worksheet is displayed before suggestions."""
+  suggestion_xml = (
+    '<test_suggestion><title>T1</title><description>D1</description></test_suggestion>'
+  )
+  audit_response = (
+    f'<audit_worksheet>R1: Covered\nR2: Uncovered</audit_worksheet>\n{suggestion_xml}'
+  )
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    audit_response=audit_response,
+  )
+  jinja_env = MagicMock()
+  jinja_env.get_template.return_value.render.return_value = 'Generated Content'
+
+  mock_ui.confirm.return_value = False  # Stop after displaying worksheet and suggestions
+
+  with (
+    patch('wptgen.phases.generation.confirm_prompts', return_value=None),
+    patch('wptgen.phases.generation.Path.read_text', return_value='Style Guide Content'),
+  ):
+    await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
+
+  # Check that the worksheet was displayed
+  mock_ui.print.assert_any_call('[bold cyan]Coverage Audit Worksheet:[/bold cyan]')
+  mock_ui.display_markdown.assert_any_call('R1: Covered\nR2: Uncovered')
+
+
+@pytest.mark.asyncio
 async def test_run_test_generation_normalization(
   mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock
 ) -> None:

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -55,6 +55,13 @@ async def run_test_generation(
     )
     return []
 
+  # Display the audit worksheet to the user for visibility into the rationale
+  audit_worksheet = extract_xml_tag(context.audit_response, 'audit_worksheet')
+  if audit_worksheet:
+    ui.print('[bold cyan]Coverage Audit Worksheet:[/bold cyan]')
+    ui.display_markdown(audit_worksheet.strip())
+    ui.print()
+
   suggestions = parse_suggestions(context.audit_response)
 
   if not suggestions:

--- a/wptgen/templates/coverage_audit_system.jinja
+++ b/wptgen/templates/coverage_audit_system.jinja
@@ -7,9 +7,9 @@ You are a Principal Software Engineer in Test (SDET) and a strict W3C Compliance
 3.  **Satisfaction:** You are perfectly happy to find no gaps. If the existing tests cover all requirements, you must explicitly declare the audit satisfied.
 
 # INPUTS
-1.  `<requirements_list>`: A structured list of normative test requirements extracted from the specification.
-2.  A `<test_suite>` containing two sections:
-    - `<test_files>`: A list of independent web-platform-test (WPT) files to analyze.
+1. `<requirements_list>`: A structured list of normative test requirements extracted from the specification.
+2. A `<test_suite>` containing two sections:
+    - `<test_batch>`: A list of independent web-platform-test (WPT) files to analyze, each wrapped in a `<test_file>` tag.
     - `<dependency_library>`: A collection of shared dependency files referenced by the tests.
 
 # THE AUDIT PROTOCOL

--- a/wptgen/templates/test_generation.jinja
+++ b/wptgen/templates/test_generation.jinja
@@ -1,3 +1,3 @@
-Generate a single WPT file based on the following blueprint:
+Generate a single WPT file for the feature "{{feature_name}}" ({{feature_description}}) based on the following blueprint:
 
 {{ test_suggestion_xml_block }}


### PR DESCRIPTION
This change is primarily a fix of some inconsistencies in some of the prompts.

- Align coverage audit system prompt tags with the actual XML structure passed in the user prompt.
- Include feature name and description in test generation prompts to provide better grounding context for code synthesis.
- Refactor partitioning and suffix instructions in the generation system prompt to be clearer and non-overlapping for Reftests vs. single-file tests.
- Display the audit worksheet in the standard generation workflow to provide visibility into the rationale behind test suggestions.
- Add a unit test to verify the display of the audit worksheet during the generation phase.