### PR TITLE
feat: automatically verify and correct reftest reference links

### DIFF
--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -106,6 +106,52 @@ async def test_run_test_evaluation_correction(
 
 
 @pytest.mark.asyncio
+async def test_run_test_evaluation_reftest_link_fix(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Verify that reftest links are corrected during evaluation when files are updated."""
+  context = WorkflowContext(feature_id='reftest-feat')
+  jinja_env = MagicMock()
+
+  test_path = tmp_path / 'reftest-001.html'
+  ref_path = tmp_path / 'reftest-001-ref.html'
+
+  test_path.write_text('<link rel="match" href="old-ref.html">')
+  ref_path.write_text('Reference content')
+
+  suggestion_xml = '<test_suggestion><test_type>Reftest</test_type></test_suggestion>'
+  generated_tests = [
+    (test_path, test_path.read_text(), suggestion_xml),
+    (ref_path, ref_path.read_text(), suggestion_xml),
+  ]
+
+  # Mock LLM returning corrected content with a DIFFERENT SUFFIX for the reference
+  # FILE_1: test, FILE_2: ref
+  corrected_content = """
+[FILE_1: .https.html]
+<link rel="match" href="wrong-again.html">
+[/FILE_1]
+[FILE_2: .https.html]
+Updated reference
+[/FILE_2]
+"""
+  mock_llm.generate_content.return_value = corrected_content
+
+  with patch('wptgen.phases.evaluation.Path.read_text', return_value='Style Guide'):
+    await run_test_evaluation(context, mock_config, mock_llm, mock_ui, jinja_env, generated_tests)
+
+  # Check that the new files exist and have correct content
+  new_test_path = tmp_path / 'reftest-001.https.html'
+  new_ref_path = tmp_path / 'reftest-001-ref.https.html'
+
+  assert new_test_path.exists()
+  assert new_ref_path.exists()
+
+  # The link in the test should point to the NEW reference filename
+  assert '<link rel="match" href="reftest-001-ref.https.html">' in new_test_path.read_text()
+
+
+@pytest.mark.asyncio
 async def test_run_test_evaluation_with_markdown(
   mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
 ) -> None:
@@ -182,7 +228,8 @@ corrected ref content
   with patch('wptgen.phases.evaluation.Path.read_text', return_value=style_guide_content):
     await run_test_evaluation(context, mock_config, mock_llm, mock_ui, jinja_env, generated_tests)
 
-  assert test_path.read_text() == 'corrected test content'
+  assert '<link rel="match" href="test-ref.html">' in test_path.read_text()
+  assert 'corrected test content' in test_path.read_text()
   assert ref_path.read_text() == 'corrected ref content'
   mock_ui.report_evaluation_result.assert_any_call('test.html', success=True, updated=True)
   mock_ui.report_evaluation_result.assert_any_call('test-ref.html', success=True, updated=True)
@@ -295,7 +342,8 @@ new ref content
   new_ref_path = tmp_path / 'feat-001-ref.sub.html'
 
   assert new_test_path.exists()
-  assert new_test_path.read_text() == 'new test content'
+  assert '<link rel="match" href="feat-001-ref.sub.html">' in new_test_path.read_text()
+  assert 'new test content' in new_test_path.read_text()
   assert not test_path.exists()
 
   assert new_ref_path.exists()

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -325,6 +325,41 @@ async def test_run_test_generation_no_suggestions(
 
 
 @pytest.mark.asyncio
+async def test_run_test_generation_reftest_link_fix(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Verify that reftest links are corrected during generation."""
+  mock_config.output_dir = str(tmp_path)
+  context = WorkflowContext(
+    feature_id='reftest-feat',
+    audit_response='<status>TESTS_NEEDED</status><test_suggestion><test_type>Reftest</test_type><name>my-test</name></test_suggestion>',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+  )
+  jinja_env = MagicMock()
+  jinja_env.get_template.return_value.render.return_value = 'Mock Template'
+
+  reftest_content = """
+[FILE_1: .html]
+<link rel="match" href="wrong-ref.html">
+[/FILE_1]
+[FILE_2: .html]
+Reference content
+[/FILE_2]
+"""
+
+  with patch('wptgen.phases.generation.generate_safe', return_value=reftest_content):
+    res = await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
+
+  assert len(res) == 2
+  test_path, test_content, _ = res[0]
+  ref_path, ref_content, _ = res[1]
+
+  assert test_path.name == 'reftest-feat-001.html'
+  assert ref_path.name == 'reftest-feat-001-ref.html'
+  assert '<link rel="match" href="reftest-feat-001-ref.html">' in test_content
+
+
+@pytest.mark.asyncio
 async def test_run_test_generation_none_selected(
   mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock
 ) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -368,3 +368,43 @@ def test_get_next_available_root_large_number(tmp_path: Path) -> None:
 
   root = get_next_available_root('feat', tmp_path, used_names)
   assert root == 'feat-1000'
+
+
+def test_fix_reftest_link_update_existing() -> None:
+  from wptgen.utils import fix_reftest_link
+
+  content = '<link rel="match" href="old-ref.html">'
+  result = fix_reftest_link(content, 'new-ref.html')
+  assert result == '<link rel="match" href="new-ref.html">'
+
+  content = '<link href="old-ref.html" rel="match">'
+  result = fix_reftest_link(content, 'new-ref.html')
+  assert result == '<link rel="match" href="new-ref.html">'
+
+  content = "<html><head><link rel='match' href='old-ref.html'></head></html>"
+  result = fix_reftest_link(content, 'new-ref.html')
+  assert result == '<html><head><link rel="match" href="new-ref.html"></head></html>'
+
+
+def test_fix_reftest_link_add_to_head() -> None:
+  from wptgen.utils import fix_reftest_link
+
+  content = '<html><head><title>Test</title></head><body></body></html>'
+  result = fix_reftest_link(content, 'ref.html')
+  assert '<head>\n<link rel="match" href="ref.html">' in result
+
+
+def test_fix_reftest_link_add_to_html() -> None:
+  from wptgen.utils import fix_reftest_link
+
+  content = '<html><body></body></html>'
+  result = fix_reftest_link(content, 'ref.html')
+  assert '<html>\n<link rel="match" href="ref.html">' in result
+
+
+def test_fix_reftest_link_prepend() -> None:
+  from wptgen.utils import fix_reftest_link
+
+  content = '<div>No head or html tags here</div>'
+  result = fix_reftest_link(content, 'ref.html')
+  assert result == '<link rel="match" href="ref.html">\n<div>No head or html tags here</div>'

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -23,7 +23,12 @@ from wptgen.llm import LLMClient
 from wptgen.models import STYLE_GUIDE_MAP, TestType, WorkflowContext
 from wptgen.phases.utils import generate_safe
 from wptgen.ui import UIProvider
-from wptgen.utils import MARKDOWN_CODE_BLOCK_RE, extract_xml_tag, parse_multi_file_response
+from wptgen.utils import (
+  MARKDOWN_CODE_BLOCK_RE,
+  extract_xml_tag,
+  fix_reftest_link,
+  parse_multi_file_response,
+)
 
 
 async def run_test_evaluation(
@@ -100,7 +105,9 @@ async def run_test_evaluation(
       test_suggestion_xml=suggestion_xml,
       generated_code_content=generated_code_content.strip(),
     )
-    tasks.append(_evaluate_and_update(group, prompt, llm, ui, config, system_instruction))
+    tasks.append(
+      _evaluate_and_update(group, prompt, llm, ui, config, system_instruction, test_type_enum)
+    )
 
   await asyncio.gather(*tasks)
   ui.on_phase_complete('Evaluation')
@@ -113,6 +120,7 @@ async def _evaluate_and_update(
   ui: UIProvider,
   config: Config,
   system_instruction: str,
+  test_type_enum: TestType,
 ) -> None:
   """Evaluates a single test (or multi-file test) and updates the file(s) if needed."""
   display_names = ', '.join([p.name for p, _ in files])
@@ -149,31 +157,41 @@ async def _evaluate_and_update(
       test_path_item = next((item for item in files if '-ref.' not in item[0].name), None)
       ref_path_item = next((item for item in files if '-ref.' in item[0].name), None)
 
+      p_test_new = None
+      p_ref_new = None
+      c_test_new = None
+      c_ref_new = None
+
       if len(multi_files) >= 1 and test_path_item:
         p_old, _ = test_path_item
         new_suffix, fcontent = multi_files[0]
-        # Use existing root but update suffix if LLM suggested a change
         root = p_old.name.split('.', 1)[0]
-        p_new = p_old.with_name(f'{root}{new_suffix}')
-
-        clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
-        if p_new != p_old:
-          p_old.unlink(missing_ok=True)
-        p_new.write_text(clean_content, encoding='utf-8')
-        ui.report_evaluation_result(p_new.name, success=True, updated=True)
+        p_test_new = p_old.with_name(f'{root}{new_suffix}')
+        c_test_new = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
 
       if len(multi_files) >= 2 and ref_path_item:
         p_old, _ = ref_path_item
         new_suffix, fcontent = multi_files[1]
-        # Use existing root but update suffix if LLM suggested a change
         root = p_old.name.split('.', 1)[0]
-        p_new = p_old.with_name(f'{root}{new_suffix}')
+        p_ref_new = p_old.with_name(f'{root}{new_suffix}')
+        c_ref_new = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
 
-        clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
-        if p_new != p_old:
-          p_old.unlink(missing_ok=True)
-        p_new.write_text(clean_content, encoding='utf-8')
-        ui.report_evaluation_result(p_new.name, success=True, updated=True)
+      # If it's a reftest, fix the link in test content
+      if test_type_enum == TestType.REFTEST and c_test_new and p_ref_new:
+        c_test_new = fix_reftest_link(c_test_new, p_ref_new.name)
+
+      # Now save
+      if p_test_new and test_path_item and c_test_new is not None:
+        if p_test_new != test_path_item[0]:
+          test_path_item[0].unlink(missing_ok=True)
+        p_test_new.write_text(c_test_new, encoding='utf-8')
+        ui.report_evaluation_result(p_test_new.name, success=True, updated=True)
+
+      if p_ref_new and ref_path_item and c_ref_new is not None:
+        if p_ref_new != ref_path_item[0]:
+          ref_path_item[0].unlink(missing_ok=True)
+        p_ref_new.write_text(c_ref_new, encoding='utf-8')
+        ui.report_evaluation_result(p_ref_new.name, success=True, updated=True)
     else:
       # If it's a single file correction
       if len(files) == 1:

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -25,6 +25,7 @@ from wptgen.ui import UIProvider
 from wptgen.utils import (
   MARKDOWN_CODE_BLOCK_RE,
   extract_xml_tag,
+  fix_reftest_link,
   get_next_available_root,
   parse_multi_file_response,
   parse_suggestions,
@@ -192,16 +193,27 @@ async def _generate_and_save(
   # Check if we have multiple files (Reftests)
   multi_files = parse_multi_file_response(content)
   if multi_files:
-    for i, (suffix, fcontent) in enumerate(multi_files, 1):
-      # Handle reftest naming: FILE_2 gets -ref
+    raw_test_type = extract_xml_tag(suggestion_xml, 'test_type') or ''
+    is_reftest = raw_test_type.lower() == 'reftest'
+
+    # Pre-calculate filenames to know the reference name
+    filenames = []
+    for i, (suffix, _) in enumerate(multi_files, 1):
       if i == 2:
         # Assuming FILE_2 is always the ref for reftests
-        fname = f'{root_name}-ref{suffix}'
+        filenames.append(f'{root_name}-ref{suffix}')
       else:
         # For FILE_1 (test) and any other potential files, just use root + suffix
-        fname = f'{root_name}{suffix}'
+        filenames.append(f'{root_name}{suffix}')
 
+    for i, (_suffix, fcontent) in enumerate(multi_files, 0):
+      fname = filenames[i]
       clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', fcontent).strip()
+
+      # If it's the first file (the test) and it's a reftest, fix the link
+      if i == 0 and is_reftest and len(filenames) >= 2:
+        clean_content = fix_reftest_link(clean_content, filenames[1])
+
       output_path = output_dir / fname
       output_path.write_text(clean_content, encoding='utf-8')
       ui.report_test_generated(root_name, success=True, path=output_path)

--- a/wptgen/utils.py
+++ b/wptgen/utils.py
@@ -75,6 +75,44 @@ def parse_multi_file_response(raw_text: str) -> list[tuple[str, str]]:
   return files
 
 
+def fix_reftest_link(test_content: str, ref_filename: str) -> str:
+  """Verifies and updates the <link rel="match" href="..."> tag in a reftest.
+
+  Args:
+    test_content: The HTML content of the test file.
+    ref_filename: The name of the reference file (e.g., 'counter-set-001-ref.html').
+
+  Returns:
+    The updated HTML content with the correct <link rel="match" href="..."> tag.
+  """
+  # Pattern to match the <link rel="match" href="..."> tag.
+  # Flexible with single/double quotes, whitespace, and self-closing tags.
+  link_re = re.compile(
+    r'<link\s+[^>]*rel=["\']match["\'][^>]*href=["\'](.*?)["\'][^>]*\/?>'
+    r'|<link\s+[^>]*href=["\'](.*?)["\'][^>]*rel=["\']match["\'][^>]*\/?>',
+    re.IGNORECASE | re.DOTALL,
+  )
+
+  new_link = f'<link rel="match" href="{ref_filename}">'
+
+  if link_re.search(test_content):
+    # Update existing link
+    return link_re.sub(new_link, test_content)
+
+  # If no link tag exists, add it to the <head> section.
+  head_re = re.compile(r'(<head.*?>)', re.IGNORECASE)
+  if head_re.search(test_content):
+    return head_re.sub(r'\1\n' + new_link, test_content, count=1)
+
+  # Fallback: find <html> tag
+  html_re = re.compile(r'(<html.*?>)', re.IGNORECASE)
+  if html_re.search(test_content):
+    return html_re.sub(r'\1\n' + new_link, test_content, count=1)
+
+  # Absolute fallback: prepend to content
+  return new_link + '\n' + test_content
+
+
 def get_next_available_root(
   feature_id: str,
   output_dir: Path,


### PR DESCRIPTION
Ensure that reftests correctly reference their corresponding reference files in the `<link rel="match" href="...">` tag. This verification and correction happens during both the generation and evaluation phases to maintain correctness even if filenames or suffixes are updated.

- Add `fix_reftest_link` utility in `wptgen/utils.py` to update or insert the reftest match link using regex.
- Update `wptgen/phases/generation.py` to apply the correction after initial test generation.
- Update `wptgen/phases/evaluation.py` to handle link correction when reftests are updated or renamed during the evaluation phase.
- Fix linter and type-checker issues (unused variables, None checks).
- Add unit and integration tests to verify link correction across different HTML structures and workflow phases.