### PR TITLE
Add Phase 6: Test Execution to run generated tests with `./wpt`

### DIFF
--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,175 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from wptgen.config import Config
+from wptgen.models import WorkflowContext
+from wptgen.phases.execution import run_test_execution
+
+
+@pytest.fixture
+def mock_ui() -> MagicMock:
+  """Fixture that provides a mocked UI provider."""
+  return MagicMock()
+
+
+@pytest.fixture
+def mock_config(tmp_path: Path) -> Config:
+  """Fixture that provides a basic test configuration."""
+  return Config(
+    provider='test',
+    default_model='test-model',
+    api_key='test-key',
+    categories={'lightweight': 'test-model', 'reasoning': 'test-model'},
+    phase_model_mapping={},
+    wpt_path=str(tmp_path / 'wpt'),
+    cache_path=str(tmp_path / 'cache'),
+    output_dir=str(tmp_path / 'output'),
+    wpt_browser='chrome',
+    wpt_channel='canary',
+    execution_timeout=300,
+  )
+
+
+@pytest.mark.asyncio
+async def test_run_test_execution_success(
+  mock_config: Config, mock_ui: MagicMock, tmp_path: Path
+) -> None:
+  wpt_root = Path(mock_config.wpt_path)
+  wpt_root.mkdir(parents=True)
+  wpt_executable = wpt_root / 'wpt'
+  wpt_executable.touch()
+
+  test_path = wpt_root / 'test.html'
+  generated_tests = [(test_path, 'content', 'xml')]
+
+  context = WorkflowContext(feature_id='feat')
+
+  mock_process = AsyncMock()
+  mock_process.communicate.return_value = (b'stdout', b'stderr')
+  mock_process.returncode = 0
+
+  with patch('asyncio.create_subprocess_exec', return_value=mock_process) as mock_exec:
+    await run_test_execution(context, mock_config, mock_ui, generated_tests)
+
+    mock_exec.assert_called_once()
+    args = mock_exec.call_args[0]
+    assert args[0] == str(wpt_executable)
+    assert 'run' in args
+    assert 'chrome' in args
+    assert 'canary' in args
+    mock_ui.success.assert_called_with('Test execution succeeded for test.html.')
+
+
+@pytest.mark.asyncio
+async def test_run_test_execution_failure(
+  mock_config: Config, mock_ui: MagicMock, tmp_path: Path
+) -> None:
+  wpt_root = Path(mock_config.wpt_path)
+  wpt_root.mkdir(parents=True)
+  (wpt_root / 'wpt').touch()
+
+  test_path = wpt_root / 'test.html'
+  generated_tests = [(test_path, 'content', 'xml')]
+
+  context = WorkflowContext(feature_id='feat')
+
+  mock_process = AsyncMock()
+  mock_process.communicate.return_value = (b'some output', b'some error')
+  mock_process.returncode = 1
+
+  with patch('asyncio.create_subprocess_exec', return_value=mock_process):
+    await run_test_execution(context, mock_config, mock_ui, generated_tests)
+
+    mock_ui.error.assert_any_call('Test execution failed for test.html with exit code 1.')
+    mock_ui.print.assert_any_call('some output\nsome error')
+
+
+@pytest.mark.asyncio
+async def test_run_test_execution_timeout(
+  mock_config: Config, mock_ui: MagicMock, tmp_path: Path
+) -> None:
+  wpt_root = Path(mock_config.wpt_path)
+  wpt_root.mkdir(parents=True)
+  (wpt_root / 'wpt').touch()
+
+  test_path = wpt_root / 'test.html'
+  generated_tests = [(test_path, 'content', 'xml')]
+
+  context = WorkflowContext(feature_id='feat')
+
+  mock_config.execution_timeout = 0.01  # Very short timeout for testing
+
+  mock_process = AsyncMock()
+  mock_process.kill = MagicMock()
+
+  # Make communicate hang so it triggers the timeout
+  async def slow_communicate() -> tuple[bytes, bytes]:
+    await asyncio.sleep(1)
+    return b'stdout', b'stderr'
+
+  mock_process.communicate = slow_communicate
+
+  with patch('asyncio.create_subprocess_exec', return_value=mock_process):
+    await run_test_execution(context, mock_config, mock_ui, generated_tests)
+
+    mock_process.kill.assert_called_once()
+    mock_ui.error.assert_called_with(
+      f'Test execution timed out for test.html after {mock_config.execution_timeout}s.'
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_test_execution_missing_executable(
+  mock_config: Config, mock_ui: MagicMock
+) -> None:
+  generated_tests = [(Path('test.html'), 'content', 'xml')]
+  context = WorkflowContext(feature_id='feat')
+
+  await run_test_execution(context, mock_config, mock_ui, generated_tests)
+
+  mock_ui.error.assert_called()
+  assert 'Could not find wpt executable' in mock_ui.error.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_run_test_execution_outside_root(
+  mock_config: Config, mock_ui: MagicMock, tmp_path: Path
+) -> None:
+  wpt_root = tmp_path / 'wpt'
+  wpt_root.mkdir()
+  (wpt_root / 'wpt').touch()
+
+  outside_path = tmp_path / 'outside' / 'test.html'
+  outside_path.parent.mkdir()
+  generated_tests = [(outside_path, 'content', 'xml')]
+
+  context = WorkflowContext(feature_id='feat')
+
+  await run_test_execution(context, mock_config, mock_ui, generated_tests)
+
+  mock_ui.warning.assert_called_with(
+    f'Test test.html is not located under wpt root ({wpt_root.resolve()}). Cannot execute via wpt run.'
+  )
+
+
+@pytest.mark.asyncio
+async def test_run_test_execution_empty(mock_config: Config, mock_ui: MagicMock) -> None:
+  await run_test_execution(WorkflowContext(feature_id='feat'), mock_config, mock_ui, [])
+  mock_ui.info.assert_called_with('No tests to execute.')

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -51,6 +51,9 @@ class Config:
   use_lightweight: bool = False
   use_reasoning: bool = False
   skip_evaluation: bool = False
+  wpt_browser: str = 'chrome'
+  wpt_channel: str = 'canary'
+  execution_timeout: int | float = 90  # Default 1.5 minutes
 
   def get_model_for_phase(self, phase_name: str) -> str | None:
     """Resolves the model name for a given workflow phase."""
@@ -233,4 +236,7 @@ def load_config(
     use_lightweight=use_lightweight_override,
     use_reasoning=use_reasoning_override,
     skip_evaluation=skip_evaluation,
+    wpt_browser=yaml_data.get('wpt_browser', 'chrome'),
+    wpt_channel=yaml_data.get('wpt_channel', 'canary'),
+    execution_timeout=yaml_data.get('execution_timeout', 90),
   )

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -24,6 +24,7 @@ from wptgen.models import WorkflowContext
 from wptgen.phases.context_assembly import run_context_assembly
 from wptgen.phases.coverage_audit import provide_coverage_report, run_coverage_audit
 from wptgen.phases.evaluation import run_test_evaluation
+from wptgen.phases.execution import run_test_execution
 from wptgen.phases.generation import run_test_generation
 from wptgen.phases.requirements_extraction import (
   run_requirements_extraction,
@@ -40,6 +41,7 @@ __all__ = [
   'provide_coverage_report',
   'run_test_generation',
   'run_test_evaluation',
+  'run_test_execution',
 ]
 
 
@@ -154,6 +156,10 @@ class WPTGenEngine:
       )
     elif context.generated_tests and self.config.skip_evaluation:
       self.ui.info('Skipping Phase 5: Evaluation.')
+
+    # Phase 6: Test Execution
+    if context.generated_tests:
+      await run_test_execution(context, self.config, self.ui, context.generated_tests)
 
     # Final cleanup of resume file on success
     resume_file = self._get_resume_file_path(web_feature_id)

--- a/wptgen/phases/execution.py
+++ b/wptgen/phases/execution.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from pathlib import Path
+
+from wptgen.config import Config
+from wptgen.models import WorkflowContext
+from wptgen.ui import UIProvider
+
+
+async def run_test_execution(
+  context: WorkflowContext,
+  config: Config,
+  ui: UIProvider,
+  generated_tests: list[tuple[Path, str, str]],
+) -> None:
+  """Runs the execution phase for generated tests using ./wpt run."""
+  ui.on_phase_start(6, 'Test Execution')
+
+  if not generated_tests:
+    ui.info('No tests to execute.')
+    return
+
+  ui.print(f'Executing [bold]{len(generated_tests)}[/bold] generated tests...')
+
+  wpt_root = Path(config.wpt_path).resolve()
+  wpt_executable = wpt_root / 'wpt'
+
+  if not wpt_executable.exists():
+    ui.error(f'Could not find wpt executable at {wpt_executable}. Skipping execution.')
+    return
+
+  for path, _content, _xml in generated_tests:
+    resolved_path = path.resolve()
+    try:
+      rel_path = resolved_path.relative_to(wpt_root)
+    except ValueError:
+      ui.warning(
+        f'Test {path.name} is not located under wpt root ({wpt_root}). Cannot execute via wpt run.'
+      )
+      continue
+
+    ui.print(
+      f'Running [cyan]{rel_path}[/cyan] with {config.wpt_browser} {config.wpt_channel} (timeout: {config.execution_timeout}s)...'
+    )
+
+    # Command: ./wpt run --channel <channel> <browser> <rel_path>
+    cmd = [
+      str(wpt_executable),
+      'run',
+      '--channel',
+      config.wpt_channel,
+      config.wpt_browser,
+      str(rel_path),
+    ]
+
+    # Execute the command
+    process = await asyncio.create_subprocess_exec(
+      *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=str(wpt_root)
+    )
+
+    try:
+      stdout, stderr = await asyncio.wait_for(
+        process.communicate(), timeout=config.execution_timeout
+      )
+    except asyncio.TimeoutError:
+      process.kill()
+      await process.wait()
+      ui.error(f'Test execution timed out for {rel_path} after {config.execution_timeout}s.')
+      continue
+
+    if process.returncode != 0:
+      ui.error(f'Test execution failed for {rel_path} with exit code {process.returncode}.')
+
+      # Print output
+      output = ''
+      if stdout:
+        output += stdout.decode('utf-8', errors='replace')
+      if stderr:
+        if output:
+          output += '\n'
+        output += stderr.decode('utf-8', errors='replace')
+
+      if output.strip():
+        ui.print(output.strip())
+
+    else:
+      ui.success(f'Test execution succeeded for {rel_path}.')
+
+  ui.on_phase_complete('Test Execution')


### PR DESCRIPTION
Introduce a new workflow phase that automatically executes generated WPT tests using the local `./wpt run` command. At the moment, this phase only logs the results of the runs.

- Create `wptgen/phases/execution.py` which implements `run_test_execution`. This phase iterates through generated tests and runs them using `./wpt run --channel canary chrome`.
- Update `wptgen/engine.py` to integrate the new execution phase into the `WPTGenEngine` workflow.
- Handle relative path resolution to ensure tests are executed correctly within the WPT root directory.
- Provide real-time UI feedback on execution progress and results, including failure output capture.