### PR TITLE
feat: Add `list-models` command to query available LLM models

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -658,6 +658,42 @@ def test_doctor_command_failure(mocker: MockerFixture, mock_config: Config) -> N
   assert 'Some checks failed.' in result.stdout
 
 
+def test_list_models_command(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test the list-models command prints the configured models."""
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+
+  result = runner.invoke(app, ['list-models'])
+
+  assert result.exit_code == 0
+  assert 'Configured Models' in result.stdout
+  mock_load_config.assert_called_once_with(
+    config_path=DEFAULT_CONFIG_PATH, provider_override=None, require_api_key=False
+  )
+
+
+def test_list_models_command_provider_override(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test the list-models command respects provider override."""
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+
+  result = runner.invoke(app, ['list-models', '--provider', 'openai'])
+
+  assert result.exit_code == 0
+  mock_load_config.assert_called_once_with(
+    config_path=DEFAULT_CONFIG_PATH, provider_override='openai', require_api_key=False
+  )
+
+
+def test_list_models_command_error(mocker: MockerFixture) -> None:
+  """Test the list-models command handles errors gracefully."""
+  mocker.patch('wptgen.main.load_config', side_effect=ValueError('Invalid provider'))
+
+  result = runner.invoke(app, ['list-models', '--provider', 'fake'])
+
+  assert result.exit_code == 1
+  assert 'Error:' in result.stdout
+  assert 'Invalid provider' in result.stdout
+
+
 def test_main_callback() -> None:
   """Test the main callback."""
   from wptgen.main import main_callback

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -393,6 +393,43 @@ def config_command(
     raise typer.Exit(code=1) from e
 
 
+@app.command(name='list-models')
+def list_models(
+  provider: Annotated[
+    str | None,
+    typer.Option(
+      '--provider',
+      '-p',
+      help="Override the default LLM provider (e.g., 'gemini', 'openai', 'anthropic').",
+    ),
+  ] = None,
+  config_path: Annotated[
+    str, typer.Option('--config', '-c', help='Path to a custom wpt-gen.yml file.')
+  ] = DEFAULT_CONFIG_PATH,
+) -> None:
+  """
+  Display the configured LLM models for the active provider.
+  """
+  try:
+    from rich.table import Table
+
+    config = load_config(config_path=config_path, provider_override=provider, require_api_key=False)
+
+    table = Table(title=f'Configured Models for {config.provider.capitalize()}')
+    table.add_column('Category', justify='left', style='cyan', no_wrap=True)
+    table.add_column('Model Name', justify='left', style='magenta')
+
+    table.add_row('default', config.default_model)
+    for cat_name, mod_name in config.categories.items():
+      table.add_row(cat_name, mod_name)
+
+    console.print()
+    console.print(table)
+  except Exception as e:
+    console.print(f'[bold red]Error:[/bold red] {str(e)}')
+    raise typer.Exit(code=1) from e
+
+
 @app.command(name='clear-cache')
 def clear_cache(
   config_path: Annotated[


### PR DESCRIPTION
## Background
Resolves #149

Users currently lack an easy way to verify which LLM models are available or configured without checking documentation. This PR implements a `list-models` command that queries and displays the configured LLM models.

## Changes
- Adds a `list-models` command to `wptgen/main.py`.
- Outputs a formatted Rich table displaying the models for the active LLM provider.
- Includes support for a `--provider` argument to override the default and inspect other supported providers.
- Displays categories like "lightweight" and "reasoning" alongside the default models.
- Includes unit tests in `tests/test_main.py`.

## Validation
- `make presubmit` completed successfully.