### PR TITLE
fix: normalize test filename suffixes and support renaming during evaluation

### DIFF
--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -254,3 +254,57 @@ async def test_run_test_evaluation_partitioning_logic(
   assert 'test content' in call_args['generated_code_content']
   assert '[FILE_2: .html]' in call_args['generated_code_content']
   assert 'ref content' in call_args['generated_code_content']
+
+
+@pytest.mark.asyncio
+async def test_run_test_evaluation_reftest_rename(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Verify that reftest files are renamed if the suffix changes during evaluation."""
+  context = WorkflowContext(feature_id='feat')
+  jinja_env = MagicMock()
+  style_guide_content = 'Style Guide Content'
+
+  test_path = tmp_path / 'feat-001.html'
+  ref_path = tmp_path / 'feat-001-ref.html'
+  test_path.write_text('old test')
+  ref_path.write_text('old ref')
+
+  suggestion_xml = '<test_suggestion><test_type>Reftest</test_type></test_suggestion>'
+  generated_tests = [
+    (test_path, 'old test', suggestion_xml),
+    (ref_path, 'old ref', suggestion_xml),
+  ]
+
+  # Mock LLM returning corrected content with NEW SUFFIXES
+  mock_llm.generate_content.return_value = """
+[FILE_1: .https.html]
+new test content
+[/FILE_1]
+
+[FILE_2: .sub.html]
+new ref content
+[/FILE_2]
+"""
+
+  with patch('wptgen.phases.evaluation.Path.read_text', return_value=style_guide_content):
+    await run_test_evaluation(context, mock_config, mock_llm, mock_ui, jinja_env, generated_tests)
+
+  # Verify files were renamed/updated
+  new_test_path = tmp_path / 'feat-001.https.html'
+  new_ref_path = tmp_path / 'feat-001-ref.sub.html'
+
+  assert new_test_path.exists()
+  assert new_test_path.read_text() == 'new test content'
+  assert not test_path.exists()
+
+  assert new_ref_path.exists()
+  assert new_ref_path.read_text() == 'new ref content'
+  assert not ref_path.exists()
+
+  mock_ui.report_evaluation_result.assert_any_call(
+    'feat-001.https.html', success=True, updated=True
+  )
+  mock_ui.report_evaluation_result.assert_any_call(
+    'feat-001-ref.sub.html', success=True, updated=True
+  )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -261,7 +261,7 @@ Random text
 ref content
 [/FILE_2]
 """
-  expected = [('test.html', 'test content'), ('ref.html', 'ref content')]
+  expected = [('.html', 'test content'), ('.html', 'ref content')]
   assert parse_multi_file_response(raw_text) == expected
 
 
@@ -277,6 +277,28 @@ html content
 [/FILE_2]
 """
   expected = [('.https.any.js', 'js content'), ('.sub.html', 'html content')]
+  assert parse_multi_file_response(raw_text) == expected
+
+
+def test_parse_multi_file_response_shave_suffixes() -> None:
+  from wptgen.utils import parse_multi_file_response
+
+  raw_text = """
+[FILE_1: my-test-001.https.html]
+content 1
+[/FILE_1]
+[FILE_2: ref-file.html]
+content 2
+[/FILE_2]
+[FILE_3: just_extension]
+content 3
+[/FILE_3]
+"""
+  expected = [
+    ('.https.html', 'content 1'),
+    ('.html', 'content 2'),
+    ('.just_extension', 'content 3'),
+  ]
   assert parse_multi_file_response(raw_text) == expected
 
 

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -150,18 +150,30 @@ async def _evaluate_and_update(
       ref_path_item = next((item for item in files if '-ref.' in item[0].name), None)
 
       if len(multi_files) >= 1 and test_path_item:
-        p, _ = test_path_item
-        _, fcontent = multi_files[0]
+        p_old, _ = test_path_item
+        new_suffix, fcontent = multi_files[0]
+        # Use existing root but update suffix if LLM suggested a change
+        root = p_old.name.split('.', 1)[0]
+        p_new = p_old.with_name(f'{root}{new_suffix}')
+
         clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
-        p.write_text(clean_content, encoding='utf-8')
-        ui.report_evaluation_result(p.name, success=True, updated=True)
+        if p_new != p_old:
+          p_old.unlink(missing_ok=True)
+        p_new.write_text(clean_content, encoding='utf-8')
+        ui.report_evaluation_result(p_new.name, success=True, updated=True)
 
       if len(multi_files) >= 2 and ref_path_item:
-        p, _ = ref_path_item
-        _, fcontent = multi_files[1]
+        p_old, _ = ref_path_item
+        new_suffix, fcontent = multi_files[1]
+        # Use existing root but update suffix if LLM suggested a change
+        root = p_old.name.split('.', 1)[0]
+        p_new = p_old.with_name(f'{root}{new_suffix}')
+
         clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
-        p.write_text(clean_content, encoding='utf-8')
-        ui.report_evaluation_result(p.name, success=True, updated=True)
+        if p_new != p_old:
+          p_old.unlink(missing_ok=True)
+        p_new.write_text(clean_content, encoding='utf-8')
+        ui.report_evaluation_result(p_new.name, success=True, updated=True)
     else:
       # If it's a single file correction
       if len(files) == 1:

--- a/wptgen/utils.py
+++ b/wptgen/utils.py
@@ -51,15 +51,27 @@ def parse_multi_file_response(raw_text: str) -> list[tuple[str, str]]:
   """Extracts multiple files from a partitioned LLM response.
 
   Expected format:
-  [FILE_1: filename.html]
+  [FILE_1: .flags.html]
   content
   [/FILE_1]
+
+  This function ensures the filename returned is a suffix (starting with a dot).
+  If the LLM provides a full filename, it shaves off the start until the first dot.
   """
   files = []
   for match in MULTI_FILE_RE.finditer(raw_text):
-    filename = match.group(2).strip()
+    suffix = match.group(2).strip()
+    # Shave off the start if it doesn't lead with a period
+    if suffix and not suffix.startswith('.'):
+      dot_idx = suffix.find('.')
+      if dot_idx != -1:
+        suffix = suffix[dot_idx:]
+      else:
+        # Fallback if no dot found at all - prepend a dot
+        suffix = '.' + suffix
+
     content = match.group(3).strip()
-    files.append((filename, content))
+    files.append((suffix, content))
   return files
 
 


### PR DESCRIPTION
- Implement suffix "shaving" logic in `parse_multi_file_response` to ensure filename suffixes start with a dot, even if the LLM provides a full filename.
- Update the evaluation phase to handle file renaming when the LLM suggests a corrected suffix (e.g., adding `.https` or changing extensions).
- Ensure existing files are unlinked when a suffix change causes a rename during evaluation.
- Add unit tests for suffix shaving and reftest renaming logic.
- Update existing utility tests to expect normalized suffixes.