### PR TITLE
feat: implement limit for parallel asynchronous LLM requests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -266,3 +266,16 @@ def test_load_config_skip_evaluation(monkeypatch: pytest.MonkeyPatch) -> None:
   # Case 2: Override to True
   config = load_config(config_path='non_existent_dummy.yaml', skip_evaluation_override=True)
   assert config.skip_evaluation is True
+
+
+def test_load_config_max_parallel_requests(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Test that max_parallel_requests is correctly loaded."""
+  monkeypatch.setenv('GEMINI_API_KEY', 'mock-key')
+
+  # Case 1: Default (10)
+  config = load_config(config_path='non_existent_dummy.yaml')
+  assert config.max_parallel_requests == 10
+
+  # Case 2: Override to 20
+  config = load_config(config_path='non_existent_dummy.yaml', max_parallel_requests_override=20)
+  assert config.max_parallel_requests == 20

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -100,6 +100,7 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    max_parallel_requests_override=None,
   )
   mock_engine_class.assert_called_once()
   # Verify config was passed correctly
@@ -134,6 +135,7 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    max_parallel_requests_override=None,
   )
 
 
@@ -164,6 +166,7 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    max_parallel_requests_override=None,
   )
 
 
@@ -194,6 +197,7 @@ def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    max_parallel_requests_override=None,
   )
 
 
@@ -224,6 +228,7 @@ def test_generate_max_retries(mocker: MockerFixture, mock_config: Config) -> Non
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    max_parallel_requests_override=None,
   )
 
 
@@ -254,6 +259,7 @@ def test_generate_detailed_requirements(mocker: MockerFixture, mock_config: Conf
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    max_parallel_requests_override=None,
   )
 
 
@@ -283,6 +289,7 @@ def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) ->
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=True,
+    max_parallel_requests_override=None,
   )
 
   # Run with --no-eval alias
@@ -307,6 +314,7 @@ def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) ->
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=True,
+    max_parallel_requests_override=None,
   )
 
 
@@ -368,6 +376,7 @@ def test_generate_spec_urls(mocker: MockerFixture, mock_config: Config) -> None:
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    max_parallel_requests_override=None,
   )
 
 
@@ -398,6 +407,7 @@ def test_generate_description(mocker: MockerFixture, mock_config: Config) -> Non
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    max_parallel_requests_override=None,
   )
 
 
@@ -428,6 +438,7 @@ def test_generate_resume(mocker: MockerFixture, mock_config: Config) -> None:
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    max_parallel_requests_override=None,
   )
 
 
@@ -458,6 +469,7 @@ def test_generate_use_lightweight(mocker: MockerFixture, mock_config: Config) ->
     use_lightweight_override=True,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    max_parallel_requests_override=None,
   )
 
 
@@ -488,6 +500,7 @@ def test_generate_use_reasoning(mocker: MockerFixture, mock_config: Config) -> N
     use_lightweight_override=False,
     use_reasoning_override=True,
     skip_evaluation_override=False,
+    max_parallel_requests_override=None,
   )
 
 
@@ -518,6 +531,38 @@ def test_generate_categorized_requirements(mocker: MockerFixture, mock_config: C
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    max_parallel_requests_override=None,
+  )
+
+
+def test_generate_max_parallel_requests(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test that the --max-parallel-requests flag is correctly passed to load_config."""
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+  mocker.patch('wptgen.main.WPTGenEngine')
+
+  # Run with --max-parallel-requests
+  result = runner.invoke(app, ['generate', 'grid', '--max-parallel-requests', '5'])
+
+  assert result.exit_code == 0
+  mock_load_config.assert_called_once_with(
+    config_path=DEFAULT_CONFIG_PATH,
+    provider_override=None,
+    wpt_dir_override=None,
+    output_dir_override=None,
+    show_responses=False,
+    yes_tokens_override=False,
+    suggestions_only=False,
+    resume_override=False,
+    max_retries_override=3,
+    timeout_override=600,
+    spec_urls_override=None,
+    feature_description_override=None,
+    detailed_requirements_override=False,
+    categorized_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
+    skip_evaluation_override=False,
+    max_parallel_requests_override=5,
   )
 
 

--- a/tests/test_phase_utils.py
+++ b/tests/test_phase_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -133,3 +134,74 @@ async def test_generate_safe_exception(
   res = await generate_safe('prompt', 'Task', mock_llm, mock_ui, mock_config)
   assert res == ''
   mock_ui.error.assert_called_once_with('Task failed (test-model): test error')
+
+
+@pytest.mark.asyncio
+async def test_generate_safe_parallelism_limit(
+  mock_ui: MagicMock, mock_llm: MagicMock, mock_config: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  """Test that generate_safe respects the max_parallel_requests limit."""
+  import asyncio
+  import time
+
+  from wptgen.phases import utils
+
+  # Reset the global semaphore for this test
+  monkeypatch.setattr(utils, '_llm_semaphore', None)
+  mock_config.max_parallel_requests = 2
+
+  active_requests = 0
+  max_seen_parallel = 0
+
+  # So we can just mock llm.generate_content to be slow.
+  def slow_sync_generate(*args: Any, **kwargs: Any) -> str:
+    nonlocal active_requests, max_seen_parallel
+    active_requests += 1
+    max_seen_parallel = max(max_seen_parallel, active_requests)
+    time.sleep(0.1)
+    active_requests -= 1
+    return 'response'
+
+  mock_llm.generate_content.side_effect = slow_sync_generate
+
+  # Run 5 requests in parallel
+  tasks = [generate_safe(f'p{i}', f'T{i}', mock_llm, mock_ui, mock_config) for i in range(5)]
+  await asyncio.gather(*tasks)
+
+  # With max_parallel_requests = 2, we should never see more than 2 at a time
+  assert max_seen_parallel <= 2
+
+
+@pytest.mark.asyncio
+async def test_confirm_prompts_parallelism_limit(
+  mock_ui: MagicMock, mock_llm: MagicMock, mock_config: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  """Test that confirm_prompts respects the max_parallel_requests limit."""
+  import time
+
+  from wptgen.phases import utils
+
+  # Reset the global semaphore for this test
+  monkeypatch.setattr(utils, '_llm_semaphore', None)
+  mock_config.max_parallel_requests = 3
+
+  active_requests = 0
+  max_seen_parallel = 0
+
+  def slow_count_tokens(*args: Any, **kwargs: Any) -> int:
+    nonlocal active_requests, max_seen_parallel
+    active_requests += 1
+    max_seen_parallel = max(max_seen_parallel, active_requests)
+    time.sleep(0.05)
+    active_requests -= 1
+    return 100
+
+  mock_llm.count_tokens.side_effect = slow_count_tokens
+  mock_ui.confirm.return_value = True
+
+  # 10 prompts
+  prompt_data = [(f'p{i}', f'n{i}') for i in range(10)]
+  await confirm_prompts(prompt_data, 'Phase', mock_llm, mock_ui, mock_config)
+
+  # With max_parallel_requests = 3, we should never see more than 3 at a time
+  assert max_seen_parallel <= 3

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -55,6 +55,7 @@ class Config:
   wpt_browser: str = 'chrome'
   wpt_channel: str = 'canary'
   execution_timeout: int | float = 90  # Default 1.5 minutes
+  max_parallel_requests: int = 10
 
   def get_model_for_phase(self, phase_name: str) -> str | None:
     """Resolves the model name for a given workflow phase."""
@@ -128,6 +129,7 @@ def load_config(
   use_reasoning_override: bool = False,
   skip_evaluation_override: bool = False,
   require_api_key: bool = True,
+  max_parallel_requests_override: int | None = None,
 ) -> Config:
   """
   Loads configuration from YAML and environment variables.
@@ -191,6 +193,9 @@ def load_config(
   )
   max_retries = max_retries_override or yaml_data.get('max_retries', 3)
   timeout = timeout_override or yaml_data.get('timeout', DEFAULT_LLM_TIMEOUT)
+  max_parallel_requests = max_parallel_requests_override or yaml_data.get(
+    'max_parallel_requests', 10
+  )
 
   if timeout < MIN_LLM_TIMEOUT:
     logging.warning(
@@ -245,4 +250,5 @@ def load_config(
     wpt_browser=yaml_data.get('wpt_browser', 'chrome'),
     wpt_channel=yaml_data.get('wpt_channel', 'canary'),
     execution_timeout=yaml_data.get('execution_timeout', 90),
+    max_parallel_requests=max_parallel_requests,
   )

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -159,6 +159,13 @@ def generate(
       help='Skip the evaluation phase after generating tests.',
     ),
   ] = False,
+  max_parallel_requests: Annotated[
+    int | None,
+    typer.Option(
+      '--max-parallel-requests',
+      help='Maximum number of parallel asynchronous LLM requests.',
+    ),
+  ] = None,
 ) -> None:
   """
   Generate Web Platform Tests for a specific web feature.
@@ -213,6 +220,7 @@ def generate(
       use_lightweight_override=use_lightweight,
       use_reasoning_override=use_reasoning,
       skip_evaluation_override=skip_evaluation,
+      max_parallel_requests_override=max_parallel_requests,
     )
 
     config_info = Text.assemble(

--- a/wptgen/phases/utils.py
+++ b/wptgen/phases/utils.py
@@ -20,6 +20,17 @@ from wptgen.config import Config
 from wptgen.llm import LLMClient
 from wptgen.ui import UIProvider
 
+# Global semaphore to limit parallel LLM requests
+_llm_semaphore: asyncio.Semaphore | None = None
+
+
+def get_semaphore(config: Config) -> asyncio.Semaphore:
+  """Returns a shared semaphore to limit parallel LLM requests."""
+  global _llm_semaphore
+  if _llm_semaphore is None:
+    _llm_semaphore = asyncio.Semaphore(config.max_parallel_requests)
+  return _llm_semaphore
+
 
 async def confirm_prompts(
   prompt_data: list[tuple[str, str]],
@@ -38,10 +49,11 @@ async def confirm_prompts(
   with ui.status(f'Calculating token usage for {phase_name} ({target_model})...'):
     # We do token counting concurrently for speed
     async def get_info(prompt: str, name: str) -> tuple[int, bool, str]:
-      tokens = await loop.run_in_executor(None, llm.count_tokens, prompt, target_model)
-      limit_exceeded = await loop.run_in_executor(
-        None, llm.prompt_exceeds_input_token_limit, prompt, target_model
-      )
+      async with get_semaphore(config):
+        tokens = await loop.run_in_executor(None, llm.count_tokens, prompt, target_model)
+        limit_exceeded = await loop.run_in_executor(
+          None, llm.prompt_exceeds_input_token_limit, prompt, target_model
+        )
       return tokens, limit_exceeded, name
 
     results = await asyncio.gather(*(get_info(p, n) for p, n in prompt_data))
@@ -76,9 +88,10 @@ async def generate_safe(
   try:
     loop = asyncio.get_running_loop()
     with ui.status(f'Executing {task_name} ({target_model})...'):
-      response = await loop.run_in_executor(
-        None, llm.generate_content, prompt, system_instruction, temperature, model
-      )
+      async with get_semaphore(config):
+        response = await loop.run_in_executor(
+          None, llm.generate_content, prompt, system_instruction, temperature, model
+        )
 
     ui.success(f'{task_name} finished (using {target_model}).')
     if config.show_responses:


### PR DESCRIPTION
- Add `max_parallel_requests` configuration to `Config` (default 10).
- Expose `--max-parallel-requests` CLI flag in the `generate` command.
- Implement `asyncio.Semaphore` in `wptgen/phases/utils.py` to enforce the limit.
- Wrap LLM generation and token counting with the semaphore to prevent API overloading.
- Add comprehensive tests for configuration loading and parallelism enforcement.
- Update existing tests and fix mypy type annotation errors.