### PR TITLE
Add `--resume` flag to wpt-gen generate

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -90,6 +90,7 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     show_responses=False,
     yes_tokens_override=False,
     suggestions_only=False,
+    resume_override=False,
     max_retries_override=3,
     spec_urls_override=None,
     feature_description_override=None,
@@ -118,6 +119,7 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     show_responses=True,
     yes_tokens_override=False,
     suggestions_only=False,
+    resume_override=False,
     max_retries_override=3,
     spec_urls_override=None,
     feature_description_override=None,
@@ -142,6 +144,7 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     show_responses=False,
     yes_tokens_override=True,
     suggestions_only=False,
+    resume_override=False,
     max_retries_override=3,
     spec_urls_override=None,
     feature_description_override=None,
@@ -166,6 +169,7 @@ def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -
     show_responses=False,
     yes_tokens_override=False,
     suggestions_only=True,
+    resume_override=False,
     max_retries_override=3,
     spec_urls_override=None,
     feature_description_override=None,
@@ -190,6 +194,7 @@ def test_generate_max_retries(mocker: MockerFixture, mock_config: Config) -> Non
     show_responses=False,
     yes_tokens_override=False,
     suggestions_only=False,
+    resume_override=False,
     max_retries_override=5,
     spec_urls_override=None,
     feature_description_override=None,
