### PR TITLE
Add `--use-lightweight` and `--use-reasoning` flags to generate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ wpt-gen generate grid
 | `--wpt-dir` | `-w` | Override the path to the local web-platform-tests repository. |
 | `--config` | `-c` | Path to a custom `wpt-gen.yml` file. |
 | `--show-responses`| `-s` | Display every LLM-generated response to the user. |
+| `--use-lightweight`| | Use the provider's lightweight model for all LLM requests. |
+| `--use-reasoning`| | Use the provider's reasoning model for all LLM requests. |
 
 
 ## Development

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -151,6 +151,48 @@ def test_load_config_detailed_requirements(monkeypatch: pytest.MonkeyPatch) -> N
   assert config.detailed_requirements is True
 
 
+def test_config_get_model_for_phase_overrides() -> None:
+  """Test that use_lightweight and use_reasoning override phase-specific models."""
+  config = Config(
+    provider='gemini',
+    default_model='default',
+    api_key='key',
+    wpt_path='.',
+    categories={'lightweight': 'light-model', 'reasoning': 'heavy-model'},
+    phase_model_mapping={'phase1': 'lightweight', 'phase2': 'reasoning'},
+  )
+
+  # Default behavior
+  assert config.get_model_for_phase('phase1') == 'light-model'
+  assert config.get_model_for_phase('phase2') == 'heavy-model'
+
+  # Lightweight override
+  config.use_lightweight = True
+  assert config.get_model_for_phase('phase1') == 'light-model'
+  assert config.get_model_for_phase('phase2') == 'light-model'
+
+  # Reasoning override (takes precedence if we set it, but we should test independently)
+  config.use_lightweight = False
+  config.use_reasoning = True
+  assert config.get_model_for_phase('phase1') == 'heavy-model'
+  assert config.get_model_for_phase('phase2') == 'heavy-model'
+
+
+def test_load_config_model_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Test that load_config correctly sets default_model based on flags."""
+  monkeypatch.setenv('GEMINI_API_KEY', 'mock-key')
+
+  # Case 1: use_lightweight_override
+  config = load_config(config_path='non_existent_dummy.yaml', use_lightweight_override=True)
+  assert config.use_lightweight is True
+  assert config.default_model == 'gemini-3-flash-preview'
+
+  # Case 2: use_reasoning_override
+  config = load_config(config_path='non_existent_dummy.yaml', use_reasoning_override=True)
+  assert config.use_reasoning is True
+  assert config.default_model == 'gemini-3.1-pro-preview'
+
+
 def test_get_default_cache_path_windows(monkeypatch: pytest.MonkeyPatch) -> None:
   """Test default cache path on Windows."""
   monkeypatch.setattr('sys.platform', 'win32')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -95,6 +95,8 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
   )
   mock_engine_class.assert_called_once()
   # Verify config was passed correctly
@@ -124,6 +126,8 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
   )
 
 
@@ -149,6 +153,8 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
   )
 
 
@@ -174,6 +180,8 @@ def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
   )
 
 
@@ -199,6 +207,8 @@ def test_generate_max_retries(mocker: MockerFixture, mock_config: Config) -> Non
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
   )
 
 
@@ -224,6 +234,8 @@ def test_generate_detailed_requirements(mocker: MockerFixture, mock_config: Conf
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=True,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
   )
 
 
@@ -280,6 +292,8 @@ def test_generate_spec_urls(mocker: MockerFixture, mock_config: Config) -> None:
     spec_urls_override=['https://url1.com', 'https://url2.com'],
     feature_description_override=None,
     detailed_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
   )
 
 
@@ -305,6 +319,8 @@ def test_generate_description(mocker: MockerFixture, mock_config: Config) -> Non
     spec_urls_override=None,
     feature_description_override='Test Description',
     detailed_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
   )
 
 
@@ -330,7 +346,73 @@ def test_generate_resume(mocker: MockerFixture, mock_config: Config) -> None:
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
   )
+
+
+def test_generate_use_lightweight(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test that the --use-lightweight flag is correctly passed to load_config."""
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+  mocker.patch('wptgen.main.WPTGenEngine')
+
+  # Run with --use-lightweight
+  result = runner.invoke(app, ['generate', 'grid', '--use-lightweight'])
+
+  assert result.exit_code == 0
+  mock_load_config.assert_called_once_with(
+    config_path=DEFAULT_CONFIG_PATH,
+    provider_override=None,
+    wpt_dir_override=None,
+    output_dir_override=None,
+    show_responses=False,
+    yes_tokens_override=False,
+    suggestions_only=False,
+    resume_override=False,
+    max_retries_override=3,
+    spec_urls_override=None,
+    feature_description_override=None,
+    detailed_requirements_override=False,
+    use_lightweight_override=True,
+    use_reasoning_override=False,
+  )
+
+
+def test_generate_use_reasoning(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test that the --use-reasoning flag is correctly passed to load_config."""
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+  mocker.patch('wptgen.main.WPTGenEngine')
+
+  # Run with --use-reasoning
+  result = runner.invoke(app, ['generate', 'grid', '--use-reasoning'])
+
+  assert result.exit_code == 0
+  mock_load_config.assert_called_once_with(
+    config_path=DEFAULT_CONFIG_PATH,
+    provider_override=None,
+    wpt_dir_override=None,
+    output_dir_override=None,
+    show_responses=False,
+    yes_tokens_override=False,
+    suggestions_only=False,
+    resume_override=False,
+    max_retries_override=3,
+    spec_urls_override=None,
+    feature_description_override=None,
+    detailed_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=True,
+  )
+
+
+def test_generate_mutually_exclusive_models(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test that providing both model flags results in an error."""
+  mocker.patch('wptgen.main.load_config', return_value=mock_config)
+
+  result = runner.invoke(app, ['generate', 'grid', '--use-lightweight', '--use-reasoning'])
+
+  assert result.exit_code == 1
+  assert 'Cannot use both --use-lightweight and --use-reasoning' in result.stdout
 
 
 def test_version_not_found(mocker: MockerFixture) -> None:

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -41,9 +41,15 @@ class Config:
   spec_urls: list[str] | None = None
   feature_description: str | None = None
   detailed_requirements: bool = False
+  use_lightweight: bool = False
+  use_reasoning: bool = False
 
   def get_model_for_phase(self, phase_name: str) -> str | None:
     """Resolves the model name for a given workflow phase."""
+    if self.use_lightweight:
+      return self.categories.get('lightweight')
+    if self.use_reasoning:
+      return self.categories.get('reasoning')
     category = self.phase_model_mapping.get(phase_name)
     if not category:
       return None
@@ -104,6 +110,8 @@ def load_config(
   spec_urls_override: list[str] | None = None,
   feature_description_override: str | None = None,
   detailed_requirements_override: bool = False,
+  use_lightweight_override: bool = False,
+  use_reasoning_override: bool = False,
   require_api_key: bool = True,
 ) -> Config:
   """
@@ -170,6 +178,11 @@ def load_config(
   default_model = provider_settings.get('default_model', default_model_name)
   categories = provider_settings.get('categories', default_categories)
 
+  if use_lightweight_override:
+    default_model = categories.get('lightweight', default_model)
+  elif use_reasoning_override:
+    default_model = categories.get('reasoning', default_model)
+
   # Ensure default mapping if missing in YAML
   default_phase_mapping = {
     'requirements_extraction': 'reasoning',
@@ -196,4 +209,6 @@ def load_config(
     spec_urls=spec_urls_override,
     feature_description=feature_description_override,
     detailed_requirements=detailed_requirements,
+    use_lightweight=use_lightweight_override,
+    use_reasoning=use_reasoning_override,
   )

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -128,6 +128,14 @@ def generate(
       help='Use a more detailed, iterative requirements extraction process.',
     ),
   ] = False,
+  use_lightweight: Annotated[
+    bool,
+    typer.Option('--use-lightweight', help='Use the lightweight model for all LLM requests.'),
+  ] = False,
+  use_reasoning: Annotated[
+    bool,
+    typer.Option('--use-reasoning', help='Use the reasoning model for all LLM requests.'),
+  ] = False,
 ) -> None:
   """
   Generate Web Platform Tests for a specific web feature.
@@ -144,6 +152,10 @@ def generate(
   console.print(banner)
   console.print(f'\n[bold]Target Feature:[/bold] [cyan]{web_feature_id}[/cyan]\n')
 
+  if use_lightweight and use_reasoning:
+    ui.error('Cannot use both --use-lightweight and --use-reasoning.')
+    raise typer.Exit(code=1)
+
   try:
     # 1. Load configuration (merging YAML, env vars, and CLI overrides)
 
@@ -151,8 +163,10 @@ def generate(
     wpt_dir_str = str(wpt_dir) if wpt_dir else None
     output_dir_str = str(output_dir) if output_dir else None
 
-    # Parse comma-separated spec URLs
-    spec_urls_list = [url.strip() for url in spec_urls.split(',')] if spec_urls else None
+    # Parse spec_urls if provided
+    spec_urls_list = None
+    if spec_urls:
+      spec_urls_list = [u.strip() for u in spec_urls.split(',')]
 
     config = load_config(
       config_path=config_path,
@@ -167,6 +181,8 @@ def generate(
       spec_urls_override=spec_urls_list,
       feature_description_override=description,
       detailed_requirements_override=detailed_requirements,
+      use_lightweight_override=use_lightweight,
+      use_reasoning_override=use_reasoning,
     )
 
     config_info = Text.assemble(


### PR DESCRIPTION
This change introduces two new CLI flags, `--use-lightweight` and `--use-reasoning`, which allow users to force the use of a specific model category for the entire WPT generation workflow, overriding phase-specific model mappings.

- Added `use_lightweight` and `use_reasoning` boolean flags to the `Config` dataclass in `wptgen/config.py`.
- Updated `Config.get_model_for_phase` to prioritize these global overrides when set.
- Modified `load_config` to handle the new overrides and update the `default_model` based on the provider's configured model categories.
- Updated the `generate` command in `wptgen/main.py` to include the new flags and enforced mutual exclusivity between them.
- Expanded the test suite in `tests/test_config.py` and `tests/test_main.py` to cover the new flags, including override logic and error handling.
- Updated `README.md` to document the new command options.