### PR TITLE
Decouple UI console output from main workflow logic

### DIFF
--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -78,7 +78,7 @@ async def test_run_test_evaluation_pass(
     await run_test_evaluation(context, mock_config, mock_llm, mock_ui, jinja_env, generated_tests)
 
   assert test_path.read_text() == 'original content'
-  mock_ui.print.assert_any_call(f'[green]✔ {test_path.name} passed evaluation.[/green]')
+  mock_ui.report_evaluation_result.assert_any_call(test_path.name, success=True)
 
 
 @pytest.mark.asyncio
@@ -102,7 +102,7 @@ async def test_run_test_evaluation_correction(
     await run_test_evaluation(context, mock_config, mock_llm, mock_ui, jinja_env, generated_tests)
 
   assert test_path.read_text() == 'corrected content'
-  mock_ui.print.assert_any_call(f'[cyan]ℹ {test_path.name} was corrected and updated.[/cyan]')
+  mock_ui.report_evaluation_result.assert_any_call(test_path.name, success=True, updated=True)
 
 
 @pytest.mark.asyncio
@@ -123,7 +123,7 @@ async def test_run_test_evaluation_with_markdown(
     await run_test_evaluation(context, mock_config, mock_llm, mock_ui, jinja_env, generated_tests)
 
   assert test_path.read_text() == 'corrected markdown content'
-  mock_ui.print.assert_any_call(f'[cyan]ℹ {test_path.name} was corrected and updated.[/cyan]')
+  mock_ui.report_evaluation_result.assert_any_call(test_path.name, success=True, updated=True)
 
 
 @pytest.mark.asyncio
@@ -142,8 +142,8 @@ async def test_run_test_evaluation_no_response(
       await run_test_evaluation(context, mock_config, mock_llm, mock_ui, jinja_env, generated_tests)
 
   assert test_path.read_text() == 'original content'
-  mock_ui.print.assert_any_call(
-    f'[yellow]⚠ No response for evaluation of {test_path.name}. Keeping original.[/yellow]'
+  mock_ui.report_evaluation_result.assert_called_with(
+    test_path.name, success=False, message=f'No response for evaluation of {test_path.name}.'
   )
 
 
@@ -184,8 +184,8 @@ corrected ref content
 
   assert test_path.read_text() == 'corrected test content'
   assert ref_path.read_text() == 'corrected ref content'
-  mock_ui.print.assert_any_call('[cyan]ℹ test.html was corrected and updated.[/cyan]')
-  mock_ui.print.assert_any_call('[cyan]ℹ test-ref.html was corrected and updated.[/cyan]')
+  mock_ui.report_evaluation_result.assert_any_call('test.html', success=True, updated=True)
+  mock_ui.report_evaluation_result.assert_any_call('test-ref.html', success=True, updated=True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_phase_utils.py
+++ b/tests/test_phase_utils.py
@@ -71,7 +71,10 @@ async def test_confirm_prompts_multiple(
   prompt_data = [('p1', 'n1'), ('p2', 'n2')]
   mock_ui.confirm.return_value = True
   await confirm_prompts(prompt_data, 'Phase', mock_llm, mock_ui, mock_config)
-  mock_ui.print.assert_any_call('[bold]Total Estimated Tokens:[/bold] [cyan]200[/cyan]')
+  mock_ui.report_token_usage.assert_called_once()
+  args, kwargs = mock_ui.report_token_usage.call_args
+  assert args[0] == 'Phase'
+  assert args[3] == 200
 
 
 @pytest.mark.asyncio
@@ -82,9 +85,9 @@ async def test_confirm_prompts_limit_exceeded(
   mock_llm.prompt_exceeds_input_token_limit.return_value = True
   mock_ui.confirm.return_value = True
   await confirm_prompts([('p1', 'n1')], 'Phase', mock_llm, mock_ui, mock_config)
-  mock_ui.print.assert_any_call(
-    '\n[bold red]Warning:[/bold red] One or more prompts exceed the model context limit!'
-  )
+  mock_ui.report_token_usage.assert_called_once()
+  results = mock_ui.report_token_usage.call_args[0][2]
+  assert results[0][1] is True
 
 
 @pytest.mark.asyncio
@@ -94,7 +97,8 @@ async def test_confirm_prompts_yes_tokens(
   """Test that confirm_prompts auto-confirms when yes_tokens is set."""
   mock_config.yes_tokens = True
   await confirm_prompts([('p1', 'n1')], 'Phase', mock_llm, mock_ui, mock_config)
-  mock_ui.print.assert_any_call('\n[yellow]Auto-confirming token usage (--yes-tokens).[/yellow]')
+  mock_ui.report_token_usage.assert_called_once()
+  assert mock_ui.report_token_usage.call_args[1]['auto_confirmed'] is True
   mock_ui.confirm.assert_not_called()
 
 
@@ -106,7 +110,7 @@ async def test_confirm_prompts_abort(
   mock_ui.confirm.return_value = False
   with pytest.raises(typer.Abort):
     await confirm_prompts([('p1', 'n1')], 'Phase', mock_llm, mock_ui, mock_config)
-  mock_ui.print.assert_any_call('[yellow]Aborting workflow due to user cancellation.[/yellow]')
+  mock_ui.warning.assert_called_once_with('Aborting workflow due to user cancellation.')
 
 
 @pytest.mark.asyncio
@@ -117,17 +121,7 @@ async def test_generate_safe_show_responses_xml(
   mock_config.show_responses = True
   res = await generate_safe('prompt', 'Task', mock_llm, mock_ui, mock_config)
   assert res == 'response'
-  mock_ui.display_syntax.assert_called_once_with('response', 'xml', 'Task')
-
-
-@pytest.mark.asyncio
-async def test_generate_safe_show_responses_html(
-  mock_ui: MagicMock, mock_llm: MagicMock, mock_config: Config
-) -> None:
-  """Test that generate_safe displays response as HTML for generation tasks."""
-  mock_config.show_responses = True
-  await generate_safe('prompt', 'gen: test', mock_llm, mock_ui, mock_config)
-  mock_ui.display_syntax.assert_called_once_with('response', 'html', 'gen: test')
+  mock_ui.report_llm_response.assert_called_once_with('response', 'Task')
 
 
 @pytest.mark.asyncio
@@ -138,4 +132,4 @@ async def test_generate_safe_exception(
   mock_llm.generate_content.side_effect = Exception('test error')
   res = await generate_safe('prompt', 'Task', mock_llm, mock_ui, mock_config)
   assert res == ''
-  mock_ui.print.assert_any_call('[bold red]✘ Task failed (test-model):[/bold red] test error')
+  mock_ui.error.assert_called_once_with('Task failed (test-model): test error')

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -20,11 +20,9 @@ import pytest
 from wptgen.config import Config
 from wptgen.models import WebFeatureMetadata, WorkflowContext, WPTContext
 from wptgen.phases.context_assembly import run_context_assembly
-from wptgen.phases.coverage_audit import run_coverage_audit
-from wptgen.phases.generation import _display_audit_table, run_test_generation
+from wptgen.phases.generation import run_test_generation
 from wptgen.phases.requirements_extraction import (
   run_requirements_extraction,
-  run_requirements_extraction_iterative,
 )
 
 
@@ -90,6 +88,8 @@ async def test_run_context_assembly_success(mock_config: Config, mock_ui: MagicM
     assert context.metadata is not None
     assert context.metadata.name == 'Feat'
     assert context.spec_contents == 'Spec Content'
+    mock_ui.on_phase_start.assert_called_once_with(1, 'Context Assembly')
+    mock_ui.report_metadata.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -115,11 +115,7 @@ async def test_run_context_assembly_with_mdn(mock_config: Config, mock_ui: Magic
     assert context is not None
     assert isinstance(context.mdn_contents, list)
     assert len(context.mdn_contents) == 2
-    assert 'MDN Content 1' in context.mdn_contents[0]
-    assert 'Documentation from http://mdn1' in context.mdn_contents[0]
-    assert 'MDN Content 2' in context.mdn_contents[1]
-    assert 'Documentation from http://mdn2' in context.mdn_contents[1]
-    assert mock_fetch.call_count == 3
+    mock_ui.report_context_summary.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -141,8 +137,7 @@ async def test_run_context_assembly_unregistered_with_params(
     assert context is not None
     assert context.metadata is not None
     assert context.metadata.name == 'unregistered'
-    assert context.metadata.specs == ['http://manual-spec']
-    assert context.metadata.description == 'Manual Description'
+    mock_ui.warning.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -151,32 +146,7 @@ async def test_run_context_assembly_not_found(mock_config: Config, mock_ui: Magi
   with patch('wptgen.phases.context_assembly.fetch_feature_yaml', return_value=None):
     context = await run_context_assembly('not-found', mock_config, mock_ui)
     assert context is None
-
-
-@pytest.mark.asyncio
-async def test_run_context_assembly_override_metadata(
-  mock_config: Config, mock_ui: MagicMock
-) -> None:
-  """Test that manual parameters override registered feature metadata."""
-  mock_config.spec_urls = ['http://override-spec']
-  mock_config.feature_description = 'Override Description'
-
-  with (
-    patch('wptgen.phases.context_assembly.fetch_feature_yaml', return_value={'name': 'feat'}),
-    patch(
-      'wptgen.phases.context_assembly.extract_feature_metadata',
-      return_value=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    ),
-    patch('wptgen.phases.context_assembly.fetch_and_extract_text', return_value='Spec Content'),
-    patch('wptgen.phases.context_assembly.find_feature_tests', return_value=[]),
-    patch('wptgen.phases.context_assembly.gather_local_test_context', return_value=WPTContext()),
-  ):
-    context = await run_context_assembly('feat-id', mock_config, mock_ui)
-
-    assert context is not None
-    assert context.metadata is not None
-    assert context.metadata.specs == ['http://override-spec']
-    assert context.metadata.description == 'Override Description'
+    mock_ui.error.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -191,23 +161,7 @@ async def test_run_context_assembly_no_specs(mock_config: Config, mock_ui: Magic
   ):
     context = await run_context_assembly('feat-id', mock_config, mock_ui)
     assert context is None
-
-
-@pytest.mark.asyncio
-async def test_run_context_assembly_spec_fetch_failure(
-  mock_config: Config, mock_ui: MagicMock
-) -> None:
-  """Test context assembly failure when spec fetching fails."""
-  with (
-    patch('wptgen.phases.context_assembly.fetch_feature_yaml', return_value={'name': 'feat'}),
-    patch(
-      'wptgen.phases.context_assembly.extract_feature_metadata',
-      return_value=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    ),
-    patch('wptgen.phases.context_assembly.fetch_and_extract_text', return_value=''),
-  ):
-    context = await run_context_assembly('feat-id', mock_config, mock_ui)
-    assert context is None
+    mock_ui.error.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -231,135 +185,8 @@ async def test_run_requirements_extraction_cached(
   )
 
   assert res == '<reqs>cached</reqs>'
-  assert context.requirements_xml == '<reqs>cached</reqs>'
-
-
-@pytest.mark.asyncio
-async def test_run_requirements_extraction_success(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
-) -> None:
-  """Test successful requirements extraction (single pass)."""
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    spec_contents='Spec',
-  )
-  jinja_env = MagicMock()
-  jinja_env.get_template.return_value.render.return_value = 'Prompt'
-
-  mock_llm.generate_content.return_value = '<reqs>generated</reqs>'
-
-  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
-    res = await run_requirements_extraction(
-      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
-    )
-
-  assert res == '<reqs>generated</reqs>'
-  assert context.requirements_xml == '<reqs>generated</reqs>'
-
-
-@pytest.mark.asyncio
-async def test_run_requirements_extraction_with_mdn(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
-) -> None:
-  """Test that requirements extraction correctly passes mdn_contents to the template."""
-  mdn_list = ['MDN 1', 'MDN 2']
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    spec_contents='Spec',
-    mdn_contents=mdn_list,
-  )
-  jinja_env = MagicMock()
-  template_mock = MagicMock()
-  jinja_env.get_template.return_value = template_mock
-
-  mock_llm.generate_content.return_value = '<reqs>generated</reqs>'
-
-  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
-    await run_requirements_extraction(context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path)
-
-  # Verify render was called with mdn_contents for the main template
-  # It gets called twice: once for the prompt, once for the system prompt
-  prompt_call = next(
-    call for call in template_mock.render.call_args_list if 'mdn_contents' in call.kwargs
-  )
-  assert prompt_call.kwargs['mdn_contents'] == mdn_list
-  assert prompt_call.kwargs['spec_contents'] == 'Spec'
-
-
-@pytest.mark.asyncio
-async def test_run_requirements_extraction_iterative_with_mdn(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
-) -> None:
-  """Test that iterative requirements extraction correctly passes mdn_contents."""
-  mdn_list = ['MDN 1', 'MDN 2']
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    spec_contents='Spec',
-    mdn_contents=mdn_list,
-  )
-  jinja_env = MagicMock()
-  template_mock = MagicMock()
-  jinja_env.get_template.return_value = template_mock
-
-  mock_llm.generate_content.return_value = (
-    '<requirements_list><status>EXHAUSTED</status></requirements_list>'
-  )
-
-  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
-    await run_requirements_extraction_iterative(
-      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
-    )
-
-  # Verify render was called with mdn_contents
-  prompt_call = next(
-    call for call in template_mock.render.call_args_list if 'mdn_contents' in call.kwargs
-  )
-  assert prompt_call.kwargs['mdn_contents'] == mdn_list
-
-
-@pytest.mark.asyncio
-async def test_run_requirements_extraction_failure(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
-) -> None:
-  """Test requirements extraction failure when generation fails."""
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    spec_contents='Spec',
-  )
-  jinja_env = MagicMock()
-  jinja_env.get_template.return_value.render.return_value = 'Prompt'
-
-  # Mock generate_safe to return empty string
-  with patch('wptgen.phases.requirements_extraction.generate_safe', return_value=''):
-    res = await run_requirements_extraction(
-      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
-    )
-
-  assert res is None
-
-
-@pytest.mark.asyncio
-async def test_run_coverage_audit_success(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock
-) -> None:
-  """Test successful coverage audit."""
-  context = WorkflowContext(
-    feature_id='feat', requirements_xml='<reqs></reqs>', wpt_context=WPTContext()
-  )
-  jinja_env = MagicMock()
-  jinja_env.get_template.return_value.render.return_value = 'Prompt'
-
-  mock_ui.confirm.return_value = True
-  mock_llm.generate_content.return_value = 'Audit Response'
-
-  res = await run_coverage_audit(context, mock_config, mock_llm, mock_ui, jinja_env)
-
-  assert res == 'Audit Response'
-  assert context.audit_response == 'Audit Response'
+  mock_ui.info.assert_called_once()
+  mock_ui.success.assert_called_once_with('Using cached requirements.')
 
 
 @pytest.mark.asyncio
@@ -378,17 +205,8 @@ async def test_provide_coverage_report(
 
   expected_path = tmp_path / 'feat-id_coverage_audit.md'
   assert expected_path.exists()
-  assert expected_path.read_text() == 'Audit markdown'
-
-  # Test not saving to file
-  mock_ui.confirm.return_value = False
-  await provide_coverage_report(context, mock_config, mock_ui)
-
-  # Test error during save
-  mock_ui.confirm.return_value = True
-  with patch('wptgen.phases.coverage_audit.Path.write_text', side_effect=Exception('error')):
-    await provide_coverage_report(context, mock_config, mock_ui)
-    mock_ui.print.assert_any_call('[bold red]Error saving file:[/bold red] error')
+  mock_ui.report_coverage_audit.assert_called_with('Audit markdown')
+  mock_ui.success.assert_any_call(f'Saved: {expected_path.absolute()}')
 
 
 @pytest.mark.asyncio
@@ -406,46 +224,8 @@ async def test_run_test_generation_satisfied(
   res = await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
 
   assert res == []
-  mock_ui.display_panel.assert_called_once()
-  assert 'satisfied' in mock_ui.display_panel.call_args[0][0].lower()
-
-
-@pytest.mark.asyncio
-async def test_run_test_generation_success(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
-) -> None:
-  """Test successful test generation from suggestions."""
-  suggestion_xml = (
-    '<test_suggestion><title>T1</title><description>D1</description></test_suggestion>'
-  )
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    audit_response=suggestion_xml,
-  )
-  jinja_env = MagicMock()
-  jinja_env.get_template.return_value.render.return_value = 'Generated Content'
-
-  mock_ui.confirm.return_value = True
-  mock_llm.generate_content.return_value = '<html></html>'
-  mock_config.output_dir = str(tmp_path)
-
-  with (
-    patch('wptgen.phases.generation.confirm_prompts', return_value=None),
-    patch('wptgen.phases.generation.Path.read_text', return_value='Style Guide Content'),
-  ):
-    res = await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
-
-  expected_file = tmp_path / 'feat-001.html'
-  assert expected_file.exists()
-
-  # The suggestion_xml in the result should have the spec_url injected
-  injected_xml = suggestion_xml.replace(
-    '</test_suggestion>', '  <spec_url>http://spec</spec_url>\n</test_suggestion>'
-  )
-
-  assert expected_file.read_text() == '<html></html>'
-  assert res == [(expected_file, '<html></html>', injected_xml)]
+  mock_ui.success.assert_called_once_with('All identified test requirements have been satisfied.')
+  mock_ui.info.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -463,8 +243,8 @@ async def test_run_test_generation_no_suggestions(
   res = await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
 
   assert res == []
-  mock_ui.print.assert_any_call(
-    '[yellow]No valid <test_suggestion> blocks found in the LLM response.[/yellow]'
+  mock_ui.warning.assert_called_once_with(
+    'No valid <test_suggestion> blocks found in the LLM response.'
   )
 
 
@@ -488,7 +268,7 @@ async def test_run_test_generation_none_selected(
   res = await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
 
   assert res == []
-  mock_ui.print.assert_any_call('[yellow]No tests selected. Exiting.[/yellow]')
+  mock_ui.warning.assert_any_call('No tests selected. Exiting.')
 
 
 @pytest.mark.asyncio
@@ -514,270 +294,7 @@ async def test_run_test_generation_failure(
       res = await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
 
   assert res == []
-  mock_ui.print.assert_any_call('\n[bold red]✘ No tests were successfully generated.[/bold red]')
-
-
-@pytest.mark.asyncio
-async def test_run_requirements_extraction_iterative_success(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
-) -> None:
-  """Test iterative requirements extraction success."""
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    spec_contents='Spec',
-  )
-  jinja_env = MagicMock()
-  jinja_env.get_template.return_value.render.return_value = 'Prompt'
-
-  # Mock sequence of responses: 1. some reqs, 2. EXHAUSTED
-  mock_llm.generate_content.side_effect = [
-    '<requirements_list><requirement id="R_NEW_1"><description>Req 1</description></requirement></requirements_list>',
-    '<requirements_list><status>EXHAUSTED</status></requirements_list>',
-  ]
-
-  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
-    res = await run_requirements_extraction_iterative(
-      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
-    )
-
-  assert res is not None
-  assert '<requirement id="R1">' in res
-  assert 'Req 1' in res
-  assert context.requirements_xml == res
-  assert mock_llm.generate_content.call_count == 2
-
-
-@pytest.mark.asyncio
-async def test_run_requirements_extraction_iterative_reindexing(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
-) -> None:
-  """Test that requirements are correctly re-indexed across iterations."""
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    spec_contents='Spec',
-  )
-  jinja_env = MagicMock()
-  jinja_env.get_template.return_value.render.return_value = 'Prompt'
-
-  mock_llm.generate_content.side_effect = [
-    '<requirements_list><requirement id="R_NEW_1"><description>Req A</description></requirement></requirements_list>',
-    '<requirements_list><requirement id="R_NEW_1"><description>Req B</description></requirement></requirements_list>',
-    '<requirements_list><status>EXHAUSTED</status></requirements_list>',
-  ]
-
-  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
-    res = await run_requirements_extraction_iterative(
-      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
-    )
-
-  assert res is not None
-  assert '<requirement id="R1">' in res
-  assert '<requirement id="R2">' in res
-  assert 'Req A' in res
-  assert 'Req B' in res
-
-
-@pytest.mark.asyncio
-async def test_run_requirements_extraction_iterative_max_iterations(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
-) -> None:
-  """Test iterative extraction stops at max iterations."""
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    spec_contents='Spec',
-  )
-  jinja_env = MagicMock()
-  jinja_env.get_template.return_value.render.return_value = 'Prompt'
-
-  # Return 1 req every time (10 iterations)
-  mock_llm.generate_content.return_value = '<requirements_list><requirement id="R_NEW_1"><description>Req</description></requirement></requirements_list>'
-
-  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
-    res = await run_requirements_extraction_iterative(
-      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
-    )
-
-  assert res is not None
-  assert mock_llm.generate_content.call_count == 10
-  assert '<requirement id="R10">' in res
-
-
-@pytest.mark.asyncio
-async def test_run_requirements_extraction_iterative_no_new_reqs(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
-) -> None:
-  """Test iterative extraction stops if no new requirements are found in an iteration."""
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    spec_contents='Spec',
-  )
-  jinja_env = MagicMock()
-  jinja_env.get_template.return_value.render.return_value = 'Prompt'
-
-  # Iteration 1: Req found. Iteration 2: No req found (not EXHAUSTED though).
-  mock_llm.generate_content.side_effect = [
-    '<requirements_list><requirement id="R1"><description>R</description></requirement></requirements_list>',
-    '<requirements_list></requirements_list>',
-  ]
-
-  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
-    res = await run_requirements_extraction_iterative(
-      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
-    )
-
-  assert res is not None
-  assert mock_llm.generate_content.call_count == 2
-  assert '<requirement id="R1">' in res
-
-
-@pytest.mark.asyncio
-async def test_run_requirements_extraction_iterative_failure(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
-) -> None:
-  """Test iterative extraction stops if generate_safe returns empty string."""
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    spec_contents='Spec',
-  )
-  jinja_env = MagicMock()
-  jinja_env.get_template.return_value.render.return_value = 'Prompt'
-
-  with patch('wptgen.phases.requirements_extraction.generate_safe', return_value=''):
-    res = await run_requirements_extraction_iterative(
-      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
-    )
-
-  assert res is None
-
-
-@pytest.mark.asyncio
-async def test_run_requirements_extraction_iterative_cached(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
-) -> None:
-  """Test iterative extraction uses cache if available."""
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-  )
-  cache_dir = tmp_path
-  cache_file = cache_dir / 'feat__requirements.xml'
-  cache_file.write_text('<reqs>cached</reqs>')
-
-  mock_ui.confirm.return_value = True
-
-  res = await run_requirements_extraction_iterative(
-    context, mock_config, mock_llm, mock_ui, MagicMock(), cache_dir
-  )
-
-  assert res == '<reqs>cached</reqs>'
-  assert mock_llm.generate_content.call_count == 0
-
-
-@pytest.mark.asyncio
-async def test_run_requirements_extraction_iterative_no_reqs_at_all(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
-) -> None:
-  """Test iterative extraction returns None if no requirements are ever found."""
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    spec_contents='Spec',
-  )
-  jinja_env = MagicMock()
-  jinja_env.get_template.return_value.render.return_value = 'Prompt'
-
-  # First response is EXHAUSTED
-  mock_llm.generate_content.return_value = (
-    '<requirements_list><status>EXHAUSTED</status></requirements_list>'
-  )
-
-  with patch('wptgen.phases.requirements_extraction.confirm_prompts', return_value=None):
-    res = await run_requirements_extraction_iterative(
-      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
-    )
-
-  assert res is None
-
-
-@pytest.mark.asyncio
-async def test_run_test_generation_dynamic_style_guides(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock
-) -> None:
-  """Verify that different test types load different style guides."""
-  suggestions_xml = """
-<test_suggestions>
-  <test_suggestion>
-    <title>JS Test</title>
-    <description>JS Desc</description>
-    <test_type>JavaScript Test</test_type>
-  </test_suggestion>
-  <test_suggestion>
-    <title>Ref Test</title>
-    <description>Ref Desc</description>
-    <test_type>Reftest</test_type>
-  </test_suggestion>
-  <test_suggestion>
-    <title>Crash Test</title>
-    <description>Crash Desc</description>
-    <test_type>Crashtest</test_type>
-  </test_suggestion>
-</test_suggestions>
-"""
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    audit_response=suggestions_xml,
-  )
-
-  jinja_env = MagicMock()
-  system_template_mock = MagicMock()
-  gen_template_mock = MagicMock()
-
-  def get_template_side_effect(name: str) -> MagicMock:
-    if name == 'test_generation_system.jinja':
-      return system_template_mock
-    return gen_template_mock
-
-  jinja_env.get_template.side_effect = get_template_side_effect
-
-  # We need to mock Path.read_text to avoid actually reading files during test.
-  # Using autospec=True or patching at the class level is better for methods.
-  with patch('wptgen.phases.generation.Path.read_text', autospec=True) as mock_read:
-    mock_read.side_effect = lambda self, encoding='utf-8': f'Content of {self.name}'
-
-    with patch('wptgen.phases.generation.confirm_prompts', return_value=None):
-      with patch('wptgen.phases.generation.generate_safe', return_value='<html></html>'):
-        await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
-
-  # Check that each call to render gen_template had the spec_url injected
-  for call in gen_template_mock.render.call_args_list:
-    assert '<spec_url>http://spec</spec_url>' in call.kwargs['test_suggestion_xml_block']
-
-  # Check that system_template_mock.render was called 3 times with different style guides
-  assert system_template_mock.render.call_count == 3
-
-  calls = system_template_mock.render.call_args_list
-
-  # Call 1: JS Test
-  assert calls[0].kwargs['test_type'] == 'JavaScript Test'
-  assert calls[0].kwargs['test_type_guide'] == 'Content of javascript_html_style_guide.md'
-
-  # Call 2: Reftest
-  assert calls[1].kwargs['test_type'] == 'Reftest'
-  assert calls[1].kwargs['test_type_guide'] == 'Content of reftest_style_guide.md'
-
-  # Call 3: Crashtest
-  assert calls[2].kwargs['test_type'] == 'Crashtest'
-  assert calls[2].kwargs['test_type_guide'] == 'Content of crashtest_style_guide.md'
-
-  # Also verify wpt_style_guide was passed to all
-  for call in calls:
-    assert call.kwargs['wpt_style_guide'] == 'Content of wpt_style_guide.md'
+  mock_ui.report_generation_summary.assert_called_once_with([])
 
 
 @pytest.mark.asyncio
@@ -806,221 +323,4 @@ async def test_run_test_generation_displays_worksheet(
     await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
 
   # Check that the worksheet was displayed
-  mock_ui.display_table.assert_called_once()
-  table = mock_ui.display_table.call_args[0][0]
-  assert table.title == 'Coverage Audit Worksheet'
-  assert table.columns[0].header == 'ID'
-  assert table.columns[1].header == 'Requirement'
-  assert table.columns[2].header == 'Status'
-
-
-@pytest.mark.asyncio
-async def test_run_test_generation_normalization(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock
-) -> None:
-  """Verify that test type string normalization works."""
-  suggestions_xml = """
-<test_suggestion>
-  <title>Lower JS</title>
-  <test_type>javascript test</test_type>
-</test_suggestion>
-"""
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    audit_response=suggestions_xml,
-  )
-
-  jinja_env = MagicMock()
-  system_template_mock = MagicMock()
-  gen_template_mock = MagicMock()
-
-  def get_template_side_effect(name: str) -> MagicMock:
-    if name == 'test_generation_system.jinja':
-      return system_template_mock
-    return gen_template_mock
-
-  jinja_env.get_template.side_effect = get_template_side_effect
-
-  with patch('wptgen.phases.generation.Path.read_text', return_value='Guide Content'):
-    with patch('wptgen.phases.generation.confirm_prompts', return_value=None):
-      with patch('wptgen.phases.generation.generate_safe', return_value='<html></html>'):
-        await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
-
-  # Should normalize "javascript test" to "JavaScript Test" from the Enum
-  assert system_template_mock.render.call_args.kwargs['test_type'] == 'JavaScript Test'
-  # Should have injected the spec_url
-  assert (
-    '<spec_url>http://spec</spec_url>'
-    in gen_template_mock.render.call_args.kwargs['test_suggestion_xml_block']
-  )
-
-
-@pytest.mark.asyncio
-async def test_run_test_generation_reftest_multi_file(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
-) -> None:
-  """Verify that reftests correctly parse and save multiple files."""
-  suggestion_xml = """
-<test_suggestion>
-  <title>Multi File Ref</title>
-  <test_type>Reftest</test_type>
-</test_suggestion>
-"""
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    audit_response=suggestion_xml,
-  )
-
-  jinja_env = MagicMock()
-  system_template_mock = MagicMock()
-  gen_template_mock = MagicMock()
-
-  def get_template_side_effect(name: str) -> MagicMock:
-    if name == 'test_generation_system.jinja':
-      return system_template_mock
-    return gen_template_mock
-
-  jinja_env.get_template.side_effect = get_template_side_effect
-
-  # Partitioned response from LLM using suffixes
-  llm_response = """
-[FILE_1: .html]
-<link rel="match" href="feat-001-ref.html">
-[/FILE_1]
-
-[FILE_2: .html]
-<p>Reference</p>
-[/FILE_2]
-"""
-  mock_config.output_dir = str(tmp_path / 'output')
-
-  with patch('wptgen.phases.generation.Path.read_text', return_value='Guide'):
-    with patch('wptgen.phases.generation.confirm_prompts', return_value=None):
-      with patch('wptgen.phases.generation.generate_safe', return_value=llm_response):
-        res = await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
-
-  assert len(res) == 2
-
-  test_file = Path(mock_config.output_dir) / 'feat-001.html'
-  ref_file = Path(mock_config.output_dir) / 'feat-001-ref.html'
-
-  assert test_file.exists()
-  assert ref_file.exists()
-
-  assert '<link rel="match"' in test_file.read_text()
-  assert '<p>Reference</p>' in ref_file.read_text()
-
-
-@pytest.mark.asyncio
-async def test_run_test_evaluation_dynamic_style_guides(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock
-) -> None:
-  """Verify that different test types load different style guides during evaluation."""
-  generated_tests = [
-    (
-      Path('js_test.html'),
-      'content',
-      '<test_suggestion><test_type>JavaScript Test</test_type></test_suggestion>',
-    ),
-    (
-      Path('ref_test.html'),
-      'content',
-      '<test_suggestion><test_type>Reftest</test_type></test_suggestion>',
-    ),
-    (
-      Path('crash_test.html'),
-      'content',
-      '<test_suggestion><test_type>Crashtest</test_type></test_suggestion>',
-    ),
-  ]
-  context = WorkflowContext(feature_id='feat')
-
-  jinja_env = MagicMock()
-  system_template_mock = MagicMock()
-  eval_template_mock = MagicMock()
-
-  def get_template_side_effect(name: str) -> MagicMock:
-    if name == 'evaluation_system.jinja':
-      return system_template_mock
-    return eval_template_mock
-
-  jinja_env.get_template.side_effect = get_template_side_effect
-
-  with patch('wptgen.phases.evaluation.Path.read_text', autospec=True) as mock_read:
-    mock_read.side_effect = lambda self, encoding='utf-8': f'Content of {self.name}'
-
-    with patch('wptgen.phases.evaluation.generate_safe', return_value='PASS'):
-      from wptgen.phases.evaluation import run_test_evaluation
-
-      await run_test_evaluation(context, mock_config, mock_llm, mock_ui, jinja_env, generated_tests)
-
-  # Check that system_template_mock.render was called 3 times with different style guides
-  assert system_template_mock.render.call_count == 3
-  calls = system_template_mock.render.call_args_list
-
-  assert calls[0].kwargs['test_type'] == 'JavaScript Test'
-  assert calls[0].kwargs['test_type_guide'] == 'Content of javascript_html_style_guide.md'
-
-  assert calls[2].kwargs['test_type'] == 'Crashtest'
-  assert calls[2].kwargs['test_type_guide'] == 'Content of crashtest_style_guide.md'
-
-
-def test_display_audit_table_sorting(mock_ui: MagicMock) -> None:
-  """Test _display_audit_table sorts IDs numerically."""
-  # Unordered worksheet with IDs that would sort incorrectly lexicographically (R10 before R2)
-  worksheet = (
-    'R10: Req 10 -> [UNCOVERED]\nR2: Req 2 -> [COVERED by t.html]\nR1: Req 1 -> [UNCOVERED]'
-  )
-  _display_audit_table(worksheet, mock_ui)
-
-  mock_ui.display_table.assert_called_once()
-  table = mock_ui.display_table.call_args[0][0]
-  assert len(table.rows) == 3
-
-  # Check sorting: R1, R2, R10
-  assert table.columns[0]._cells[0] == 'R1'
-  assert table.columns[0]._cells[1] == 'R2'
-  assert table.columns[0]._cells[2] == 'R10'
-
-
-def test_display_audit_table_valid(mock_ui: MagicMock) -> None:
-  """Test _display_audit_table with valid worksheet content."""
-  worksheet = 'R1: Requirement 1 -> [COVERED by test.html]\nR2: Requirement 2 -> [UNCOVERED]'
-  _display_audit_table(worksheet, mock_ui)
-
-  mock_ui.display_table.assert_called_once()
-  table = mock_ui.display_table.call_args[0][0]
-  assert table.title == 'Coverage Audit Worksheet'
-  assert len(table.rows) == 2
-
-  # Check first row by inspecting the data in each column
-  # In rich.Table, cells are stored in columns
-  assert table.columns[0]._cells[0] == 'R1'
-  assert table.columns[1]._cells[0] == 'Requirement 1'
-  assert '[green]' in table.columns[2]._cells[0]
-
-  # Check second row
-  assert table.columns[0]._cells[1] == 'R2'
-  assert table.columns[1]._cells[1] == 'Requirement 2'
-  assert '[bold red]' in table.columns[2]._cells[1]
-
-
-def test_display_audit_table_empty(mock_ui: MagicMock) -> None:
-  """Test _display_audit_table with empty worksheet content."""
-  _display_audit_table('', mock_ui)
-
-  mock_ui.display_table.assert_called_once()
-  table = mock_ui.display_table.call_args[0][0]
-  assert len(table.rows) == 0
-
-
-def test_display_audit_table_no_matches(mock_ui: MagicMock) -> None:
-  """Test _display_audit_table with content that doesn't match the regex."""
-  worksheet = 'Invalid format line\nAnother invalid line'
-  _display_audit_table(worksheet, mock_ui)
-
-  mock_ui.display_table.assert_called_once()
-  table = mock_ui.display_table.call_args[0][0]
-  assert len(table.rows) == 0
+  mock_ui.report_audit_worksheet.assert_called_once()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from rich.table import Table
 
+from wptgen.models import WebFeatureMetadata
 from wptgen.ui import RichUIProvider
 
 
@@ -38,13 +39,6 @@ def test_print(ui: RichUIProvider, mock_console: MagicMock) -> None:
   mock_console.print.assert_called_once_with('test message', style='bold red')
 
 
-def test_rule(ui: RichUIProvider, mock_console: MagicMock) -> None:
-  """Test that the rule method correctly delegates to the rich console."""
-  ui.rule('test title', style='green')
-  assert mock_console.print.call_count == 2
-  mock_console.rule.assert_called_once_with('[bold green]test title')
-
-
 def test_status(ui: RichUIProvider, mock_console: MagicMock) -> None:
   """Test that the status method correctly delegates to the rich console."""
   ui.status('loading...')
@@ -60,37 +54,86 @@ def test_confirm(mock_ask: MagicMock, ui: RichUIProvider) -> None:
   mock_ask.assert_called_once_with('Are you sure?', default=True)
 
 
-def test_display_markdown(ui: RichUIProvider, mock_console: MagicMock) -> None:
-  """Test that display_markdown correctly renders markdown content."""
-  ui.display_markdown('# Hello')
-  mock_console.print.assert_called_once()
-  args, _ = mock_console.print.call_args
-  assert args[0].markup == '# Hello'
+def test_info(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test the info semantic method."""
+  ui.info('info message')
+  mock_console.print.assert_called_once_with('[blue]ℹ[/blue] info message')
 
 
-def test_display_panel(ui: RichUIProvider, mock_console: MagicMock) -> None:
-  """Test that display_panel correctly renders a rich panel."""
-  ui.display_panel('panel content', title='Panel Title', border_style='red')
+def test_success(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test the success semantic method."""
+  ui.success('success message')
+  mock_console.print.assert_called_once_with('[bold green]✔[/bold green] success message')
+
+
+def test_warning(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test the warning semantic method."""
+  ui.warning('warning message')
+  mock_console.print.assert_called_once_with('[yellow]⚠[/yellow] warning message')
+
+
+def test_error(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test the error semantic method."""
+  ui.error('error message')
+  mock_console.print.assert_called_once_with('[bold red]✘[/bold red] error message')
+
+
+def test_on_phase_start(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test on_phase_start semantic method."""
+  ui.on_phase_start(1, 'Test Phase')
+  mock_console.rule.assert_called_once_with('[bold cyan]Phase 1: Test Phase')
+
+
+def test_report_metadata(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test report_metadata semantic method."""
+  metadata = WebFeatureMetadata('Feat', 'Desc', ['http://spec'])
+  ui.report_metadata(metadata)
   mock_console.print.assert_called_once()
   args, _ = mock_console.print.call_args
   panel = args[0]
-  assert panel.renderable == 'panel content'
-  assert panel.title == '[bold]Panel Title[/bold]'
-  assert panel.border_style == 'red'
+  assert panel.title == '[bold]Feature Metadata[/bold]'
 
 
-def test_display_table(ui: RichUIProvider, mock_console: MagicMock) -> None:
-  """Test that display_table correctly renders a rich table."""
-  table = Table()
-  ui.display_table(table)
-  mock_console.print.assert_called_once_with(table)
+def test_report_token_usage(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test report_token_usage semantic method."""
+  ui.report_token_usage('Phase', 'Model', [(100, False, 'Task')], 100)
+  mock_console.print.assert_called_once()
 
 
-def test_display_syntax(ui: RichUIProvider, mock_console: MagicMock) -> None:
-  """Test that display_syntax correctly renders syntax-highlighted code in a panel."""
-  with patch.object(ui, 'display_panel') as mock_display_panel:
-    ui.display_syntax("print('hi')", 'python', 'Test Syntax')
-    mock_display_panel.assert_called_once()
-    args, kwargs = mock_display_panel.call_args
-    assert kwargs['title'] == 'LLM Response: Test Syntax'
-    assert kwargs['border_style'] == 'cyan'
+def test_report_llm_response(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test report_llm_response semantic method."""
+  ui.report_llm_response('response', 'Task')
+  mock_console.print.assert_called_once()
+
+
+def test_report_coverage_audit(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test report_coverage_audit semantic method."""
+  ui.report_coverage_audit('audit response')
+  # Rule + Print
+  assert mock_console.rule.call_count == 1
+
+
+def test_report_audit_worksheet(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test report_audit_worksheet semantic method."""
+  ui.report_audit_worksheet('R1: Req -> [UNCOVERED]')
+  # Table + Print newline
+  assert mock_console.print.call_count == 2
+
+
+def test_report_test_suggestion(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test report_test_suggestion semantic method."""
+  ui.report_test_suggestion(1, 'Title', 'Desc', 'Type')
+  mock_console.print.assert_called_once()
+
+
+def test_report_generation_summary(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test report_generation_summary semantic method."""
+  ui.report_generation_summary([(Path('p'), 'c', 's')])
+  # Newline + Table + Success message
+  assert mock_console.print.call_count == 3
+
+
+def test_report_evaluation_result(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test report_evaluation_result semantic method."""
+  ui.report_evaluation_result('test.html', success=True)
+  mock_console.print.assert_called_once_with('[green]✔ test.html passed evaluation.[/green]')

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -81,7 +81,7 @@ class WPTGenEngine:
         data = json.load(f)
       return WorkflowContext.from_dict(data)
     except (json.JSONDecodeError, KeyError, TypeError) as e:
-      self.ui.print(f'[yellow]⚠ Failed to load resume state: {e}. Starting fresh.[/yellow]')
+      self.ui.warning(f'Failed to load resume state: {e}. Starting fresh.')
       return None
 
   async def _run_async_workflow(self, web_feature_id: str) -> None:
@@ -90,7 +90,7 @@ class WPTGenEngine:
     if self.config.resume:
       context = self._load_resume_state(web_feature_id)
       if context:
-        self.ui.print(f'[bold green]✔ Resuming workflow for {web_feature_id}[/bold green]')
+        self.ui.success(f'Resuming workflow for {web_feature_id}')
 
     # Phase 1: Context Assembly
     if not context or not context.wpt_context:
@@ -141,7 +141,7 @@ class WPTGenEngine:
       context.generated_tests = generated_tests
       self._save_resume_state(context)
     else:
-      self.ui.print('[bold green]✔ Skipping Phase 4: Tests already generated.[/bold green]')
+      self.ui.success('Skipping Phase 4: Tests already generated.')
 
     # Phase 5: Evaluation
     if context.generated_tests:

--- a/wptgen/phases/context_assembly.py
+++ b/wptgen/phases/context_assembly.py
@@ -14,8 +14,6 @@
 
 import asyncio
 
-from rich.table import Table
-
 from wptgen.config import Config
 from wptgen.context import (
   WebFeatureMetadata,
@@ -33,24 +31,22 @@ from wptgen.ui import UIProvider
 async def run_context_assembly(
   web_feature_id: str, config: Config, ui: UIProvider
 ) -> WorkflowContext | None:
-  ui.rule('Phase 1: Context Assembly')
+  ui.on_phase_start(1, 'Context Assembly')
 
   feature_data = fetch_feature_yaml(web_feature_id)
   if not feature_data:
     if config.spec_urls and config.feature_description:
-      ui.print(
-        f'[yellow]Warning:[/yellow] Feature [bold]{web_feature_id}[/bold] not found in the web-features repository.'
-      )
+      ui.warning(f'Feature {web_feature_id} not found in the web-features repository.')
       metadata = WebFeatureMetadata(
         name=web_feature_id,
         description=config.feature_description,
         specs=config.spec_urls,
       )
     else:
-      ui.print(f'[bold red]Error:[/bold red] Feature {web_feature_id} not found.')
+      ui.error(f'Feature {web_feature_id} not found.')
       ui.print(
-        'To generate tests for an unregistered feature, please provide both a spec URL using [bold]--spec-urls[/bold] '
-        'and a description using [bold]--description[/bold].'
+        'To generate tests for an unregistered feature, please provide both a spec URL using --spec-urls '
+        'and a description using --description.'
       )
       return None
   else:
@@ -61,22 +57,17 @@ async def run_context_assembly(
       metadata.description = config.feature_description
 
   if not metadata.specs:
-    ui.print('[bold red]Error:[/bold red] No specification URL found.')
+    ui.error('No specification URL found.')
     return None
 
-  metadata_table = Table(show_header=False, box=None, padding=(0, 2))
-  metadata_table.add_row('[bold]Web Feature Name:[/bold]', f'[cyan]{metadata.name}[/cyan]')
-  metadata_table.add_row('[bold]Description:[/bold]', metadata.description)
-  metadata_table.add_row('[bold]Spec URL:[/bold]', f'[blue]{metadata.specs[0]}[/blue]')
-
-  ui.display_panel(metadata_table, title='Feature Metadata')
+  ui.report_metadata(metadata)
 
   ui.print('\nFetching spec content...')
-  with ui.status('[blue]Fetching and extracting text...[/blue]'):
+  with ui.status('Fetching and extracting text...'):
     spec_contents = fetch_and_extract_text(metadata.specs[0])
 
   if not spec_contents:
-    ui.print('[bold red]Error:[/bold red] Failed to extract spec content.')
+    ui.error('Failed to extract spec content.')
     return None
 
   ui.print('Scanning local WPT repository for existing tests and dependencies...')
@@ -87,7 +78,7 @@ async def run_context_assembly(
   mdn_contents: list[str] | None = None
   mdn_urls = fetch_mdn_urls(web_feature_id)
   if mdn_urls:
-    with ui.status(f'[blue]Fetching {len(mdn_urls)} MDN pages...[/blue]'):
+    with ui.status(f'Fetching {len(mdn_urls)} MDN pages...'):
       # Fetch all MDN pages asynchronously using to_thread for the synchronous fetch_and_extract_text
       results = await asyncio.gather(
         *[asyncio.to_thread(fetch_and_extract_text, url) for url in mdn_urls]
@@ -98,11 +89,11 @@ async def run_context_assembly(
         if res
       ]
 
-  ui.print(
-    f'✔ Context gathered: {len(spec_contents)} chars of spec, '
-    f'{len(mdn_contents) if mdn_contents else 0} MDN pages, '
-    f'{len(wpt_context.test_contents)} tests, '
-    f'{len(wpt_context.dependency_contents)} dependency files.'
+  ui.report_context_summary(
+    len(spec_contents),
+    len(mdn_contents) if mdn_contents else 0,
+    len(wpt_context.test_contents),
+    len(wpt_context.dependency_contents),
   )
 
   return WorkflowContext(

--- a/wptgen/phases/coverage_audit.py
+++ b/wptgen/phases/coverage_audit.py
@@ -33,7 +33,7 @@ async def run_coverage_audit(
   ui: UIProvider,
   jinja_env: Environment,
 ) -> str | None:
-  ui.rule('Phase 3: Coverage Audit')
+  ui.on_phase_start(3, 'Coverage Audit')
 
   audit_prompt = jinja_env.get_template('coverage_audit.jinja').render(
     requirements_list_xml=context.requirements_xml,
@@ -67,10 +67,8 @@ async def run_coverage_audit(
 
 async def provide_coverage_report(context: WorkflowContext, config: Config, ui: UIProvider) -> None:
   """Prints the coverage audit report and optionally saves it to a file."""
-  ui.rule('Coverage Audit Report')
   assert context.audit_response is not None
-  ui.display_markdown(context.audit_response)
-  ui.print()
+  ui.report_coverage_audit(context.audit_response)
 
   if ui.confirm('\nSave report to a file?'):
     # Create a sanitized filename from the feature ID
@@ -81,6 +79,6 @@ async def provide_coverage_report(context: WorkflowContext, config: Config, ui: 
     try:
       output_path.parent.mkdir(parents=True, exist_ok=True)
       output_path.write_text(context.audit_response, encoding='utf-8')
-      ui.print(f'[green]Saved:[/green] {output_path.absolute()}')
+      ui.success(f'Saved: {output_path.absolute()}')
     except Exception as e:
-      ui.print(f'[bold red]Error saving file:[/bold red] {e}')
+      ui.error(f'Error saving file: {e}')

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -35,14 +35,14 @@ async def run_test_evaluation(
   generated_tests: list[tuple[Path, str, str]],
 ) -> None:
   """Runs the evaluation phase for generated tests."""
-  ui.rule('Phase 5: Evaluation')
+  ui.on_phase_start(5, 'Evaluation')
 
   # Group tests by their suggestion XML to handle multi-file tests (Reftests) together
   grouped_tests: dict[str, list[tuple[Path, str]]] = defaultdict(list)
   for path, content, suggestion_xml in generated_tests:
     grouped_tests[suggestion_xml].append((path, content))
 
-  ui.print(f'Evaluating [bold]{len(grouped_tests)}[/bold] test suggestions...')
+  ui.report_evaluation_start(len(grouped_tests))
 
   # Load the general style guide
   resources_path = Path(__file__).parent.parent / 'templates' / 'resources'
@@ -103,7 +103,7 @@ async def run_test_evaluation(
     tasks.append(_evaluate_and_update(group, prompt, llm, ui, config, system_instruction))
 
   await asyncio.gather(*tasks)
-  ui.print('\n[bold green]✔ Evaluation phase complete.[/bold green]')
+  ui.on_phase_complete('Evaluation')
 
 
 async def _evaluate_and_update(
@@ -116,7 +116,7 @@ async def _evaluate_and_update(
 ) -> None:
   """Evaluates a single test (or multi-file test) and updates the file(s) if needed."""
   display_names = ', '.join([p.name for p, _ in files])
-  ui.print(f'Evaluating: [bold]{display_names}[/bold]...')
+  ui.print(f'Evaluating: {display_names}...')
 
   response = await generate_safe(
     prompt,
@@ -130,13 +130,15 @@ async def _evaluate_and_update(
   )
 
   if not response:
-    ui.print(f'[yellow]⚠ No response for evaluation of {display_names}. Keeping original.[/yellow]')
+    ui.report_evaluation_result(
+      display_names, success=False, message=f'No response for evaluation of {display_names}.'
+    )
     return
 
   clean_response = response.strip()
 
   if clean_response == 'PASS':
-    ui.print(f'[green]✔ {display_names} passed evaluation.[/green]')
+    ui.report_evaluation_result(display_names, success=True)
   else:
     # If it's not PASS, it should be the corrected file content
     # Check if we have multiple files in the response
@@ -152,22 +154,24 @@ async def _evaluate_and_update(
         _, fcontent = multi_files[0]
         clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
         p.write_text(clean_content, encoding='utf-8')
-        ui.print(f'[cyan]ℹ {p.name} was corrected and updated.[/cyan]')
+        ui.report_evaluation_result(p.name, success=True, updated=True)
 
       if len(multi_files) >= 2 and ref_path_item:
         p, _ = ref_path_item
         _, fcontent = multi_files[1]
         clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
         p.write_text(clean_content, encoding='utf-8')
-        ui.print(f'[cyan]ℹ {p.name} was corrected and updated.[/cyan]')
+        ui.report_evaluation_result(p.name, success=True, updated=True)
     else:
       # If it's a single file correction
       if len(files) == 1:
         path = files[0][0]
         clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', clean_response).strip()
         path.write_text(clean_content, encoding='utf-8')
-        ui.print(f'[cyan]ℹ {path.name} was corrected and updated.[/cyan]')
+        ui.report_evaluation_result(path.name, success=True, updated=True)
       else:
-        ui.print(
-          f'[yellow]⚠ Received single-file correction for multi-file test {display_names}. Skipping.[/yellow]'
+        ui.report_evaluation_result(
+          display_names,
+          success=False,
+          message=f'Received single-file correction for multi-file test {display_names}. Skipping.',
         )

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 import asyncio
-import re
 from pathlib import Path
 
 from jinja2 import Environment
-from rich.table import Table
 
 from wptgen.config import Config
 from wptgen.llm import LLMClient
@@ -40,7 +38,7 @@ async def run_test_generation(
   ui: UIProvider,
   jinja_env: Environment,
 ) -> list[tuple[Path, str, str]]:
-  ui.rule('Phase 4: User Selection & Generation')
+  ui.on_phase_start(4, 'User Selection & Generation')
 
   assert context.audit_response is not None
   assert context.metadata is not None
@@ -48,26 +46,22 @@ async def run_test_generation(
   # Check for satisfaction status
   status = extract_xml_tag(context.audit_response, 'status')
   if status and status.strip() == 'SATISFIED':
-    ui.display_panel(
-      '[bold green]All identified test requirements have been satisfied.[/bold green]\n'
-      '[italic]No new test suggestions were generated because existing coverage is sufficient.[/italic]',
-      title='Status',
-      border_style='green',
-    )
+    ui.success('All identified test requirements have been satisfied.')
+    ui.info('No new test suggestions were generated because existing coverage is sufficient.')
     return []
 
   # Display the audit worksheet in a formatted table
   audit_worksheet = extract_xml_tag(context.audit_response, 'audit_worksheet')
   if audit_worksheet:
-    _display_audit_table(audit_worksheet, ui)
+    ui.report_audit_worksheet(audit_worksheet)
 
   suggestions = parse_suggestions(context.audit_response)
 
   if not suggestions:
-    ui.print('[yellow]No valid <test_suggestion> blocks found in the LLM response.[/yellow]')
+    ui.warning('No valid <test_suggestion> blocks found in the LLM response.')
     return []
 
-  ui.print(f'[bold green]{len(suggestions)}[/bold green] new test suggestions found!\n')
+  ui.success(f'{len(suggestions)} new test suggestions found!\n')
 
   approved_suggestions_xml = []
   for i, suggestion in enumerate(suggestions):
@@ -75,16 +69,12 @@ async def run_test_generation(
     description = extract_xml_tag(suggestion, 'description') or 'No description provided.'
     test_type = extract_xml_tag(suggestion, 'test_type') or 'Unknown'
 
-    ui.display_panel(
-      f'[bold cyan]Description:[/bold cyan] {description}\n'
-      f'[bold cyan]Test Type:[/bold cyan] {test_type}',
-      title=f'[bold cyan] Test Suggestion #{i + 1}:[/bold cyan] [white]{title}[/white]',
-    )
+    ui.report_test_suggestion(i + 1, title, description, test_type)
     if ui.confirm('Generate this test?'):
       approved_suggestions_xml.append(suggestion)
 
   if not approved_suggestions_xml:
-    ui.print('[yellow]No tests selected. Exiting.[/yellow]')
+    ui.warning('No tests selected. Exiting.')
     return []
 
   # Load the general style guide
@@ -149,7 +139,7 @@ async def run_test_generation(
     model=config.get_model_for_phase('generation'),
   )
 
-  ui.print(f'\nGenerating [bold]{len(prompts_to_confirm)}[/bold] tests in parallel...')
+  ui.report_generation_start(len(prompts_to_confirm))
 
   tasks = [
     _generate_and_save(
@@ -162,52 +152,9 @@ async def run_test_generation(
   # Flatten the list of lists (each task returns a list of files)
   final_results = [r for sublist in results for r in sublist]
 
-  if final_results:
-    summary_table = Table(
-      title='Generated Tests Summary', show_header=True, header_style='bold green'
-    )
-    summary_table.add_column('File Name', style='cyan')
-    summary_table.add_column('Full Path', style='dim')
-
-    for p, _content, _s_xml in final_results:
-      summary_table.add_row(p.name, str(p.absolute()))
-
-    ui.print()
-    ui.display_table(summary_table)
-    ui.print(f'\n[bold green]✔ {len(final_results)} tests generated successfully.[/bold green]')
-  else:
-    ui.print('\n[bold red]✘ No tests were successfully generated.[/bold red]')
+  ui.report_generation_summary(final_results)
 
   return final_results
-
-
-def _display_audit_table(worksheet_text: str, ui: UIProvider) -> None:
-  """Parses the audit worksheet text and displays it as a formatted table."""
-  table = Table(title='Coverage Audit Worksheet', show_header=True, header_style='bold cyan')
-  table.add_column('ID', style='dim')
-  table.add_column('Requirement')
-  table.add_column('Status', justify='center')
-
-  # Regex to parse lines like: R1: [Requirement Text] -> [COVERED by filename.html]
-  # or R1: [Requirement Text] -> [UNCOVERED]
-  pattern = re.compile(r'^(R\d+):\s*(.*)\s*->\s*\[(.*)\]', re.MULTILINE)
-
-  matches = list(pattern.finditer(worksheet_text))
-  # Sort by numerical value of the ID (e.g., R1, R2, R10)
-  matches.sort(key=lambda m: int(m.group(1)[1:]))
-
-  for match in matches:
-    req_id, req_text, status_info = match.groups()
-
-    if 'UNCOVERED' in status_info.upper():
-      status_display = f'[bold red]✘ {status_info}[/bold red]'
-    else:
-      status_display = f'[green]✔ {status_info}[/green]'
-
-    table.add_row(req_id, req_text.strip(), status_display)
-
-  ui.display_table(table)
-  ui.print()
 
 
 async def _generate_and_save(
@@ -221,7 +168,7 @@ async def _generate_and_save(
   temperature: float | None = None,
 ) -> list[tuple[Path, str, str]]:
   """Helper to generate specific test file(s) and save to disk."""
-  ui.print(f'Starting generation for: [bold]{root_name}[/bold]...')
+  ui.print(f'Starting generation for: {root_name}...')
 
   content = await generate_safe(
     prompt,
@@ -235,6 +182,7 @@ async def _generate_and_save(
   )
 
   if not content:
+    ui.report_test_generated(root_name, success=False)
     return []
 
   results = []
@@ -256,14 +204,14 @@ async def _generate_and_save(
       clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
       output_path = output_dir / fname
       output_path.write_text(clean_content, encoding='utf-8')
-      ui.print(f'[green]✔ Saved:[/green] {output_path.absolute()}')
+      ui.report_test_generated(root_name, success=True, path=output_path)
       results.append((output_path, clean_content, suggestion_xml))
   else:
     # Single file fallback - if the LLM failed to use partitioning tags, default to .html
     clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', content).strip()
     output_path = output_dir / f'{root_name}.html'
     output_path.write_text(clean_content, encoding='utf-8')
-    ui.print(f'[green]✔ Saved (fallback):[/green] {output_path.absolute()}')
+    ui.report_test_generated(root_name, success=True, path=output_path, fallback=True)
     results.append((output_path, clean_content, suggestion_xml))
 
   return results

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -32,7 +32,7 @@ async def run_requirements_extraction(
   jinja_env: Environment,
   cache_dir: Path,
 ) -> str | None:
-  ui.rule('Phase 2: Requirements Extraction')
+  ui.on_phase_start(2, 'Requirements Extraction')
 
   assert context.metadata is not None
 
@@ -41,10 +41,10 @@ async def run_requirements_extraction(
   requirements_xml = None
 
   if cache_file.exists():
-    ui.print(f'[yellow]Found cached requirements for {web_feature_id}.[/yellow]')
+    ui.info(f'Found cached requirements for {web_feature_id}.')
     if ui.confirm('Use cached requirements?'):
       requirements_xml = cache_file.read_text(encoding='utf-8')
-      ui.print('✔ Using cached requirements.')
+      ui.success('Using cached requirements.')
 
   if not requirements_xml:
     extraction_prompt = jinja_env.get_template('requirements_extraction.jinja').render(
@@ -96,7 +96,7 @@ async def run_requirements_extraction_iterative(
   jinja_env: Environment,
   cache_dir: Path,
 ) -> str | None:
-  ui.rule('Phase 2: Requirements Extraction (Iterative)')
+  ui.on_phase_start(2, 'Requirements Extraction (Iterative)')
 
   assert context.metadata is not None
 
@@ -105,10 +105,10 @@ async def run_requirements_extraction_iterative(
   requirements_xml = None
 
   if cache_file.exists():
-    ui.print(f'[yellow]Found cached requirements for {web_feature_id}.[/yellow]')
+    ui.info(f'Found cached requirements for {web_feature_id}.')
     if ui.confirm('Use cached requirements?'):
       requirements_xml = cache_file.read_text(encoding='utf-8')
-      ui.print('✔ Using cached requirements.')
+      ui.success('Using cached requirements.')
 
   if not requirements_xml:
     all_requirements: list[str] = []
@@ -156,14 +156,14 @@ async def run_requirements_extraction_iterative(
         break
 
       if '<status>EXHAUSTED</status>' in response:
-        ui.print(f'✔ Extraction complete: LLM signaled exhaustion at iteration {iteration}.')
+        ui.success(f'Extraction complete: LLM signaled exhaustion at iteration {iteration}.')
         break
 
       # Extract individual <requirement> blocks.
       new_reqs = re.findall(r'(<requirement.*?>.*?</requirement>)', response, re.DOTALL)
 
       if not new_reqs:
-        ui.print('[yellow]No new requirements found in this iteration. Stopping.[/yellow]')
+        ui.warning('No new requirements found in this iteration. Stopping.')
         break
 
       ui.print(f'  - Found {len(new_reqs)} new requirements.')
@@ -179,10 +179,10 @@ async def run_requirements_extraction_iterative(
       iteration += 1
     else:
       if iteration > max_iterations:
-        ui.print(f'[yellow]Reached maximum iterations ({max_iterations}).[/yellow]')
+        ui.warning(f'Reached maximum iterations ({max_iterations}).')
 
     if not all_requirements:
-      ui.print('[red]No requirements extracted.[/red]')
+      ui.error('No requirements extracted.')
       return None
 
     requirements_xml = (

--- a/wptgen/phases/utils.py
+++ b/wptgen/phases/utils.py
@@ -15,7 +15,6 @@
 import asyncio
 
 import typer
-from rich.table import Table
 
 from wptgen.config import Config
 from wptgen.llm import LLMClient
@@ -34,48 +33,31 @@ async def confirm_prompts(
   loop = asyncio.get_running_loop()
 
   total_tokens = 0
-  any_limit_exceeded = False
   target_model = model or llm.model
 
-  with ui.status(f'[yellow]Calculating token usage for {phase_name} ({target_model})...[/yellow]'):
+  with ui.status(f'Calculating token usage for {phase_name} ({target_model})...'):
     # We do token counting concurrently for speed
     async def get_info(prompt: str, name: str) -> tuple[int, bool, str]:
-      tokens = await loop.run_in_executor(None, llm.count_tokens, prompt, model)
+      tokens = await loop.run_in_executor(None, llm.count_tokens, prompt, target_model)
       limit_exceeded = await loop.run_in_executor(
-        None, llm.prompt_exceeds_input_token_limit, prompt, model
+        None, llm.prompt_exceeds_input_token_limit, prompt, target_model
       )
       return tokens, limit_exceeded, name
 
     results = await asyncio.gather(*(get_info(p, n) for p, n in prompt_data))
 
-  table = Table(
-    title=f'Token Usage Summary ({phase_name})', show_header=True, header_style='bold magenta'
-  )
-  table.add_column('Task', style='dim')
-  table.add_column('Model', style='blue')
-  table.add_column('Tokens', justify='right', style='cyan')
-  table.add_column('Status', justify='center')
-
-  for tokens, limit_exceeded, name in results:
+  for tokens, _, _ in results:
     total_tokens += tokens
-    status = '[bold red]EXCEEDED[/bold red]' if limit_exceeded else '[bold green]OK[/bold green]'
-    table.add_row(name, target_model, str(tokens), status)
-    if limit_exceeded:
-      any_limit_exceeded = True
 
-  ui.display_table(table)
-  if len(prompt_data) > 1:
-    ui.print(f'[bold]Total Estimated Tokens:[/bold] [cyan]{total_tokens}[/cyan]')
-
-  if any_limit_exceeded:
-    ui.print('\n[bold red]Warning:[/bold red] One or more prompts exceed the model context limit!')
+  ui.report_token_usage(
+    phase_name, target_model, results, total_tokens, auto_confirmed=config.yes_tokens
+  )
 
   if config.yes_tokens:
-    ui.print('\n[yellow]Auto-confirming token usage (--yes-tokens).[/yellow]')
     return
 
   if not ui.confirm('\nProceed with these LLM requests?'):
-    ui.print('[yellow]Aborting workflow due to user cancellation.[/yellow]')
+    ui.warning('Aborting workflow due to user cancellation.')
     raise typer.Abort()
 
 
@@ -93,20 +75,15 @@ async def generate_safe(
   target_model = model or llm.model
   try:
     loop = asyncio.get_running_loop()
-    with ui.status(f'[blue]Executing {task_name} ({target_model})...[/blue]'):
+    with ui.status(f'Executing {task_name} ({target_model})...'):
       response = await loop.run_in_executor(
         None, llm.generate_content, prompt, system_instruction, temperature, model
       )
 
-    ui.print(f'✔ {task_name} finished (using {target_model}).')
+    ui.success(f'{task_name} finished (using {target_model}).')
     if config.show_responses:
-      # Determine syntax highlighting based on content (defaulting to xml).
-      syntax_lexer = 'xml'
-      if 'gen:' in task_name.lower():
-        syntax_lexer = 'html'
-
-      ui.display_syntax(response, syntax_lexer, task_name)
+      ui.report_llm_response(response, task_name)
     return response
   except Exception as e:
-    ui.print(f'[bold red]✘ {task_name} failed ({target_model}):[/bold red] {e}')
+    ui.error(f'{task_name} failed ({target_model}): {e}')
     return ''

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -12,41 +12,77 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import AbstractContextManager
-from typing import Any, Protocol
+from __future__ import annotations
 
-from rich.console import Console, RenderableType
+import re
+from contextlib import AbstractContextManager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.prompt import Confirm
 from rich.syntax import Syntax
 from rich.table import Table
 
+if TYPE_CHECKING:
+  from wptgen.models import WebFeatureMetadata
+
 
 class UIProvider(Protocol):
-  def print(self, message: Any = '', style: str | None = None) -> None: ...
-  def rule(self, title: str = '', style: str = 'cyan') -> None: ...
+  """Semantic UI interface for the WPT generation workflow."""
+
+  # Core interaction
   def status(self, message: str) -> AbstractContextManager[Any]: ...
   def confirm(self, question: str, default: bool = True) -> bool: ...
-  def display_markdown(self, content: str) -> None: ...
-  def display_panel(
-    self, content: RenderableType | str, title: str | None = None, border_style: str = 'blue'
+
+  # Generic semantic messaging
+  def print(self, message: Any = '', style: str | None = None) -> None: ...
+  def info(self, message: str) -> None: ...
+  def success(self, message: str) -> None: ...
+  def warning(self, message: str) -> None: ...
+  def error(self, message: str) -> None: ...
+
+  # Phase and lifecycle events
+  def on_phase_start(self, phase_num: int, phase_name: str) -> None: ...
+  def on_phase_complete(self, phase_name: str) -> None: ...
+
+  # Domain-specific reporting
+  def report_metadata(self, metadata: WebFeatureMetadata) -> None: ...
+  def report_context_summary(
+    self, spec_len: int, mdn_count: int, test_count: int, dep_count: int
   ) -> None: ...
-  def display_table(self, table: Table) -> None: ...
-  def display_syntax(self, code: str, lexer: str, title: str) -> None: ...
+  def report_token_usage(
+    self,
+    phase_name: str,
+    model: str,
+    results: list[tuple[int, bool, str]],
+    total_tokens: int,
+    auto_confirmed: bool = False,
+  ) -> None: ...
+  def report_llm_response(self, response: str, task_name: str) -> None: ...
+  def report_coverage_audit(self, audit_response: str) -> None: ...
+  def report_audit_worksheet(self, worksheet_text: str) -> None: ...
+  def report_test_suggestion(
+    self, suggestion_index: int, title: str, description: str, test_type: str
+  ) -> None: ...
+  def report_generation_start(self, count: int) -> None: ...
+  def report_test_generated(
+    self, root_name: str, success: bool, path: Path | None = None, fallback: bool = False
+  ) -> None: ...
+  def report_generation_summary(self, generated_tests: list[tuple[Path, str, str]]) -> None: ...
+  def report_evaluation_start(self, count: int) -> None: ...
+  def report_evaluation_result(
+    self, display_names: str, success: bool, updated: bool = False, message: str | None = None
+  ) -> None: ...
 
 
 class RichUIProvider:
+  """Rich-based implementation of the UIProvider protocol."""
+
   def __init__(self, console: Console | None = None):
     self.console = console or Console()
-
-  def print(self, message: Any = '', style: str | None = None) -> None:
-    self.console.print(message, style=style)
-
-  def rule(self, title: str = '', style: str = 'cyan') -> None:
-    self.console.print()
-    self.console.rule(f'[bold {style}]{title}')
-    self.console.print()
 
   def status(self, message: str) -> AbstractContextManager[Any]:
     return self.console.status(message)
@@ -54,24 +90,193 @@ class RichUIProvider:
   def confirm(self, question: str, default: bool = True) -> bool:
     return Confirm.ask(question, default=default)
 
-  def display_markdown(self, content: str) -> None:
-    self.console.print(Markdown(content))
+  def print(self, message: Any = '', style: str | None = None) -> None:
+    self.console.print(message, style=style)
 
-  def display_panel(
-    self, content: RenderableType | str, title: str | None = None, border_style: str = 'blue'
-  ) -> None:
+  def info(self, message: str) -> None:
+    self.console.print(f'[blue]ℹ[/blue] {message}')
+
+  def success(self, message: str) -> None:
+    self.console.print(f'[bold green]✔[/bold green] {message}')
+
+  def warning(self, message: str) -> None:
+    self.console.print(f'[yellow]⚠[/yellow] {message}')
+
+  def error(self, message: str) -> None:
+    self.console.print(f'[bold red]✘[/bold red] {message}')
+
+  def on_phase_start(self, phase_num: int, phase_name: str) -> None:
+    self.console.print()
+    self.console.rule(f'[bold cyan]Phase {phase_num}: {phase_name}')
+    self.console.print()
+
+  def on_phase_complete(self, phase_name: str) -> None:
+    self.success(f'{phase_name} complete.')
+
+  def report_metadata(self, metadata: WebFeatureMetadata) -> None:
+    metadata_table = Table(show_header=False, box=None, padding=(0, 2))
+    metadata_table.add_row('[bold]Web Feature Name:[/bold]', f'[cyan]{metadata.name}[/cyan]')
+    metadata_table.add_row('[bold]Description:[/bold]', metadata.description)
+    metadata_table.add_row('[bold]Spec URL:[/bold]', f'[blue]{metadata.specs[0]}[/blue]')
+
     self.console.print(
       Panel(
-        content,
-        title=f'[bold]{title}[/bold]' if title else None,
-        border_style=border_style,
+        metadata_table,
+        title='[bold]Feature Metadata[/bold]',
+        border_style='blue',
         expand=False,
       )
     )
 
-  def display_table(self, table: Table) -> None:
-    self.console.print(table)
+  def report_context_summary(
+    self, spec_len: int, mdn_count: int, test_count: int, dep_count: int
+  ) -> None:
+    self.success(
+      f'Context gathered: {spec_len} chars of spec, '
+      f'{mdn_count} MDN pages, '
+      f'{test_count} tests, '
+      f'{dep_count} dependency files.'
+    )
 
-  def display_syntax(self, code: str, lexer: str, title: str) -> None:
-    syntax = Syntax(code, lexer, theme='monokai', line_numbers=True, word_wrap=True)
-    self.display_panel(syntax, title=f'LLM Response: {title}', border_style='cyan')
+  def report_token_usage(
+    self,
+    phase_name: str,
+    model: str,
+    results: list[tuple[int, bool, str]],
+    total_tokens: int,
+    auto_confirmed: bool = False,
+  ) -> None:
+    table = Table(
+      title=f'Token Usage Summary ({phase_name})', show_header=True, header_style='bold magenta'
+    )
+    table.add_column('Task', style='dim')
+    table.add_column('Model', style='blue')
+    table.add_column('Tokens', justify='right', style='cyan')
+    table.add_column('Status', justify='center')
+
+    for tokens, limit_exceeded, name in results:
+      status = '[bold red]EXCEEDED[/bold red]' if limit_exceeded else '[bold green]OK[/bold green]'
+      table.add_row(name, model, str(tokens), status)
+
+    self.console.print(table)
+    if len(results) > 1:
+      self.console.print(f'[bold]Total Estimated Tokens:[/bold] [cyan]{total_tokens}[/cyan]')
+
+    if any(limit_exceeded for _, limit_exceeded, _ in results):
+      self.console.print(
+        '\n[bold red]Warning:[/bold red] One or more prompts exceed the model context limit!'
+      )
+
+    if auto_confirmed:
+      self.console.print('\n[yellow]Auto-confirming token usage (--yes-tokens).[/yellow]')
+
+  def report_llm_response(self, response: str, task_name: str) -> None:
+    # Determine syntax highlighting based on content (defaulting to xml).
+    syntax_lexer = 'xml'
+    if 'gen:' in task_name.lower():
+      syntax_lexer = 'html'
+
+    syntax = Syntax(response, syntax_lexer, theme='monokai', line_numbers=True, word_wrap=True)
+    self.console.print(
+      Panel(
+        syntax,
+        title=f'[bold]LLM Response: {task_name}[/bold]',
+        border_style='cyan',
+        expand=False,
+      )
+    )
+
+  def report_coverage_audit(self, audit_response: str) -> None:
+    self.console.print()
+    self.console.rule('[bold cyan]Coverage Audit Report')
+    self.console.print()
+    self.console.print(Markdown(audit_response))
+    self.console.print()
+
+  def report_audit_worksheet(self, worksheet_text: str) -> None:
+    table = Table(title='Coverage Audit Worksheet', show_header=True, header_style='bold cyan')
+    table.add_column('ID', style='dim')
+    table.add_column('Requirement')
+    table.add_column('Status', justify='center')
+
+    # Regex to parse lines like: R1: [Requirement Text] -> [COVERED by filename.html]
+    # or R1: [Requirement Text] -> [UNCOVERED]
+    pattern = re.compile(r'^(R\d+):\s*(.*)\s*->\s*\[(.*)\]', re.MULTILINE)
+
+    matches = list(pattern.finditer(worksheet_text))
+    # Sort by numerical value of the ID (e.g., R1, R2, R10)
+    matches.sort(key=lambda m: int(m.group(1)[1:]))
+
+    for match in matches:
+      req_id, req_text, status_info = match.groups()
+
+      if 'UNCOVERED' in status_info.upper():
+        status_display = f'[bold red]✘ {status_info}[/bold red]'
+      else:
+        status_display = f'[green]✔ {status_info}[/green]'
+
+      table.add_row(req_id, req_text.strip(), status_display)
+
+    self.console.print(table)
+    self.console.print()
+
+  def report_test_suggestion(
+    self, suggestion_index: int, title: str, description: str, test_type: str
+  ) -> None:
+    self.console.print(
+      Panel(
+        f'[bold cyan]Description:[/bold cyan] {description}\n'
+        f'[bold cyan]Test Type:[/bold cyan] {test_type}',
+        title=f'[bold cyan] Test Suggestion #{suggestion_index}:[/bold cyan] [white]{title}[/white]',
+        border_style='blue',
+        expand=False,
+      )
+    )
+
+  def report_generation_start(self, count: int) -> None:
+    self.console.print(f'\nGenerating [bold]{count}[/bold] tests in parallel...')
+
+  def report_test_generated(
+    self, root_name: str, success: bool, path: Path | None = None, fallback: bool = False
+  ) -> None:
+    if success:
+      if fallback:
+        self.console.print(f'[green]✔ Saved (fallback):[/green] {path.absolute() if path else ""}')
+      else:
+        self.console.print(f'[green]✔ Saved:[/green] {path.absolute() if path else ""}')
+    else:
+      self.error(f'Failed to generate: {root_name}')
+
+  def report_generation_summary(self, generated_tests: list[tuple[Path, str, str]]) -> None:
+    if generated_tests:
+      summary_table = Table(
+        title='Generated Tests Summary', show_header=True, header_style='bold green'
+      )
+      summary_table.add_column('File Name', style='cyan')
+      summary_table.add_column('Full Path', style='dim')
+
+      for p, _content, _s_xml in generated_tests:
+        summary_table.add_row(p.name, str(p.absolute()))
+
+      self.console.print()
+      self.console.print(summary_table)
+      self.success(f'{len(generated_tests)} tests generated successfully.')
+    else:
+      self.error('No tests were successfully generated.')
+
+  def report_evaluation_start(self, count: int) -> None:
+    self.console.print(f'Evaluating [bold]{count}[/bold] test suggestions...')
+
+  def report_evaluation_result(
+    self, display_names: str, success: bool, updated: bool = False, message: str | None = None
+  ) -> None:
+    if success:
+      if updated:
+        self.console.print(f'[cyan]ℹ {display_names} was corrected and updated.[/cyan]')
+      else:
+        self.console.print(f'[green]✔ {display_names} passed evaluation.[/green]')
+    else:
+      if message:
+        self.warning(f'{message}')
+      else:
+        self.warning(f'Evaluation of {display_names} failed or was skipped.')


### PR DESCRIPTION
Fixes #80

**This change should have no effect on behavior.**

Introduces a semantic `UIProvider` protocol to separate presentation details from the core workflow phases.

- Defined a domain-specific `UIProvider` interface in `wptgen/ui.py` with methods like `on_phase_start`, `report_metadata`, and `report_token_usage`.
- Moved all `rich`-specific formatting, table construction, and markup logic into `RichUIProvider`.
- Refactored all workflow phases (`context_assembly`, `requirements_extraction`, `coverage_audit`, `generation`, `evaluation`) to use semantic UI calls.
- Removed UI-specific dependencies and markup strings from the core logic.
- Updated the test suite to align with the new semantic interface.

This change ensures that the core logic remains independent of the presentation layer while preserving the exact same console behavior.