@@ -214,6 +219,7 @@ def test_generate_detailed_requirements(mocker: MockerFixture, mock_config: Conf
     show_responses=False,
     yes_tokens_override=False,
     suggestions_only=False,
+    resume_override=False,
     max_retries_override=3,
     spec_urls_override=None,
     feature_description_override=None,
@@ -269,6 +275,7 @@ def test_generate_spec_urls(mocker: MockerFixture, mock_config: Config) -> None:
     show_responses=False,
     yes_tokens_override=False,
     suggestions_only=False,
+    resume_override=False,
     max_retries_override=3,
     spec_urls_override=['https://url1.com', 'https://url2.com'],
     feature_description_override=None,
@@ -293,9 +300,35 @@ def test_generate_description(mocker: MockerFixture, mock_config: Config) -> Non
     show_responses=False,
     yes_tokens_override=False,
     suggestions_only=False,
+    resume_override=False,
     max_retries_override=3,
     spec_urls_override=None,
     feature_description_override='Test Description',
+    detailed_requirements_override=False,
+  )
+
+
+def test_generate_resume(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test that the --resume flag is correctly passed to load_config."""
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+  mocker.patch('wptgen.main.WPTGenEngine')
+
+  # Run with --resume
+  result = runner.invoke(app, ['generate', 'grid', '--resume'])
+
+  assert result.exit_code == 0
+  mock_load_config.assert_called_once_with(
+    config_path=DEFAULT_CONFIG_PATH,
+    provider_override=None,
+    wpt_dir_override=None,
+    output_dir_override=None,
+    show_responses=False,
+    yes_tokens_override=False,
+    suggestions_only=False,
+    resume_override=True,
+    max_retries_override=3,
+    spec_urls_override=None,
+    feature_description_override=None,
     detailed_requirements_override=False,
   )
 

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pytest_mock import MockerFixture
+
+from wptgen.config import Config
+from wptgen.engine import WPTGenEngine
+from wptgen.models import WebFeatureMetadata, WorkflowContext, WPTContext
+
+
+@pytest.fixture
+def mock_config(tmp_path: Path) -> Config:
+  """Provides a basic Config object for testing."""
+  return Config(
+    provider='gemini',
+    default_model='gemini-3.1-pro-preview',
+    api_key='fake-key',
+    categories={
+      'lightweight': 'gemini-3-flash-preview',
+      'reasoning': 'gemini-3.1-pro-preview',
+    },
+    phase_model_mapping={
+      'requirements_extraction': 'reasoning',
+      'coverage_audit': 'reasoning',
+      'generation': 'lightweight',
+      'evaluation': 'lightweight',
+    },
+    wpt_path=str(tmp_path / 'wpt'),
+    cache_path=str(tmp_path / '.wpt-gen-cache'),
+    output_dir=str(tmp_path / 'output'),
+    resume=True,
+  )
+
+
+@pytest.fixture
+def engine(mock_config: Config) -> WPTGenEngine:
+  """Provides a WPTGenEngine instance with a mocked LLM client."""
+  with patch('wptgen.engine.get_llm_client', return_value=MagicMock()):
+    return WPTGenEngine(mock_config, MagicMock())
+
+
+def test_workflow_context_serialization() -> None:
+  """Verifies that WorkflowContext serializes and deserializes correctly."""
+  metadata = WebFeatureMetadata(name='Test', description='Desc', specs=['http://spec.com'])
+  wpt_context = WPTContext(
+    test_contents={'test.html': 'content'},
+    dependency_contents={'dep.js': 'js'},
+    test_to_deps={'test.html': {'dep.js'}},
+  )
+  context = WorkflowContext(
+    feature_id='test-feat',
+    metadata=metadata,
+    spec_contents='Spec contents',
+    wpt_context=wpt_context,
+    requirements_xml='<reqs/>',
+    audit_response='<audit/>',
+    suggestions=['suggestion 1'],
+    approved_suggestions_xml=['<suggestion/>'],
+    mdn_contents=['mdn'],
+    generated_tests=[(Path('/tmp/test.html'), 'content', '<suggestion/>')],
+  )
+
+  serialized = context.to_dict()
+  # Verify types are JSON-safe
+  json_str = json.dumps(serialized)
+  deserialized_data = json.loads(json_str)
+
+  new_context = WorkflowContext.from_dict(deserialized_data)
+
+  assert new_context.feature_id == context.feature_id
+  assert new_context.metadata == context.metadata
+  assert new_context.spec_contents == context.spec_contents
+  assert new_context.wpt_context is not None
+  assert context.wpt_context is not None
+  assert new_context.wpt_context.test_contents == context.wpt_context.test_contents
+  assert new_context.wpt_context.test_to_deps == context.wpt_context.test_to_deps
+  assert new_context.requirements_xml == context.requirements_xml
+  assert new_context.audit_response == context.audit_response
+  assert new_context.generated_tests == context.generated_tests
+
+
+def test_engine_save_load_resume_state(engine: WPTGenEngine) -> None:
+  """Verifies that the engine correctly saves and loads the state file."""
+  context = WorkflowContext(feature_id='test-feat', requirements_xml='<reqs/>')
+
+  engine._save_resume_state(context)
+
+  resume_file = engine._get_resume_file_path('test-feat')
+  assert resume_file.exists()
+
+  loaded_context = engine._load_resume_state('test-feat')
+  assert loaded_context is not None
+  assert loaded_context.feature_id == 'test-feat'
+  assert loaded_context.requirements_xml == '<reqs/>'
+
+
+@pytest.mark.asyncio
+async def test_run_async_workflow_resume_skips_phases(
+  engine: WPTGenEngine, mocker: MockerFixture
+) -> None:
+  """Verifies that completed phases are correctly skipped when resuming."""
+  # Setup context with some phases completed
+  context = WorkflowContext(
+    feature_id='test-feat',
+    metadata=WebFeatureMetadata(name='Test', description='Desc', specs=[]),
+    wpt_context=WPTContext(),
+    requirements_xml='<reqs/>',
+  )
+  engine._save_resume_state(context)
+
+  mock_assembly = mocker.patch('wptgen.engine.run_context_assembly')
+  mock_extraction = mocker.patch('wptgen.engine.run_requirements_extraction')
+  mock_audit = mocker.patch('wptgen.engine.run_coverage_audit', return_value='audit')
+  mock_gen = mocker.patch('wptgen.engine.run_test_generation', return_value=[])
+
+  await engine._run_async_workflow('test-feat')
+
+  # Phase 1 and 2 should be skipped
+  mock_assembly.assert_not_called()
+  mock_extraction.assert_not_called()
+  # Phase 3 and onwards should be called
+  mock_audit.assert_called_once()
+  mock_gen.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_async_workflow_cleans_up_resume_file(
+  engine: WPTGenEngine, mocker: MockerFixture
+) -> None:
+  """Verifies that the resume file is deleted upon successful completion."""
+  context = WorkflowContext(feature_id='test-feat')
+  engine._save_resume_state(context)
+  resume_file = engine._get_resume_file_path('test-feat')
+  assert resume_file.exists()
+
+  mocker.patch('wptgen.engine.run_context_assembly', return_value=context)
+  mocker.patch('wptgen.engine.run_requirements_extraction', return_value='<reqs/>')
+  mocker.patch('wptgen.engine.run_coverage_audit', return_value='audit')
+  mocker.patch('wptgen.engine.run_test_generation', return_value=[])
+
+  await engine._run_async_workflow('test-feat')
+
+  assert not resume_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_run_async_workflow_saves_after_each_phase(
+  engine: WPTGenEngine, mocker: MockerFixture
+) -> None:
+  """Verifies that the state is saved after each phase."""
+  context = WorkflowContext(feature_id='test-feat')
+
+  mocker.patch('wptgen.engine.run_context_assembly', return_value=context)
+  mocker.patch('wptgen.engine.run_requirements_extraction', return_value='<reqs/>')
+  mocker.patch('wptgen.engine.run_coverage_audit', return_value='audit')
+  mocker.patch('wptgen.engine.run_test_generation', return_value=[])
+
+  spy_save = mocker.spy(engine, '_save_resume_state')
+
+  await engine._run_async_workflow('test-feat')
+
+  # Saved after: assembly, extraction, audit, generation
+  assert spy_save.call_count == 4

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -35,6 +35,7 @@ class Config:
   show_responses: bool = False
   yes_tokens: bool = False
   suggestions_only: bool = False
+  resume: bool = False
   max_retries: int = 3
   cache_path: str | None = None
   spec_urls: list[str] | None = None
@@ -98,6 +99,7 @@ def load_config(
   show_responses: bool = False,
   yes_tokens_override: bool = False,
   suggestions_only: bool = False,
+  resume_override: bool = False,
   max_retries_override: int | None = None,
   spec_urls_override: list[str] | None = None,
   feature_description_override: str | None = None,
@@ -156,6 +158,7 @@ def load_config(
   show_responses = show_responses or yaml_data.get('show_responses', False)
   yes_tokens = yes_tokens_override or yaml_data.get('yes_tokens', False)
   suggestions_only = suggestions_only or yaml_data.get('suggestions_only', False)
+  resume = resume_override or yaml_data.get('resume', False)
   detailed_requirements = detailed_requirements_override or yaml_data.get(
     'detailed_requirements', False
   )
@@ -186,6 +189,7 @@ def load_config(
     show_responses=show_responses,
     yes_tokens=yes_tokens,
     suggestions_only=suggestions_only,
+    resume=resume,
     max_retries=max_retries,
     cache_path=cache_path,
     spec_urls=spec_urls_override,

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import asyncio
+import json
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
 
 from wptgen.config import Config
 from wptgen.llm import get_llm_client
+from wptgen.models import WorkflowContext
 from wptgen.phases.context_assembly import run_context_assembly
 from wptgen.phases.coverage_audit import provide_coverage_report, run_coverage_audit
 from wptgen.phases.evaluation import run_test_evaluation
@@ -58,44 +60,96 @@ class WPTGenEngine:
     """Entry point for the synchronous CLI to launch the async workflow."""
     asyncio.run(self._run_async_workflow(web_feature_id))
 
+  def _get_resume_file_path(self, web_feature_id: str) -> Path:
+    """Returns the path to the resume file for a given web feature ID."""
+    return self.cache_dir / f'resume_{web_feature_id}.json'
+
+  def _save_resume_state(self, context: WorkflowContext) -> None:
+    """Serializes and saves the current workflow context to the cache."""
+    resume_file = self._get_resume_file_path(context.feature_id)
+    with open(resume_file, 'w', encoding='utf-8') as f:
+      json.dump(context.to_dict(), f, indent=2)
+
+  def _load_resume_state(self, web_feature_id: str) -> WorkflowContext | None:
+    """Attempts to load a serialized workflow context from the cache."""
+    resume_file = self._get_resume_file_path(web_feature_id)
+    if not resume_file.exists():
+      return None
+
+    try:
+      with open(resume_file, encoding='utf-8') as f:
+        data = json.load(f)
+      return WorkflowContext.from_dict(data)
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+      self.ui.print(f'[yellow]⚠ Failed to load resume state: {e}. Starting fresh.[/yellow]')
+      return None
+
   async def _run_async_workflow(self, web_feature_id: str) -> None:
     """Orchestrates the end-to-end WPT generation workflow."""
+    context = None
+    if self.config.resume:
+      context = self._load_resume_state(web_feature_id)
+      if context:
+        self.ui.print(f'[bold green]✔ Resuming workflow for {web_feature_id}[/bold green]')
+
     # Phase 1: Context Assembly
-    context = await run_context_assembly(web_feature_id, self.config, self.ui)
-    if not context:
-      return
+    if not context or not context.wpt_context:
+      context = await run_context_assembly(web_feature_id, self.config, self.ui)
+      if not context:
+        return
+      self._save_resume_state(context)
 
     # Phase 2: Requirements Extraction
-    if self.config.detailed_requirements:
-      requirements_xml = await run_requirements_extraction_iterative(
-        context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
-      )
-    else:
-      requirements_xml = await run_requirements_extraction(
-        context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
-      )
-    if not requirements_xml:
-      return
+    if not context.requirements_xml:
+      if self.config.detailed_requirements:
+        requirements_xml = await run_requirements_extraction_iterative(
+          context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
+        )
+      else:
+        requirements_xml = await run_requirements_extraction(
+          context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
+        )
+      if not requirements_xml:
+        return
+      context.requirements_xml = requirements_xml
+      self._save_resume_state(context)
 
     # Phase 3: Coverage Audit
-    audit_response = await run_coverage_audit(
-      context, self.config, self.llm, self.ui, self.jinja_env
-    )
-    if not audit_response:
-      return
+    if not context.audit_response:
+      audit_response = await run_coverage_audit(
+        context, self.config, self.llm, self.ui, self.jinja_env
+      )
+      if not audit_response:
+        return
+      context.audit_response = audit_response
+      self._save_resume_state(context)
 
     # Skip Phase 4 if the user only wants the coverage audit report.
     if self.config.suggestions_only:
       await provide_coverage_report(context, self.config, self.ui)
+      # Cleanup resume file if it exists, as this is a terminal state for suggestions-only
+      resume_file = self._get_resume_file_path(web_feature_id)
+      if resume_file.exists():
+        resume_file.unlink()
       return
 
     # Phase 4: User Selection & Generation
-    generated_tests = await run_test_generation(
-      context, self.config, self.llm, self.ui, self.jinja_env
-    )
+    if not context.generated_tests:
+      generated_tests = await run_test_generation(
+        context, self.config, self.llm, self.ui, self.jinja_env
+      )
+      context.generated_tests = generated_tests
+      self._save_resume_state(context)
+    else:
+      self.ui.print('[bold green]✔ Skipping Phase 4: Tests already generated.[/bold green]')
 
     # Phase 5: Evaluation
-    if generated_tests:
+    if context.generated_tests:
       await run_test_evaluation(
-        context, self.config, self.llm, self.ui, self.jinja_env, generated_tests
+        context, self.config, self.llm, self.ui, self.jinja_env, context.generated_tests
       )
+
+    # Final cleanup of resume file on success
+    resume_file = self._get_resume_file_path(web_feature_id)
+    if resume_file.exists():
+      resume_file.unlink()

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -90,6 +90,13 @@ def generate(
       help='Only show test suggestions and skip the test generation step.',
     ),
   ] = False,
+  resume: Annotated[
+    bool,
+    typer.Option(
+      '--resume',
+      help='Resume the workflow from the last successful phase.',
+    ),
+  ] = False,
   max_retries: Annotated[
     int,
     typer.Option(
@@ -154,6 +161,7 @@ def generate(
       show_responses=show_responses,
       yes_tokens_override=yes_tokens,
       suggestions_only=suggestions_only,
+      resume_override=resume,
       max_retries_override=max_retries,
       spec_urls_override=spec_urls_list,
       feature_description_override=description,

--- a/wptgen/models.py
+++ b/wptgen/models.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from enum import Enum
+from pathlib import Path
+from typing import Any
 
 
 class TestType(Enum):
@@ -36,6 +38,13 @@ class WebFeatureMetadata:
   description: str
   specs: list[str]
 
+  def to_dict(self) -> dict[str, Any]:
+    return asdict(self)
+
+  @classmethod
+  def from_dict(cls, data: dict[str, Any]) -> 'WebFeatureMetadata':
+    return cls(**data)
+
 
 @dataclass
 class WPTContext:
@@ -44,6 +53,19 @@ class WPTContext:
   test_contents: dict[str, str] = field(default_factory=dict)
   dependency_contents: dict[str, str] = field(default_factory=dict)
   test_to_deps: dict[str, set[str]] = field(default_factory=dict)
+
+  def to_dict(self) -> dict[str, Any]:
+    data = asdict(self)
+    # Convert sets to lists for JSON serialization
+    data['test_to_deps'] = {k: list(v) for k, v in self.test_to_deps.items()}
+    return data
+
+  @classmethod
+  def from_dict(cls, data: dict[str, Any]) -> 'WPTContext':
+    # Convert lists back to sets
+    if 'test_to_deps' in data:
+      data['test_to_deps'] = {k: set(v) for k, v in data['test_to_deps'].items()}
+    return cls(**data)
 
 
 @dataclass
@@ -59,3 +81,42 @@ class WorkflowContext:
   suggestions: list[str] = field(default_factory=list)
   approved_suggestions_xml: list[str] = field(default_factory=list)
   mdn_contents: list[str] | None = None
+  generated_tests: list[tuple[Path, str, str]] | None = None
+
+  def to_dict(self) -> dict[str, Any]:
+    data = {
+      'feature_id': self.feature_id,
+      'metadata': self.metadata.to_dict() if self.metadata else None,
+      'spec_contents': self.spec_contents,
+      'wpt_context': self.wpt_context.to_dict() if self.wpt_context else None,
+      'requirements_xml': self.requirements_xml,
+      'audit_response': self.audit_response,
+      'suggestions': self.suggestions,
+      'approved_suggestions_xml': self.approved_suggestions_xml,
+      'mdn_contents': self.mdn_contents,
+      'generated_tests': (
+        [(str(p), c, s) for p, c, s in self.generated_tests] if self.generated_tests else None
+      ),
+    }
+    return data
+
+  @classmethod
+  def from_dict(cls, data: dict[str, Any]) -> 'WorkflowContext':
+    metadata = WebFeatureMetadata.from_dict(data['metadata']) if data.get('metadata') else None
+    wpt_context = WPTContext.from_dict(data['wpt_context']) if data.get('wpt_context') else None
+    generated_tests = None
+    if data.get('generated_tests'):
+      generated_tests = [(Path(p), c, s) for p, c, s in data['generated_tests']]
+
+    return cls(
+      feature_id=data['feature_id'],
+      metadata=metadata,
+      spec_contents=data.get('spec_contents'),
+      wpt_context=wpt_context,
+      requirements_xml=data.get('requirements_xml'),
+      audit_response=data.get('audit_response'),
+      suggestions=data.get('suggestions', []),
+      approved_suggestions_xml=data.get('approved_suggestions_xml', []),
+      mdn_contents=data.get('mdn_contents'),
+      generated_tests=generated_tests,
+    )


### PR DESCRIPTION
Fixes #105 

This change adds a `--resume` flag for the `wpt-gen generate` workflow, allowing users to continue interrupted or failed runs from the last successful phase. This is achieved by serializing the `WorkflowContext` into a JSON state file in the cache directory after each completed phase.

- Add to_dict/from_dict serialization to WorkflowContext and related models.
- Implement _save_resume_state and _load_resume_state in WPTGenEngine.
- Update _run_async_workflow to skip completed phases and save state incrementally.
- Add --resume CLI flag to the generate command.
- Ensure automatic cleanup of resume files on successful workflow completion.
- Add comprehensive unit tests for serialization and resume logic.
- Update existing tests to support the new resume configuration parameter.
- Fix mypy errors by adding return type annotations and safety assertions.