### PR TITLE
fix: Pass spec context to generation phase for test writing

### DIFF
--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -125,6 +125,7 @@ async def run_test_generation(
     final_prompt = gen_template.render(
       feature_name=context.metadata.name,
       feature_description=context.metadata.description,
+      spec_contents=context.spec_contents,
       test_suggestion_xml_block=suggestion_xml,
     )
 

--- a/wptgen/templates/test_generation.jinja
+++ b/wptgen/templates/test_generation.jinja
@@ -1,3 +1,9 @@
 Generate a single WPT file for the feature "{{feature_name}}" ({{feature_description}}) based on the following blueprint:
 
 {{ test_suggestion_xml_block }}
+
+{% if spec_contents -%}
+# Specification Context
+The exact API definitions, interfaces, and expected behaviors for this feature:
+{{ spec_contents }}
+{%- endif %}

--- a/wptgen/templates/test_generation_system.jinja
+++ b/wptgen/templates/test_generation_system.jinja
@@ -4,6 +4,7 @@ You are WPT-Gen, an automated, expert-level Web Platform Test (WPT) generation e
 # CORE DIRECTIVES
 1.  **Zero Conversation:** Do not output conversational filler, pleasantries, or explanatory text. Output ONLY the raw file contents.
 2.  **Formatting Strictness:** Output the exact HTML/JS file content. Do not wrap your final output in markdown code blocks unless specifically instructed.
+3.  **Specification Adherence:** Use the provided Specification Context to guarantee exact API names, WebIDL signatures, arguments, and expected behaviors. Do not hallucinate properties; rely strictly on the spec context to ensure the tests correctly target the feature.
 
 # BLUEPRINT MAPPING PROTOCOL
 You will receive a `<test_suggestion>` XML blueprint. You must map its fields to the WPT file as follows:


### PR DESCRIPTION
## Background
The generation phase previously lacked access to the spec contents, making it difficult for the LLM to know exactly how to write tests for the feature.

## Proposed Changes
- Updates `wptgen/phases/generation.py` to pass `context.spec_contents` into the LLM request.
- Updates `wptgen/templates/test_generation.jinja` to provide the specification context to the prompt, ensuring the code generation LLM has direct API definitions and examples available.
- Updates `wptgen/templates/test_generation_system.jinja` to explicitly instruct the LLM on how to use the spec contents to write accurate tests that don't hallucinate properties.

Resolves #140