### PR TITLE
Add `--temperature` flag to control LLM request temperature

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -101,6 +101,7 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     use_reasoning_override=False,
     skip_evaluation_override=False,
     max_parallel_requests_override=None,
+    temperature_override=None,
   )
   mock_engine_class.assert_called_once()
   # Verify config was passed correctly
@@ -136,6 +137,7 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     use_reasoning_override=False,
     skip_evaluation_override=False,
     max_parallel_requests_override=None,
+    temperature_override=None,
   )
 
 
@@ -167,6 +169,7 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     use_reasoning_override=False,
     skip_evaluation_override=False,
     max_parallel_requests_override=None,
+    temperature_override=None,
   )
 
 
@@ -198,6 +201,7 @@ def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -
     use_reasoning_override=False,
     skip_evaluation_override=False,
     max_parallel_requests_override=None,
+    temperature_override=None,
   )
 
 
@@ -229,6 +233,7 @@ def test_generate_max_retries(mocker: MockerFixture, mock_config: Config) -> Non
     use_reasoning_override=False,
     skip_evaluation_override=False,
     max_parallel_requests_override=None,
+    temperature_override=None,
   )
 
 
@@ -260,6 +265,7 @@ def test_generate_detailed_requirements(mocker: MockerFixture, mock_config: Conf
     use_reasoning_override=False,
     skip_evaluation_override=False,
     max_parallel_requests_override=None,
+    temperature_override=None,
   )
 
 
@@ -290,6 +296,7 @@ def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) ->
     use_reasoning_override=False,
     skip_evaluation_override=True,
     max_parallel_requests_override=None,
+    temperature_override=None,
   )
 
   # Run with --no-eval alias
@@ -315,6 +322,7 @@ def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) ->
     use_reasoning_override=False,
     skip_evaluation_override=True,
     max_parallel_requests_override=None,
+    temperature_override=None,
   )
 
 
@@ -377,6 +385,7 @@ def test_generate_spec_urls(mocker: MockerFixture, mock_config: Config) -> None:
     use_reasoning_override=False,
     skip_evaluation_override=False,
     max_parallel_requests_override=None,
+    temperature_override=None,
   )
 
 
@@ -408,6 +417,7 @@ def test_generate_description(mocker: MockerFixture, mock_config: Config) -> Non
     use_reasoning_override=False,
     skip_evaluation_override=False,
     max_parallel_requests_override=None,
+    temperature_override=None,
   )
 
 
@@ -439,6 +449,7 @@ def test_generate_resume(mocker: MockerFixture, mock_config: Config) -> None:
     use_reasoning_override=False,
     skip_evaluation_override=False,
     max_parallel_requests_override=None,
+    temperature_override=None,
   )
 
 
@@ -470,6 +481,7 @@ def test_generate_use_lightweight(mocker: MockerFixture, mock_config: Config) ->
     use_reasoning_override=False,
     skip_evaluation_override=False,
     max_parallel_requests_override=None,
+    temperature_override=None,
   )
 
 
@@ -501,6 +513,7 @@ def test_generate_use_reasoning(mocker: MockerFixture, mock_config: Config) -> N
     use_reasoning_override=True,
     skip_evaluation_override=False,
     max_parallel_requests_override=None,
+    temperature_override=None,
   )
 
 
@@ -532,6 +545,7 @@ def test_generate_categorized_requirements(mocker: MockerFixture, mock_config: C
     use_reasoning_override=False,
     skip_evaluation_override=False,
     max_parallel_requests_override=None,
+    temperature_override=None,
   )
 
 
@@ -563,6 +577,7 @@ def test_generate_max_parallel_requests(mocker: MockerFixture, mock_config: Conf
     use_reasoning_override=False,
     skip_evaluation_override=False,
     max_parallel_requests_override=5,
+    temperature_override=None,
   )
 
 

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -56,6 +56,7 @@ class Config:
   wpt_channel: str = 'canary'
   execution_timeout: int | float = 90  # Default 1.5 minutes
   max_parallel_requests: int = 10
+  temperature: float | None = None
 
   def get_model_for_phase(self, phase_name: str) -> str | None:
     """Resolves the model name for a given workflow phase."""
@@ -130,6 +131,7 @@ def load_config(
   skip_evaluation_override: bool = False,
   require_api_key: bool = True,
   max_parallel_requests_override: int | None = None,
+  temperature_override: float | None = None,
 ) -> Config:
   """
   Loads configuration from YAML and environment variables.
@@ -258,4 +260,7 @@ def load_config(
     wpt_channel=yaml_data.get('wpt_channel', 'canary'),
     execution_timeout=yaml_data.get('execution_timeout', 90),
     max_parallel_requests=max_parallel_requests,
+    temperature=temperature_override
+    if temperature_override is not None
+    else yaml_data.get('temperature'),
   )

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -168,6 +168,13 @@ def generate(
       help='Maximum number of parallel asynchronous LLM requests.',
     ),
   ] = None,
+  temperature: Annotated[
+    float | None,
+    typer.Option(
+      '--temperature',
+      help='Global temperature setting for all LLM requests (e.g., 0.01). Overrides phase-specific defaults.',
+    ),
+  ] = None,
 ) -> None:
   """
   Generate Web Platform Tests for a specific web feature.
@@ -223,6 +230,7 @@ def generate(
       use_reasoning_override=use_reasoning,
       skip_evaluation_override=skip_evaluation,
       max_parallel_requests_override=max_parallel_requests,
+      temperature_override=temperature,
     )
 
     config_info = Text.assemble(

--- a/wptgen/phases/utils.py
+++ b/wptgen/phases/utils.py
@@ -85,12 +85,13 @@ async def generate_safe(
 ) -> str:
   """Helper to run LLM generation in a thread and handle errors gracefully."""
   target_model = model or llm.model
+  effective_temperature = config.temperature if config.temperature is not None else temperature
   try:
     loop = asyncio.get_running_loop()
     with ui.status(f'Executing {task_name} ({target_model})...'):
       async with get_semaphore(config):
         response = await loop.run_in_executor(
-          None, llm.generate_content, prompt, system_instruction, temperature, model
+          None, llm.generate_content, prompt, system_instruction, effective_temperature, model
         )
 
     ui.success(f'{task_name} finished (using {target_model}).')


### PR DESCRIPTION
## Background & Motivation
This PR introduces a `--temperature` flag to the CLI, globally overriding the hardcoded phase-specific temperatures for all LLM interactions. This enables experimental configuration and fine-tuned consistency tuning when running test generations.

## Proposed Changes
- **Configuration:** Added a `temperature` attribute to `Config` in `wptgen/config.py`.
- **CLI Interface:** Exposed a `--temperature` option via Typer in `wptgen/main.py`.
- **LLM Threading:** Updated the `effective_temperature` override in `wptgen/phases/utils.py`'s `generate_safe` helper to respect the config setting.
- **Testing:** Updated `tests/test_main.py` to ensure the new `temperature_override` parameter is correctly asserted across all configuration tests.

Resolves #139