### PR TITLE
Improve workflow error reporting and handling

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -19,7 +19,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from wptgen.config import Config
-from wptgen.engine import WPTGenEngine
+from wptgen.engine import WorkflowError, WPTGenEngine
 from wptgen.models import WorkflowContext
 
 
@@ -110,17 +110,20 @@ async def test_run_async_workflow_phase_failures(
   """Test short-circuits when phases fail."""
   # Phase 1 failure
   mocker.patch('wptgen.engine.run_context_assembly', return_value=None)
-  await engine._run_async_workflow('feat-id')
+  with pytest.raises(WorkflowError, match='Phase 1: Context Assembly failed.'):
+    await engine._run_async_workflow('feat-id')
 
   # Phase 2 failure
   mocker.patch('wptgen.engine.run_context_assembly', return_value=WorkflowContext(feature_id='f'))
   mocker.patch('wptgen.engine.run_requirements_extraction', return_value=None)
-  await engine._run_async_workflow('feat-id')
+  with pytest.raises(WorkflowError, match='Phase 2: Requirements Extraction failed.'):
+    await engine._run_async_workflow('feat-id')
 
   # Phase 3 failure
   mocker.patch('wptgen.engine.run_requirements_extraction', return_value='reqs')
   mocker.patch('wptgen.engine.run_coverage_audit', return_value=None)
-  await engine._run_async_workflow('feat-id')
+  with pytest.raises(WorkflowError, match='Phase 3: Coverage Audit failed.'):
+    await engine._run_async_workflow('feat-id')
 
 
 def test_run_workflow_sync(engine: WPTGenEngine, mocker: MockerFixture) -> None:

--- a/tests/test_workflow_failure.py
+++ b/tests/test_workflow_failure.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pytest_mock import MockerFixture
+from typer.testing import CliRunner
+
+from wptgen.config import Config
+from wptgen.engine import WorkflowError, WPTGenEngine
+from wptgen.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_config(tmp_path: Path) -> Config:
+  """Provides a dummy configuration object."""
+  return Config(
+    provider='gemini',
+    default_model='gemini-3.1-pro-preview',
+    api_key='fake-key',
+    categories={
+      'lightweight': 'gemini-3.1-pro-preview',
+      'reasoning': 'gemini-3-pro-preview',
+    },
+    phase_model_mapping={
+      'requirements_extraction': 'reasoning',
+      'coverage_audit': 'reasoning',
+      'generation': 'lightweight',
+      'evaluation': 'lightweight',
+    },
+    wpt_path=str(tmp_path / 'wpt'),
+    cache_path=str(tmp_path / 'cache'),
+    output_dir=str(tmp_path / 'output'),
+    max_retries=3,
+  )
+
+
+@pytest.fixture
+def mock_ui() -> MagicMock:
+  """Provides a mocked UI provider."""
+  return MagicMock()
+
+
+@pytest.fixture
+def engine(mock_config: Config, mock_ui: MagicMock) -> WPTGenEngine:
+  """Provides a WPTGenEngine instance."""
+  with patch('wptgen.engine.get_llm_client'):
+    return WPTGenEngine(mock_config, mock_ui)
+
+
+def test_workflow_error_display(mocker: MockerFixture, mock_config: Config) -> None:
+  """Verify that a WorkflowError results in a red failure panel and exit code 1."""
+  mocker.patch('wptgen.main.load_config', return_value=mock_config)
+
+  mock_engine_class = mocker.patch('wptgen.main.WPTGenEngine')
+  mock_engine_instance = mock_engine_class.return_value
+  # Simulate a workflow failure by raising WorkflowError
+  mock_engine_instance.run_workflow.side_effect = WorkflowError('Phase 1 failure')
+
+  result = runner.invoke(app, ['generate', 'grid'])
+
+  # Verify exit code
+  assert result.exit_code == 1
+  # Verify failure message is present
+  assert 'Workflow completed with errors' in result.stdout
+  # Verify success message is NOT present
+  assert 'Workflow completed successfully' not in result.stdout
+
+
+@pytest.mark.asyncio
+async def test_engine_raises_workflow_error_on_phase_failure(
+  engine: WPTGenEngine, mocker: MockerFixture
+) -> None:
+  """Verify that the engine specifically raises WorkflowError when a phase returns None."""
+  # Mock run_context_assembly to return None (failure)
+  mocker.patch('wptgen.engine.run_context_assembly', return_value=None)
+
+  with pytest.raises(WorkflowError, match='Phase 1: Context Assembly failed.'):
+    await engine._run_async_workflow('test-feature')

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -43,6 +43,10 @@ __all__ = [
 ]
 
 
+class WorkflowError(Exception):
+  """Raised when a phase of the workflow fails to complete."""
+
+
 class WPTGenEngine:
   def __init__(self, config: Config, ui: UIProvider):
     self.config = config
@@ -96,7 +100,7 @@ class WPTGenEngine:
     if not context or not context.wpt_context:
       context = await run_context_assembly(web_feature_id, self.config, self.ui)
       if not context:
-        return
+        raise WorkflowError('Phase 1: Context Assembly failed.')
       self._save_resume_state(context)
 
     # Phase 2: Requirements Extraction
@@ -110,7 +114,7 @@ class WPTGenEngine:
           context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
         )
       if not requirements_xml:
-        return
+        raise WorkflowError('Phase 2: Requirements Extraction failed.')
       context.requirements_xml = requirements_xml
       self._save_resume_state(context)
 
@@ -120,7 +124,7 @@ class WPTGenEngine:
         context, self.config, self.llm, self.ui, self.jinja_env
       )
       if not audit_response:
-        return
+        raise WorkflowError('Phase 3: Coverage Audit failed.')
       context.audit_response = audit_response
       self._save_resume_state(context)
 

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -26,7 +26,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from wptgen.config import DEFAULT_CONFIG_PATH, DEFAULT_LLM_TIMEOUT, load_config
-from wptgen.engine import WPTGenEngine
+from wptgen.engine import WorkflowError, WPTGenEngine
 from wptgen.llm import LLMTimeoutError
 from wptgen.ui import RichUIProvider
 
@@ -233,6 +233,16 @@ def generate(
     # Catch configuration errors (like missing API keys) and exit gracefully
     console.print(f'[bold red]Configuration Error:[/bold red] {str(e)}')
     raise typer.Exit(code=1) from e
+  except WorkflowError:
+    console.print()
+    console.print(
+      Panel(
+        '[bold red]✘ Workflow completed with errors.[/bold red]',
+        border_style='red',
+        expand=False,
+      )
+    )
+    raise typer.Exit(code=1) from None
   except Exception as e:
     # Catch unexpected runtime errors
     console.print(f'[bold red]Unexpected Error:[/bold red] {str(e)}')


### PR DESCRIPTION
Fixes #92

Currently, the CLI displays a "Workflow completed successfully" message even if a phase fails and the process ends early. This change introduces a `WorkflowError` exception to properly signal and report these failures.

- Define `WorkflowError` in `wptgen/engine.py` and raise it when workflow phases (Context Assembly, Requirements Extraction, etc.) fail.
- Update `wptgen/main.py` to catch `WorkflowError`, display a red "Workflow completed with errors" panel, and exit with code 1.
- Update existing engine tests to expect `WorkflowError` during failure scenarios.
- Add `tests/test_workflow_failure.py` to verify both the CLI's error reporting and the engine's failure logic.
- Fix linting (B904) and type-checking issues in the modified files.