### PR TITLE
docs: add comprehensive CLI command reference (#133)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,17 +148,22 @@ The primary interface is the `generate` command, which requires a **Web Feature 
 wpt-gen generate grid
 ```
 
-### Command Options
+### Common Options
 
 | Option | Shorthand | Description |
 | :--- | :--- | :--- |
 | `web_feature_id` | (Arg) | **Required.** The ID of the feature (e.g., `grid`, `popover`). |
-| `--provider` | `-p` | Override the default LLM provider (`gemini`, `openai`, or `anthropic`). |
+| `--provider` | `-p` | Override the default LLM provider (`gemini`, `openai`, `anthropic`). |
 | `--wpt-dir` | `-w` | Override the path to the local web-platform-tests repository. |
 | `--config` | `-c` | Path to a custom `wpt-gen.yml` file. |
-| `--show-responses`| `-s` | Display every LLM-generated response to the user. |
-| `--use-lightweight`| | Use the provider's lightweight model for all LLM requests. |
-| `--use-reasoning`| | Use the provider's reasoning model for all LLM requests. |
+
+**Note:** For a full list of all 20+ options (including execution control, retries, and manual overrides), see the [CLI Command Reference](docs/cli.md).
+
+### Other Commands
+
+*   `wpt-gen clear-cache`: Clears local cache of specs and LLM responses.
+*   `wpt-gen version`: Displays the current version.
+
 
 
 ## Development

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,81 @@
+# CLI Command Reference
+
+This document provides a detailed reference for all commands and options available in the `wpt-gen` CLI.
+
+## `wpt-gen generate`
+
+Generate Web Platform Tests for a specific web feature.
+
+**Usage:**
+```bash
+wpt-gen generate [OPTIONS] WEB_FEATURE_ID
+```
+
+### Arguments
+
+| Argument | Description |
+| :--- | :--- |
+| `WEB_FEATURE_ID` | **Required.** The ID of the feature (e.g., `grid`, `popover`) as defined in the `web-features` repository. |
+
+### Options
+
+#### General Options
+| Option | Shorthand | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `--provider` | `-p` | Override the default LLM provider (`gemini`, `openai`, `anthropic`). | From config |
+| `--wpt-dir` | `-w` | Override the path to the local web-platform-tests repository. | From config |
+| `--config` | `-c` | Path to a custom `wpt-gen.yml` file. | `~/.wpt-gen.yml` |
+| `--output-dir` | `-o` | Directory where generated tests will be saved. | Local WPT repo |
+
+#### Execution Control
+| Option | Description |
+| :--- | :--- |
+| `--resume` | Resume the workflow from the last successful phase for this feature ID. |
+| `--suggestions-only` | Stop after generating test blueprints/suggestions. Skip the actual test file generation. |
+| `--yes-tokens` | Automatically confirm all prompts related to LLM token counts. |
+| `--skip-evaluation`, `--no-eval` | Skip the Phase 5 (Evaluation) step. |
+| `--max-parallel-requests` | Limit the number of concurrent asynchronous LLM requests. |
+
+#### Model Configuration
+| Option | Description |
+| :--- | :--- |
+| `--use-lightweight` | Force the use of the provider's "lightweight" model for all phases. |
+| `--use-reasoning` | Force the use of the provider's "reasoning" model for all phases. |
+| `--show-responses`, `-s` | Print every raw LLM response to the console (useful for debugging). |
+| `--max-retries` | Maximum number of retries for failed LLM calls. |
+| `--timeout` | Timeout for individual LLM requests in seconds. |
+
+#### Feature & Requirement Overrides
+| Option | Shorthand | Description |
+| :--- | :--- | :--- |
+| `--spec-urls` | `-u` | Comma-separated list of W3C Spec URLs to use, bypassing automatic fetching. |
+| `--description` | `-d` | Provide a manual description/summary of the feature to the agent. |
+| `--detailed-requirements` | | Use an iterative process to extract highly granular requirements (slower). |
+| `--categorized-requirements` | | Extract requirements in parallel across technical categories (faster). |
+
+---
+
+## `wpt-gen clear-cache`
+
+Clears the local cache of scraped specifications and LLM responses.
+
+**Usage:**
+```bash
+wpt-gen clear-cache [OPTIONS]
+```
+
+### Options
+| Option | Shorthand | Description |
+| :--- | :--- | :--- |
+| `--config` | `-c` | Path to a custom `wpt-gen.yml` file. |
+
+---
+
+## `wpt-gen version`
+
+Print the current version of `wpt-gen`.
+
+**Usage:**
+```bash
+wpt-gen version
+```


### PR DESCRIPTION
Created a detailed CLI documentation in `docs/cli.md` and updated the main `README.md` to point to it. This ensures all 20+ available options for the `generate` command, as well as auxiliary commands like `clear-cache` and `version`, are properly documented.

Key changes:
- Created `docs/cli.md` with a full reference of arguments and options.
- Streamlined `README.md` Usage section to focus on common flags.
- Added "Other Commands" section to `README.md`.
- Linked `README.md` to the detailed CLI reference.