### PR TITLE
feat: implement categorized parallel requirements extraction

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -96,6 +96,7 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -129,6 +130,7 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -158,6 +160,7 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -187,6 +190,7 @@ def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -216,6 +220,7 @@ def test_generate_max_retries(mocker: MockerFixture, mock_config: Config) -> Non
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -245,6 +250,7 @@ def test_generate_detailed_requirements(mocker: MockerFixture, mock_config: Conf
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=True,
+    categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -273,6 +279,7 @@ def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) ->
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=True,
@@ -296,6 +303,7 @@ def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) ->
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=True,
@@ -356,6 +364,7 @@ def test_generate_spec_urls(mocker: MockerFixture, mock_config: Config) -> None:
     spec_urls_override=['https://url1.com', 'https://url2.com'],
     feature_description_override=None,
     detailed_requirements_override=False,
+    categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -385,6 +394,7 @@ def test_generate_description(mocker: MockerFixture, mock_config: Config) -> Non
     spec_urls_override=None,
     feature_description_override='Test Description',
     detailed_requirements_override=False,
+    categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -414,6 +424,7 @@ def test_generate_resume(mocker: MockerFixture, mock_config: Config) -> None:
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -443,6 +454,7 @@ def test_generate_use_lightweight(mocker: MockerFixture, mock_config: Config) ->
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    categorized_requirements_override=False,
     use_lightweight_override=True,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -472,8 +484,39 @@ def test_generate_use_reasoning(mocker: MockerFixture, mock_config: Config) -> N
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=True,
+    skip_evaluation_override=False,
+  )
+
+
+def test_generate_categorized_requirements(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test that the --categorized-requirements flag is correctly passed to load_config."""
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+  mocker.patch('wptgen.main.WPTGenEngine')
+
+  # Run with --categorized-requirements
+  result = runner.invoke(app, ['generate', 'grid', '--categorized-requirements'])
+
+  assert result.exit_code == 0
+  mock_load_config.assert_called_once_with(
+    config_path=DEFAULT_CONFIG_PATH,
+    provider_override=None,
+    wpt_dir_override=None,
+    output_dir_override=None,
+    show_responses=False,
+    yes_tokens_override=False,
+    suggestions_only=False,
+    resume_override=False,
+    max_retries_override=3,
+    timeout_override=600,
+    spec_urls_override=None,
+    feature_description_override=None,
+    detailed_requirements_override=False,
+    categorized_requirements_override=True,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
     skip_evaluation_override=False,
   )
 
@@ -486,6 +529,20 @@ def test_generate_mutually_exclusive_models(mocker: MockerFixture, mock_config: 
 
   assert result.exit_code == 1
   assert 'Cannot use both --use-lightweight and --use-reasoning' in result.stdout
+
+
+def test_generate_mutually_exclusive_requirements(
+  mocker: MockerFixture, mock_config: Config
+) -> None:
+  """Test that providing both requirements flags results in an error."""
+  mocker.patch('wptgen.main.load_config', return_value=mock_config)
+
+  result = runner.invoke(
+    app, ['generate', 'grid', '--detailed-requirements', '--categorized-requirements']
+  )
+
+  assert result.exit_code == 1
+  assert 'Cannot use both --detailed-requirements and --categorized-requirements' in result.stdout
 
 
 def test_version_not_found(mocker: MockerFixture) -> None:

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -23,6 +23,7 @@ from wptgen.phases.context_assembly import run_context_assembly
 from wptgen.phases.generation import run_test_generation
 from wptgen.phases.requirements_extraction import (
   run_requirements_extraction,
+  run_requirements_extraction_categorized,
 )
 
 
@@ -187,6 +188,81 @@ async def test_run_requirements_extraction_cached(
   assert res == '<reqs>cached</reqs>'
   mock_ui.info.assert_called_once()
   mock_ui.success.assert_called_once_with('Using cached requirements.')
+
+
+@pytest.mark.asyncio
+async def test_run_requirements_extraction_categorized(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Test categorized requirements extraction with mocked LLM responses."""
+  context = WorkflowContext(
+    feature_id='feat',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    spec_contents='Spec',
+  )
+  jinja_env = MagicMock()
+  jinja_env.get_template.return_value.render.return_value = 'Mock Template'
+
+  # Mock generate_safe to return a single requirement for each call
+  with patch(
+    'wptgen.phases.requirements_extraction.generate_safe',
+    side_effect=[
+      '<requirements_list><requirement id="R1"><category>Existence</category><description>D1</description></requirement></requirements_list>',
+      '<requirements_list><requirement id="R1"><category>Common Use Cases</category><description>D2</description></requirement></requirements_list>',
+      '<requirements_list><requirement id="R1"><category>Error Scenarios</category><description>D3</description></requirement></requirements_list>',
+      '<requirements_list><requirement id="R1"><category>Invalidation</category><description>D4</description></requirement></requirements_list>',
+      '<requirements_list><requirement id="R1"><category>Integration</category><description>D5</description></requirement></requirements_list>',
+    ],
+  ):
+    res = await run_requirements_extraction_categorized(
+      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
+    )
+
+  assert res is not None
+  assert '<requirement id="R1">' in res
+  assert '<requirement id="R2">' in res
+  assert '<requirement id="R3">' in res
+  assert '<requirement id="R4">' in res
+  assert '<requirement id="R5">' in res
+  assert '<category>Existence</category>' in res
+  assert '<category>Integration</category>' in res
+  assert res.count('<requirement id=') == 5
+
+
+@pytest.mark.asyncio
+async def test_run_requirements_extraction_categorized_partial_empty(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Test categorized requirements extraction with some empty responses."""
+  context = WorkflowContext(
+    feature_id='feat-partial',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    spec_contents='Spec',
+  )
+  jinja_env = MagicMock()
+  jinja_env.get_template.return_value.render.return_value = 'Mock Template'
+
+  # Mock generate_safe to return a mixture of requirements and empty lists
+  with patch(
+    'wptgen.phases.requirements_extraction.generate_safe',
+    side_effect=[
+      '<requirements_list><requirement id="R1"><category>Existence</category><description>D1</description></requirement></requirements_list>',
+      '<requirements_list></requirements_list>',  # Empty
+      '<requirements_list><requirement id="R1"><category>Error Scenarios</category><description>D3</description></requirement></requirements_list>',
+      '<requirements_list></requirements_list>',  # Empty
+      '<requirements_list></requirements_list>',  # Empty
+    ],
+  ):
+    res = await run_requirements_extraction_categorized(
+      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
+    )
+
+  assert res is not None
+  assert '<requirement id="R1">' in res
+  assert '<requirement id="R2">' in res
+  assert '<category>Existence</category>' in res
+  assert '<category>Error Scenarios</category>' in res
+  assert res.count('<requirement id=') == 2
 
 
 @pytest.mark.asyncio

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -48,6 +48,7 @@ class Config:
   spec_urls: list[str] | None = None
   feature_description: str | None = None
   detailed_requirements: bool = False
+  categorized_requirements: bool = False
   use_lightweight: bool = False
   use_reasoning: bool = False
   skip_evaluation: bool = False
@@ -122,6 +123,7 @@ def load_config(
   spec_urls_override: list[str] | None = None,
   feature_description_override: str | None = None,
   detailed_requirements_override: bool = False,
+  categorized_requirements_override: bool = False,
   use_lightweight_override: bool = False,
   use_reasoning_override: bool = False,
   skip_evaluation_override: bool = False,
@@ -184,6 +186,9 @@ def load_config(
   detailed_requirements = detailed_requirements_override or yaml_data.get(
     'detailed_requirements', False
   )
+  categorized_requirements = categorized_requirements_override or yaml_data.get(
+    'categorized_requirements', False
+  )
   max_retries = max_retries_override or yaml_data.get('max_retries', 3)
   timeout = timeout_override or yaml_data.get('timeout', DEFAULT_LLM_TIMEOUT)
 
@@ -233,6 +238,7 @@ def load_config(
     spec_urls=spec_urls_override,
     feature_description=feature_description_override,
     detailed_requirements=detailed_requirements,
+    categorized_requirements=categorized_requirements,
     use_lightweight=use_lightweight_override,
     use_reasoning=use_reasoning_override,
     skip_evaluation=skip_evaluation,

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -28,6 +28,7 @@ from wptgen.phases.execution import run_test_execution
 from wptgen.phases.generation import run_test_generation
 from wptgen.phases.requirements_extraction import (
   run_requirements_extraction,
+  run_requirements_extraction_categorized,
   run_requirements_extraction_iterative,
 )
 from wptgen.ui import UIProvider
@@ -36,6 +37,7 @@ __all__ = [
   'WPTGenEngine',
   'run_context_assembly',
   'run_requirements_extraction',
+  'run_requirements_extraction_categorized',
   'run_requirements_extraction_iterative',
   'run_coverage_audit',
   'provide_coverage_report',
@@ -107,7 +109,11 @@ class WPTGenEngine:
 
     # Phase 2: Requirements Extraction
     if not context.requirements_xml:
-      if self.config.detailed_requirements:
+      if self.config.categorized_requirements:
+        requirements_xml = await run_requirements_extraction_categorized(
+          context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
+        )
+      elif self.config.detailed_requirements:
         requirements_xml = await run_requirements_extraction_iterative(
           context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
         )

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -136,6 +136,13 @@ def generate(
       help='Use a more detailed, iterative requirements extraction process.',
     ),
   ] = False,
+  categorized_requirements: Annotated[
+    bool,
+    typer.Option(
+      '--categorized-requirements',
+      help='Use a parallel, categorized requirements extraction process.',
+    ),
+  ] = False,
   use_lightweight: Annotated[
     bool,
     typer.Option('--use-lightweight', help='Use the lightweight model for all LLM requests.'),
@@ -172,6 +179,10 @@ def generate(
     ui.error('Cannot use both --use-lightweight and --use-reasoning.')
     raise typer.Exit(code=1)
 
+  if detailed_requirements and categorized_requirements:
+    ui.error('Cannot use both --detailed-requirements and --categorized-requirements.')
+    raise typer.Exit(code=1)
+
   try:
     # 1. Load configuration (merging YAML, env vars, and CLI overrides)
 
@@ -198,6 +209,7 @@ def generate(
       spec_urls_override=spec_urls_list,
       feature_description_override=description,
       detailed_requirements_override=detailed_requirements,
+      categorized_requirements_override=categorized_requirements,
       use_lightweight_override=use_lightweight,
       use_reasoning_override=use_reasoning,
       skip_evaluation_override=skip_evaluation,

--- a/wptgen/models.py
+++ b/wptgen/models.py
@@ -31,6 +31,20 @@ STYLE_GUIDE_MAP = {
   TestType.CRASHTEST: 'crashtest_style_guide.md',
 }
 
+REQUIREMENT_CATEGORIES = [
+  ('Existence', "Rules defining the feature's surface area (interfaces, methods, properties)."),
+  (
+    'Common Use Cases',
+    'Rules defining successful behaviors, processing models, and realistic "happy paths."',
+  ),
+  ('Error Scenarios', 'Rules defining error conditions, thrown exceptions, and invalid states.'),
+  ('Invalidation', 'Rules regarding caching, state changes, and dynamic updates, if any.'),
+  (
+    'Integration',
+    'Rules defining mandatory interactions with other platform features, if any.',
+  ),
+]
+
 
 @dataclass
 class WebFeatureMetadata:

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import re
 from pathlib import Path
 
@@ -19,7 +20,7 @@ from jinja2 import Environment
 
 from wptgen.config import Config
 from wptgen.llm import LLMClient
-from wptgen.models import WorkflowContext
+from wptgen.models import REQUIREMENT_CATEGORIES, WorkflowContext
 from wptgen.phases.utils import confirm_prompts, generate_safe
 from wptgen.ui import UIProvider
 
@@ -80,6 +81,103 @@ async def run_requirements_extraction(
 
     if not requirements_xml:
       return None
+
+    # Save to cache
+    cache_file.write_text(requirements_xml, encoding='utf-8')
+
+  context.requirements_xml = requirements_xml
+  return requirements_xml
+
+
+async def run_requirements_extraction_categorized(
+  context: WorkflowContext,
+  config: Config,
+  llm: LLMClient,
+  ui: UIProvider,
+  jinja_env: Environment,
+  cache_dir: Path,
+) -> str | None:
+  ui.on_phase_start(2, 'Requirements Extraction (Categorized)')
+
+  assert context.metadata is not None
+
+  web_feature_id = context.feature_id
+  cache_file = cache_dir / f'{web_feature_id}__requirements.xml'
+  requirements_xml = None
+
+  if cache_file.exists():
+    ui.info(f'Found cached requirements for {web_feature_id}.')
+    if ui.confirm('Use cached requirements?'):
+      requirements_xml = cache_file.read_text(encoding='utf-8')
+      ui.success('Using cached requirements.')
+
+  if not requirements_xml:
+    metadata = context.metadata
+    assert metadata is not None
+
+    async def extract_for_category(category_name: str, category_description: str) -> str | None:
+      extraction_prompt = jinja_env.get_template(
+        'requirements_extraction_categorized.jinja'
+      ).render(
+        feature_name=metadata.name,
+        feature_description=metadata.description,
+        spec_url=metadata.specs[0],
+        spec_contents=context.spec_contents,
+        mdn_contents=context.mdn_contents,
+        category_name=category_name,
+        category_description=category_description,
+      )
+      extraction_system_prompt = jinja_env.get_template(
+        'requirements_extraction_categorized_system.jinja'
+      ).render(
+        category_name=category_name,
+        category_description=category_description,
+      )
+
+      # We don't confirm prompts individually for parallel requests to avoid UI mess
+      # Instead we could confirm the "template" once.
+      # For now, following the spirit of parallelized extraction.
+
+      return await generate_safe(
+        extraction_prompt,
+        f'Requirements Extraction: {category_name}',
+        llm,
+        ui,
+        config,
+        system_instruction=extraction_system_prompt,
+        temperature=0.01,
+        model=config.get_model_for_phase('requirements_extraction'),
+      )
+
+    ui.info(f'Launching {len(REQUIREMENT_CATEGORIES)} parallel extraction requests...')
+    responses = await asyncio.gather(
+      *[extract_for_category(name, desc) for name, desc in REQUIREMENT_CATEGORIES]
+    )
+
+    all_requirements: list[str] = []
+    requirement_counter = 1
+
+    for response in responses:
+      if not response:
+        continue
+
+      # Extract individual <requirement> blocks.
+      new_reqs = re.findall(r'(<requirement.*?>.*?</requirement>)', response, re.DOTALL)
+      for req in new_reqs:
+        # Re-index requirements as they come out
+        re_indexed = re.sub(
+          r'(<requirement[^>]*?)id="[^"]+"', f'\\1id="R{requirement_counter}"', req
+        )
+        all_requirements.append(re_indexed)
+        requirement_counter += 1
+
+    if not all_requirements:
+      ui.error('No requirements extracted.')
+      return None
+
+    requirements_xml = (
+      '<requirements_list>\n  ' + '\n  '.join(all_requirements) + '\n</requirements_list>'
+    )
 
     # Save to cache
     cache_file.write_text(requirements_xml, encoding='utf-8')

--- a/wptgen/templates/requirements_extraction_categorized.jinja
+++ b/wptgen/templates/requirements_extraction_categorized.jinja
@@ -1,0 +1,18 @@
+Extract the core normative test requirements for the following feature and specification.
+
+<feature_definition>
+  <feature_name>{{feature_name}}</feature_name>
+  <feature_description>{{feature_description}}</feature_description>
+</feature_definition>
+
+<spec_document url="{{spec_url}}">
+{{spec_contents}}
+</spec_document>
+
+{% if mdn_contents -%}
+{% for content in mdn_contents -%}
+<mdn_document>
+{{content}}
+</mdn_document>
+{% endfor -%}
+{%- endif %}

--- a/wptgen/templates/requirements_extraction_categorized_system.jinja
+++ b/wptgen/templates/requirements_extraction_categorized_system.jinja
@@ -1,0 +1,41 @@
+# SYSTEM ROLE
+You are a Principal Software Engineer in Test (SDET) and a W3C Specification Analyst. Your exclusive job is to read W3C specifications and extract a highly-focused list of core interoperability test requirements.
+
+# CORE DIRECTIVES
+1.  **Zero Conversation:** Output strictly the XML structure defined below. No pleasantries or conversational filler.
+2.  **Normative Only:** You are extracting *normative* rules (MUST, SHALL, REQUIRED).
+3. **Principle-Based Exclusions:** You must IGNORE and DO NOT EXTRACT rules related to the following platform-level behaviors:
+  * **Non-Absolute Directives:** Ignore behaviors labeled "MAY", "SHOULD", or "OPTIONAL". Only extract absolute "MUST" or "SHALL" requirements.
+  * **Standard WebIDL Bindings:** Ignore implicit type conversions (e.g., passing a string to a boolean parameter) unless the spec defines a custom Exception for it.
+  * **User Agent UI:** Ignore visual browser behaviors, user prompts, or system dialogs.
+  * **Memory & Hardware:** Ignore Garbage Collection timing, memory limits, or non-deterministic OS constraints.
+4.  **Atomic Descriptions:** Each requirement must be a single, testable assertion. Do not combine multiple behaviors. The description must read like a test objective (e.g., "If the dictionary member is missing, it must default to false.").
+
+# INPUTS
+1.  `<spec_document>`: The technical specification text.
+2.  `<mdn_document>` (Optional): Supplemental MDN documentation for the feature.
+3.  `<feature_definition>`: The scope of your analysis. You must ignore parts of the spec that fall outside this feature definition.
+
+# EXTRACTION PROTOCOL
+Read the `<spec_document>` (and `<mdn_document>` if available) and extract every normative requirement that fits within the scope of the `<feature_definition>`.
+
+**CRITICAL:** You MUST ONLY extract requirements that fall into the following specific category:
+* **{{category_name}}**: {{category_description}}
+
+DO NOT extract requirements for any other category.
+
+If the specification contains NO normative requirements for this specific category within the feature scope, it is expected and perfectly acceptable to return an empty list.
+
+# STRICT OUTPUT FORMAT
+Your entire response must be a single `<requirements_list>` XML block. Do not wrap your response in markdown backticks.
+
+If requirements are found:
+<requirements_list>
+  <requirement id="R1">
+    <category>{{category_name}}</category>
+    <description>[Detailed explanation of the specific behavior that must be tested]</description>
+  </requirement>
+</requirements_list>
+
+If NO requirements are found for this category:
+<requirements_list></requirements_list>


### PR DESCRIPTION
This change adds a new approach to requirements extraction that breaks the problem down into 5 separate requests, based on [the categories of test coverage requirements defined in Chromium](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/testing/web_platform_tests.md#test-coverage).

- Added `--categorized-requirements` CLI flag, mutually exclusive with `--detailed-requirements`.
- Implemented `run_requirements_extraction_categorized` using `asyncio.gather` for parallelized extraction across 5 categories (Existence, Common Use Cases, Error Scenarios, Invalidation, Integration).
- Created new Jinja templates for categorized extraction with explicit handling for empty results.
- Updated `WPTGenEngine` and `Config` to support the new extraction protocol.
- Added comprehensive unit tests in `tests/test_phases.py` and updated CLI tests in `tests/test_main.py`.
- Fixed mypy type checking issues in `requirements_extraction.py`.