### PR TITLE
feat: Add MockLLMClient provider for offline testing

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -61,6 +61,22 @@ def test_load_config_provider_override_openai(monkeypatch: pytest.MonkeyPatch) -
   }
 
 
+def test_load_config_provider_override_mock(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Test overriding the provider via the CLI flag to mock, bypassing API key."""
+  monkeypatch.delenv('MOCK_API_KEY', raising=False)
+  monkeypatch.delenv('GEMINI_API_KEY', raising=False)
+
+  config = load_config(config_path='non_existent_dummy.yaml', provider_override='mock')
+
+  assert config.provider == 'mock'
+  assert config.default_model == 'mock-model'
+  assert config.api_key is None
+  assert config.categories == {
+    'lightweight': 'mock-lightweight',
+    'reasoning': 'mock-reasoning',
+  }
+
+
 def test_load_config_missing_api_key_raises_error(monkeypatch: pytest.MonkeyPatch) -> None:
   """Test that missing the required environment variable raises a ValueError."""
   # Ensure the environment variable is explicitly removed for this test

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -19,7 +19,7 @@ from google.genai import types
 from pytest_mock import MockerFixture
 
 from wptgen.config import Config
-from wptgen.llm import GeminiClient, OpenAIClient, get_llm_client
+from wptgen.llm import GeminiClient, MockLLMClient, OpenAIClient, get_llm_client
 
 
 @pytest.fixture
@@ -385,3 +385,48 @@ def test_llm_client_custom_retries(mocker: MockerFixture, gemini_config: Config)
     client.generate_content('test')
 
   assert mock_instance.models.generate_content.call_count == 5
+
+
+@pytest.fixture
+def mock_config() -> Config:
+  """Provides a valid Mock configuration."""
+  return Config(
+    provider='mock',
+    default_model='mock-model',
+    api_key='mock-key',
+    wpt_path='dummy',
+    categories={'lightweight': 'mock-light', 'reasoning': 'mock-reasoning'},
+    phase_model_mapping={},
+  )
+
+
+def test_get_llm_client_mock(mock_config: Config) -> None:
+  """Test that the factory returns a MockLLMClient when configured for mock."""
+  client = get_llm_client(mock_config)
+  assert isinstance(client, MockLLMClient)
+  assert client.model == 'mock-model'
+
+
+def test_mock_generate_content(mock_config: Config) -> None:
+  client = get_llm_client(mock_config)
+  assert 'Mock requirement' in client.generate_content(
+    prompt='foo', system_instruction='EXTRACTION PROTOCOL'
+  )
+  assert 'Mock Test' in client.generate_content(
+    prompt='foo', system_instruction='BLUEPRINT MAPPING PROTOCOL'
+  )
+  assert '[UNCOVERED]' in client.generate_content(
+    prompt='foo', system_instruction='THE AUDIT PROTOCOL'
+  )
+  assert 'PASS' in client.generate_content(prompt='foo', system_instruction='EVALUATION CRITERIA')
+  assert 'Mock response' in client.generate_content(prompt='hello')
+
+
+def test_mock_count_tokens(mock_config: Config) -> None:
+  client = get_llm_client(mock_config)
+  assert client.count_tokens('one two three') == 3
+
+
+def test_mock_prompt_exceeds_input_token_limit(mock_config: Config) -> None:
+  client = get_llm_client(mock_config)
+  assert client.prompt_exceeds_input_token_limit('huge prompt') is False

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -175,12 +175,19 @@ def load_config(
       'lightweight': 'claude-sonnet-4-6',
       'reasoning': 'claude-opus-4-6',
     }
+  elif active_provider == 'mock':
+    default_model_name = 'mock-model'
+    env_var_name = 'MOCK_API_KEY'
+    default_categories = {
+      'lightweight': 'mock-lightweight',
+      'reasoning': 'mock-reasoning',
+    }
   else:
     raise ValueError(f"CRITICAL: Unsupported provider '{active_provider}' requested.")
 
   # Enforce the environment variable constraint for the active provider
   api_key = os.environ.get(env_var_name)
-  if require_api_key and not api_key:
+  if require_api_key and active_provider != 'mock' and not api_key:
     raise ValueError(
       f'CRITICAL: {env_var_name} environment variable is missing. '
       f"Required when using the '{active_provider}' provider."

--- a/wptgen/llm.py
+++ b/wptgen/llm.py
@@ -305,8 +305,53 @@ class AnthropicClient(LLMClient):
     return token_count > limit
 
 
+class MockLLMClient(LLMClient):
+  def count_tokens(self, prompt: str, model: str | None = None) -> int:
+    """Returns a mock token count."""
+    return len(prompt.split())
+
+  def generate_content(
+    self,
+    prompt: str,
+    system_instruction: str | None = None,
+    temperature: float | None = None,
+    model: str | None = None,
+  ) -> str:
+    """Returns static dummy content based on the prompt or system instruction."""
+    system_instruction = system_instruction or ''
+
+    # Requirements Extraction
+    if 'EXTRACTION PROTOCOL' in system_instruction:
+      return '<requirements_list>\n  <requirement id="REQ-1">\n    <category>Existence</category>\n    <description>Mock requirement</description>\n  </requirement>\n</requirements_list>'
+
+    # Coverage Audit
+    elif 'THE AUDIT PROTOCOL' in system_instruction:
+      return '<audit_worksheet>\nR1: Mock requirement -> [UNCOVERED]\n</audit_worksheet>\n\n<test_suggestions>\n  <test_suggestion>\n    <title>Mock Test</title>\n    <description>Mock Description</description>\n    <test_type>JavaScript Test</test_type>\n    <pre_conditions><![CDATA[None]]></pre_conditions>\n    <steps>\n      <step>1. Mock Step 1</step>\n    </steps>\n    <expected_result>Mock Result</expected_result>\n  </test_suggestion>\n</test_suggestions>'
+
+    # Test Generation
+    elif 'BLUEPRINT MAPPING PROTOCOL' in system_instruction:
+      return '[FILE_1: .html]\n<!DOCTYPE html>\n<html>\n<head>\n<title>Mock Test</title>\n</head>\n<body></body>\n</html>\n[/FILE_1]'
+
+    # Evaluation
+    elif 'EVALUATION CRITERIA' in system_instruction:
+      return 'PASS'
+
+    return 'Mock response'
+
+  def prompt_exceeds_input_token_limit(self, prompt: str, model: str | None = None) -> bool:
+    """Always returns False for the mock client."""
+    return False
+
+
 def get_llm_client(config: Config) -> LLMClient:
   """Factory function to instantiate the correct LLM provider."""
+  if config.provider == 'mock':
+    return MockLLMClient(
+      api_key='mock',
+      model=config.default_model,
+      max_retries=config.max_retries,
+      timeout=config.timeout,
+    )
   assert config.api_key is not None, 'api_key must be set in configuration'
   if config.provider == 'gemini':
     return GeminiClient(

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -195,22 +195,25 @@ async def _evaluate_and_update(
 
       # Now save
       if p_test_new and test_path_item and c_test_new is not None:
-        if p_test_new != test_path_item[0]:
-          test_path_item[0].unlink(missing_ok=True)
-        p_test_new.write_text(c_test_new, encoding='utf-8')
+        if config.provider != 'mock':
+          if p_test_new != test_path_item[0]:
+            test_path_item[0].unlink(missing_ok=True)
+          p_test_new.write_text(c_test_new, encoding='utf-8')
         ui.report_evaluation_result(p_test_new.name, success=True, updated=True)
 
       if p_ref_new and ref_path_item and c_ref_new is not None:
-        if p_ref_new != ref_path_item[0]:
-          ref_path_item[0].unlink(missing_ok=True)
-        p_ref_new.write_text(c_ref_new, encoding='utf-8')
+        if config.provider != 'mock':
+          if p_ref_new != ref_path_item[0]:
+            ref_path_item[0].unlink(missing_ok=True)
+          p_ref_new.write_text(c_ref_new, encoding='utf-8')
         ui.report_evaluation_result(p_ref_new.name, success=True, updated=True)
     else:
       # If it's a single file correction
       if len(files) == 1:
         path = files[0][0]
         clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', clean_response).strip()
-        path.write_text(clean_content, encoding='utf-8')
+        if config.provider != 'mock':
+          path.write_text(clean_content, encoding='utf-8')
         ui.report_evaluation_result(path.name, success=True, updated=True)
       else:
         ui.report_evaluation_result(

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -228,14 +228,16 @@ async def _generate_and_save(
         clean_content = fix_reftest_link(clean_content, filenames[1])
 
       output_path = output_dir / fname
-      output_path.write_text(clean_content, encoding='utf-8')
+      if config.provider != 'mock':
+        output_path.write_text(clean_content, encoding='utf-8')
       ui.report_test_generated(root_name, success=True, path=output_path)
       results.append((output_path, clean_content, suggestion_xml))
   else:
     # Single file fallback - if the LLM failed to use partitioning tags, default to .html
     clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', content).strip()
     output_path = output_dir / f'{root_name}.html'
-    output_path.write_text(clean_content, encoding='utf-8')
+    if config.provider != 'mock':
+      output_path.write_text(clean_content, encoding='utf-8')
     ui.report_test_generated(root_name, success=True, path=output_path, fallback=True)
     results.append((output_path, clean_content, suggestion_xml))
 


### PR DESCRIPTION
Resolves #138. Added a MockLLMClient provider to simulate the test generation lifecycle offline. Verified with make presubmit.