### PR TITLE
feat(ui): display outstanding asynchronous request count

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -137,3 +137,19 @@ def test_report_evaluation_result(ui: RichUIProvider, mock_console: MagicMock) -
   """Test report_evaluation_result semantic method."""
   ui.report_evaluation_result('test.html', success=True)
   mock_console.print.assert_called_once_with('[green]✔ test.html passed evaluation.[/green]')
+
+
+@patch('wptgen.ui.Progress')
+def test_progress_indicator(mock_progress_class: MagicMock, ui: RichUIProvider) -> None:
+  """Test that progress_indicator correctly uses rich.progress.Progress."""
+  mock_progress = mock_progress_class.return_value.__enter__.return_value
+  mock_progress.add_task.return_value = 'task_1'
+
+  with ui.progress_indicator('Testing...', total=10) as indicator:
+    indicator.advance(2)
+    indicator.update(description='Updated', outstanding=8)
+
+  mock_progress_class.assert_called_once()
+  mock_progress.add_task.assert_called_once_with('Testing...', total=10)
+  mock_progress.advance.assert_called_once_with('task_1', advance=2)
+  mock_progress.update.assert_called_once_with('task_1', description='Updated (8 outstanding)')

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -109,7 +109,20 @@ async def run_test_evaluation(
       _evaluate_and_update(group, prompt, llm, ui, config, system_instruction, test_type_enum)
     )
 
-  await asyncio.gather(*tasks)
+  total_tasks = len(tasks)
+  completed_tasks = 0
+  with ui.progress_indicator(
+    f'Evaluating tests... ({total_tasks} outstanding)', total=total_tasks
+  ) as progress:
+    for future in asyncio.as_completed(tasks):
+      await future
+      completed_tasks += 1
+      remaining = total_tasks - completed_tasks
+      progress.update(
+        description='Evaluating tests...', outstanding=remaining if remaining > 0 else None
+      )
+      progress.advance()
+
   ui.on_phase_complete('Evaluation')
 
 

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -148,7 +148,20 @@ async def run_test_generation(
     )
     for prompt, root_name, suggestion_xml, system_instruction in prompts_to_confirm
   ]
-  results = await asyncio.gather(*tasks)
+
+  results = []
+  total_tasks = len(tasks)
+  with ui.progress_indicator(
+    f'Generating tests... ({total_tasks} outstanding)', total=total_tasks
+  ) as progress:
+    for future in asyncio.as_completed(tasks):
+      result = await future
+      results.append(result)
+      remaining = total_tasks - len(results)
+      progress.update(
+        description='Generating tests...', outstanding=remaining if remaining > 0 else None
+      )
+      progress.advance()
 
   # Flatten the list of lists (each task returns a list of files)
   final_results = [r for sublist in results for r in sublist]

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -150,9 +150,26 @@ async def run_requirements_extraction_categorized(
       )
 
     ui.info(f'Launching {len(REQUIREMENT_CATEGORIES)} parallel extraction requests...')
-    responses = await asyncio.gather(
-      *[extract_for_category(name, desc) for name, desc in REQUIREMENT_CATEGORIES]
-    )
+    total_tasks = len(REQUIREMENT_CATEGORIES)
+    completed_count = 0
+
+    async def wrap_with_progress(name: str, desc: str) -> str | None:
+      nonlocal completed_count
+      res = await extract_for_category(name, desc)
+      completed_count += 1
+      remaining = total_tasks - completed_count
+      progress.update(
+        description='Extracting requirements...', outstanding=remaining if remaining > 0 else None
+      )
+      progress.advance()
+      return res
+
+    with ui.progress_indicator(
+      f'Extracting requirements... ({total_tasks} outstanding)', total=total_tasks
+    ) as progress:
+      responses = await asyncio.gather(
+        *[wrap_with_progress(name, desc) for name, desc in REQUIREMENT_CATEGORIES]
+      )
 
     all_requirements: list[str] = []
     requirement_counter = 1

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -15,13 +15,15 @@
 from __future__ import annotations
 
 import re
-from contextlib import AbstractContextManager
+from collections.abc import Generator
+from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
+from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.prompt import Confirm
 from rich.syntax import Syntax
 from rich.table import Table
@@ -30,11 +32,21 @@ if TYPE_CHECKING:
   from wptgen.models import WebFeatureMetadata
 
 
+class ProgressIndicator(Protocol):
+  """Interface for updating a progress indicator."""
+
+  def advance(self, amount: float = 1) -> None: ...
+  def update(self, description: str | None = None, outstanding: int | None = None) -> None: ...
+
+
 class UIProvider(Protocol):
   """Semantic UI interface for the WPT generation workflow."""
 
   # Core interaction
   def status(self, message: str) -> AbstractContextManager[Any]: ...
+  def progress_indicator(
+    self, description: str, total: int
+  ) -> AbstractContextManager[ProgressIndicator]: ...
   def confirm(self, question: str, default: bool = True) -> bool: ...
 
   # Generic semantic messaging
@@ -86,6 +98,33 @@ class RichUIProvider:
 
   def status(self, message: str) -> AbstractContextManager[Any]:
     return self.console.status(message)
+
+  @contextmanager
+  def progress_indicator(
+    self, description: str, total: int
+  ) -> Generator[ProgressIndicator, None, None]:
+    with Progress(
+      SpinnerColumn(),
+      TextColumn('[progress.description]{task.description}'),
+      console=self.console,
+      transient=True,
+    ) as progress:
+      task_id = progress.add_task(description, total=total)
+
+      class _Indicator:
+        def advance(self, amount: float = 1) -> None:
+          progress.advance(task_id, advance=amount)
+
+        def update(self, description: str | None = None, outstanding: int | None = None) -> None:
+          kwargs: dict[str, Any] = {}
+          if description is not None:
+            if outstanding is not None:
+              kwargs['description'] = f'{description} ({outstanding} outstanding)'
+            else:
+              kwargs['description'] = description
+          progress.update(task_id, **kwargs)
+
+      yield _Indicator()
 
   def confirm(self, question: str, default: bool = True) -> bool:
     return Confirm.ask(question, default=default)


### PR DESCRIPTION
Implemented a real-time progress indicator to show the number of outstanding asynchronous requests during batch operations. This provides better feedback during long-running parallel LLM calls.

Key changes:
- Added `progress_indicator` context manager to `UIProvider` and `RichUIProvider` using `rich.progress.Progress`.
- Updated `run_requirements_extraction_categorized` to show live progress while preserving response order.
- Updated `run_test_generation` to show the number of remaining tests being generated.
- Updated `run_test_evaluation` to provide a countdown of outstanding evaluations.
- Added unit tests for the new `progress_indicator` in `tests/test_ui.py`.
- Fixed linting issues and reformatted `wptgen/ui.py`.