### PR TITLE
feat: provide rationale for empty requirement extraction categories

### DIFF
--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -266,6 +266,44 @@ async def test_run_requirements_extraction_categorized_partial_empty(
 
 
 @pytest.mark.asyncio
+async def test_run_requirements_extraction_categorized_with_rationale(
+  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  """Test categorized requirements extraction with a rationale for an empty category."""
+  context = WorkflowContext(
+    feature_id='feat-rationale',
+    metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
+    spec_contents='Spec',
+  )
+  jinja_env = MagicMock()
+  jinja_env.get_template.return_value.render.return_value = 'Mock Template'
+
+  # Mock generate_safe to return one category with a requirement and one with a rationale
+  with patch(
+    'wptgen.phases.requirements_extraction.generate_safe',
+    side_effect=[
+      '<requirements_list><requirement id="R1"><category>Existence</category><description>D1</description></requirement></requirements_list>',
+      '<requirements_list><rationale>This feature is a simple object and has no complex invalidation rules.</rationale></requirements_list>',
+      '<requirements_list></requirements_list>',  # Empty without rationale
+      '<requirements_list></requirements_list>',
+      '<requirements_list></requirements_list>',
+    ],
+  ):
+    res = await run_requirements_extraction_categorized(
+      context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
+    )
+
+  assert res is not None
+  assert '<requirement id="R1">' in res
+  assert 'rationale' not in res  # Final XML should NOT contain rationales
+
+  # Verify ui.info was called with the rationale
+  mock_ui.info.assert_any_call(
+    'No requirements found for category [Common Use Cases] This feature is a simple object and has no complex invalidation rules.'
+  )
+
+
+@pytest.mark.asyncio
 async def test_provide_coverage_report(
   mock_config: Config, mock_ui: MagicMock, tmp_path: Path
 ) -> None:

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -157,12 +157,20 @@ async def run_requirements_extraction_categorized(
     all_requirements: list[str] = []
     requirement_counter = 1
 
-    for response in responses:
+    for (name, _), response in zip(REQUIREMENT_CATEGORIES, responses, strict=True):
       if not response:
         continue
 
       # Extract individual <requirement> blocks.
       new_reqs = re.findall(r'(<requirement.*?>.*?</requirement>)', response, re.DOTALL)
+
+      if not new_reqs:
+        # If no requirements, look for a rationale.
+        rationale_match = re.search(r'<rationale>(.*?)</rationale>', response, re.DOTALL)
+        if rationale_match:
+          ui.info(f'No requirements found for category [{name}] {rationale_match.group(1).strip()}')
+        continue
+
       for req in new_reqs:
         # Re-index requirements as they come out
         re_indexed = re.sub(

--- a/wptgen/templates/requirements_extraction_categorized_system.jinja
+++ b/wptgen/templates/requirements_extraction_categorized_system.jinja
@@ -24,7 +24,7 @@ Read the `<spec_document>` (and `<mdn_document>` if available) and extract every
 
 DO NOT extract requirements for any other category.
 
-If the specification contains NO normative requirements for this specific category within the feature scope, it is expected and perfectly acceptable to return an empty list.
+If the specification contains NO normative requirements for this specific category within the feature scope, it is expected and perfectly acceptable to return an empty list, but you MUST provide a brief rationale within a `<rationale>` tag explaining why (e.g., the category is inapplicable or no absolute MUST/SHALL requirements were found).
 
 # STRICT OUTPUT FORMAT
 Your entire response must be a single `<requirements_list>` XML block. Do not wrap your response in markdown backticks.
@@ -38,4 +38,6 @@ If requirements are found:
 </requirements_list>
 
 If NO requirements are found for this category:
-<requirements_list></requirements_list>
+<requirements_list>
+  <rationale>[A brief explanation of why no normative requirements for {{category_name}} were found in the spec within the feature scope]</rationale>
+</requirements_list>


### PR DESCRIPTION
- Updated `requirements_extraction_categorized_system.jinja` to mandate a `<rationale>` tag when no normative requirements are found for a category.
- Updated `run_requirements_extraction_categorized` in `wptgen/phases/requirements_extraction.py` to capture and display these rationales in the CLI output.
- Added `test_run_requirements_extraction_categorized_with_rationale` to `tests/test_phases.py` to verify the new behavior.
- Fixed a linting issue by adding `strict=True` to the `zip()` call in `requirements_extraction.py`.

Verified with `make presubmit` (linting, type-checking, and tests passed).