### PR TITLE
Add `--skip-evaluation` flag to bypass automated test review

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -253,3 +253,16 @@ def test_load_config_timeout_minimum(
   # Case 3: Timeout greater than minimum (e.g., 60s) should remain 60s
   config = load_config(config_path='non_existent_dummy.yaml', timeout_override=60)
   assert config.timeout == 60
+
+
+def test_load_config_skip_evaluation(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Test that skip_evaluation flag is correctly loaded."""
+  monkeypatch.setenv('GEMINI_API_KEY', 'mock-key')
+
+  # Case 1: Default (False)
+  config = load_config(config_path='non_existent_dummy.yaml')
+  assert config.skip_evaluation is False
+
+  # Case 2: Override to True
+  config = load_config(config_path='non_existent_dummy.yaml', skip_evaluation_override=True)
+  assert config.skip_evaluation is True

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -183,3 +183,26 @@ def test_engine_init(engine: WPTGenEngine, mock_config: Config) -> None:
   assert engine.config == mock_config
   assert engine.llm is not None
   assert engine.jinja_env is not None
+
+
+@pytest.mark.asyncio
+async def test_run_async_workflow_skip_evaluation(
+  engine: WPTGenEngine, mock_ui: MagicMock, mocker: MockerFixture
+) -> None:
+  """Verifies that Phase 5: Evaluation is skipped when config.skip_evaluation is True."""
+  engine.config.skip_evaluation = True
+  context = WorkflowContext(feature_id='feat-id')
+  requirements = 'reqs'
+  audit = 'audit'
+  generated_tests = [('path', 'content', 'suggestion')]
+
+  mocker.patch('wptgen.engine.run_context_assembly', return_value=context)
+  mocker.patch('wptgen.engine.run_requirements_extraction', return_value=requirements)
+  mocker.patch('wptgen.engine.run_coverage_audit', return_value=audit)
+  mocker.patch('wptgen.engine.run_test_generation', return_value=generated_tests)
+  mock_eval = mocker.patch('wptgen.engine.run_test_evaluation', return_value=None)
+
+  await engine._run_async_workflow('feat-id')
+
+  mock_eval.assert_not_called()
+  mock_ui.info.assert_called_with('Skipping Phase 5: Evaluation.')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -98,6 +98,7 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     detailed_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
+    skip_evaluation_override=False,
   )
   mock_engine_class.assert_called_once()
   # Verify config was passed correctly
@@ -130,6 +131,7 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     detailed_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
+    skip_evaluation_override=False,
   )
 
 
@@ -158,6 +160,7 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     detailed_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
+    skip_evaluation_override=False,
   )
 
 
@@ -186,6 +189,7 @@ def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -
     detailed_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
+    skip_evaluation_override=False,
   )
 
 
@@ -214,6 +218,7 @@ def test_generate_max_retries(mocker: MockerFixture, mock_config: Config) -> Non
     detailed_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
+    skip_evaluation_override=False,
   )
 
 
@@ -242,6 +247,58 @@ def test_generate_detailed_requirements(mocker: MockerFixture, mock_config: Conf
     detailed_requirements_override=True,
     use_lightweight_override=False,
     use_reasoning_override=False,
+    skip_evaluation_override=False,
+  )
+
+
+def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test that the --skip-evaluation/--no-eval flag is correctly passed to load_config."""
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+  mocker.patch('wptgen.main.WPTGenEngine')
+
+  # Run with --skip-evaluation
+  result = runner.invoke(app, ['generate', 'grid', '--skip-evaluation'])
+  assert result.exit_code == 0
+  mock_load_config.assert_called_with(
+    config_path=DEFAULT_CONFIG_PATH,
+    provider_override=None,
+    wpt_dir_override=None,
+    output_dir_override=None,
+    show_responses=False,
+    yes_tokens_override=False,
+    suggestions_only=False,
+    resume_override=False,
+    max_retries_override=3,
+    timeout_override=600,
+    spec_urls_override=None,
+    feature_description_override=None,
+    detailed_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
+    skip_evaluation_override=True,
+  )
+
+  # Run with --no-eval alias
+  mock_load_config.reset_mock()
+  result = runner.invoke(app, ['generate', 'grid', '--no-eval'])
+  assert result.exit_code == 0
+  mock_load_config.assert_called_with(
+    config_path=DEFAULT_CONFIG_PATH,
+    provider_override=None,
+    wpt_dir_override=None,
+    output_dir_override=None,
+    show_responses=False,
+    yes_tokens_override=False,
+    suggestions_only=False,
+    resume_override=False,
+    max_retries_override=3,
+    timeout_override=600,
+    spec_urls_override=None,
+    feature_description_override=None,
+    detailed_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
+    skip_evaluation_override=True,
   )
 
 
@@ -301,6 +358,7 @@ def test_generate_spec_urls(mocker: MockerFixture, mock_config: Config) -> None:
     detailed_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
+    skip_evaluation_override=False,
   )
 
 
@@ -329,6 +387,7 @@ def test_generate_description(mocker: MockerFixture, mock_config: Config) -> Non
     detailed_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
+    skip_evaluation_override=False,
   )
 
 
