### PR TITLE
feat(ui): display cumulative test requirements count after extraction

### DIFF
--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -187,7 +187,8 @@ async def test_run_requirements_extraction_cached(
 
   assert res == '<reqs>cached</reqs>'
   mock_ui.info.assert_called_once()
-  mock_ui.success.assert_called_once_with('Using cached requirements.')
+  mock_ui.success.assert_any_call('Using cached requirements.')
+  mock_ui.success.assert_any_call('Extracted 0 test requirements.')
 
 
 @pytest.mark.asyncio

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -85,6 +85,9 @@ async def run_requirements_extraction(
     # Save to cache
     cache_file.write_text(requirements_xml, encoding='utf-8')
 
+  count = len(re.findall(r'<requirement.*?>', requirements_xml))
+  ui.success(f'Extracted {count} test requirements.')
+
   context.requirements_xml = requirements_xml
   return requirements_xml
 
@@ -207,6 +210,8 @@ async def run_requirements_extraction_categorized(
     # Save to cache
     cache_file.write_text(requirements_xml, encoding='utf-8')
 
+  count = len(re.findall(r'<requirement.*?>', requirements_xml))
+  ui.success(f'Extracted {count} test requirements.')
   context.requirements_xml = requirements_xml
   return requirements_xml
 
@@ -315,5 +320,7 @@ async def run_requirements_extraction_iterative(
     # Save to cache
     cache_file.write_text(requirements_xml, encoding='utf-8')
 
+  count = len(re.findall(r'<requirement.*?>', requirements_xml))
+  ui.success(f'Extracted {count} test requirements.')
   context.requirements_xml = requirements_xml
   return requirements_xml


### PR DESCRIPTION
Updated the requirements extraction phase to report the total number of normative requirements identified from the specification. This provides immediate feedback on the volume of testable material found before proceeding to the coverage audit.

Key changes:
- Integrated count aggregation into `run_requirements_extraction`, `run_requirements_extraction_categorized`, and `run_requirements_extraction_iterative`.
- Displays the total count using the existing `ui.success` mechanism.
- Updated `test_run_requirements_extraction_cached` in `tests/test_phases.py` to verify the additional UI reporting when loading from cache.
- Ensured consistency by counting requirements from the final XML, avoiding potential scope errors during parallel or iterative extraction.

Verified with `make presubmit` (linting, type-checking, and tests passed).