@@ -357,6 +416,7 @@ def test_generate_resume(mocker: MockerFixture, mock_config: Config) -> None:
     detailed_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
+    skip_evaluation_override=False,
   )
 
 
@@ -385,6 +445,7 @@ def test_generate_use_lightweight(mocker: MockerFixture, mock_config: Config) ->
     detailed_requirements_override=False,
     use_lightweight_override=True,
     use_reasoning_override=False,
+    skip_evaluation_override=False,
   )
 
 
@@ -413,6 +474,7 @@ def test_generate_use_reasoning(mocker: MockerFixture, mock_config: Config) -> N
     detailed_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=True,
+    skip_evaluation_override=False,
   )
 
 

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -50,6 +50,7 @@ class Config:
   detailed_requirements: bool = False
   use_lightweight: bool = False
   use_reasoning: bool = False
+  skip_evaluation: bool = False
 
   def get_model_for_phase(self, phase_name: str) -> str | None:
     """Resolves the model name for a given workflow phase."""
@@ -120,6 +121,7 @@ def load_config(
   detailed_requirements_override: bool = False,
   use_lightweight_override: bool = False,
   use_reasoning_override: bool = False,
+  skip_evaluation_override: bool = False,
   require_api_key: bool = True,
 ) -> Config:
   """
@@ -190,6 +192,7 @@ def load_config(
     timeout = MIN_LLM_TIMEOUT
 
   cache_path = yaml_data.get('cache_path') or _get_default_cache_path()
+  skip_evaluation = skip_evaluation_override or yaml_data.get('skip_evaluation', False)
 
   # Load model categories and phase mapping
   default_model = provider_settings.get('default_model', default_model_name)
@@ -229,4 +232,5 @@ def load_config(
     detailed_requirements=detailed_requirements,
     use_lightweight=use_lightweight_override,
     use_reasoning=use_reasoning_override,
+    skip_evaluation=skip_evaluation,
   )

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -148,10 +148,12 @@ class WPTGenEngine:
       self.ui.success('Skipping Phase 4: Tests already generated.')
 
     # Phase 5: Evaluation
-    if context.generated_tests:
+    if context.generated_tests and not self.config.skip_evaluation:
       await run_test_evaluation(
         context, self.config, self.llm, self.ui, self.jinja_env, context.generated_tests
       )
+    elif context.generated_tests and self.config.skip_evaluation:
+      self.ui.info('Skipping Phase 5: Evaluation.')
 
     # Final cleanup of resume file on success
     resume_file = self._get_resume_file_path(web_feature_id)

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -144,6 +144,14 @@ def generate(
     bool,
     typer.Option('--use-reasoning', help='Use the reasoning model for all LLM requests.'),
   ] = False,
+  skip_evaluation: Annotated[
+    bool,
+    typer.Option(
+      '--skip-evaluation',
+      '--no-eval',
+      help='Skip the evaluation phase after generating tests.',
+    ),
+  ] = False,
 ) -> None:
   """
   Generate Web Platform Tests for a specific web feature.
@@ -192,6 +200,7 @@ def generate(
       detailed_requirements_override=detailed_requirements,
       use_lightweight_override=use_lightweight,
       use_reasoning_override=use_reasoning,
+      skip_evaluation_override=skip_evaluation,
     )
 
     config_info = Text.assemble(


### PR DESCRIPTION
Fixes #79

Introduce a new CLI flag `--skip-evaluation` (with alias `--no-eval`) to allow users to skip Phase 5: Evaluation, which performs an automated LLM-based review of generated tests. This provides a faster workflow for users who prefer manual verification of the generated code.

- Update `wptgen/main.py` to include the new CLI option and pass it to the configuration loader.
- Update `wptgen/config.py` to support `skip_evaluation` in the `Config` dataclass and handle it during initialization.
- Update `wptgen/engine.py` to conditionally skip the evaluation phase based on the configuration.
- Add and update tests in `tests/test_config.py`, `tests/test_engine.py`, and `tests/test_main.py` to verify the new flag's behavior and ensure CLI argument parsing works as expected.