### PR TITLE
feat: explicitly state config path in wpt-gen config output

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -292,3 +292,22 @@ def test_load_config_yes_tests(monkeypatch: pytest.MonkeyPatch) -> None:
   # Case 2: Override to True
   config = load_config(config_path='non_existent_dummy.yaml', yes_tests_override=True)
   assert config.yes_tests is True
+
+
+def test_load_config_loaded_from(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+  """Test that loaded_from is correctly set when a config file exists."""
+  monkeypatch.setenv('GEMINI_API_KEY', 'mock-key')
+
+  config_file = tmp_path / 'wpt-gen.yml'
+  config_file.write_text('provider: openai', encoding='utf-8')
+
+  config = load_config(config_path=str(config_file), require_api_key=False)
+  assert config.loaded_from == str(config_file.resolve())
+
+
+def test_load_config_loaded_from_none(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Test that loaded_from is None when no config file exists."""
+  monkeypatch.setenv('GEMINI_API_KEY', 'mock-key')
+
+  config = load_config(config_path='non_existent.yml', require_api_key=False)
+  assert config.loaded_from is None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -702,7 +702,8 @@ def test_main_callback() -> None:
 
 
 def test_config_command(mocker: MockerFixture, mock_config: Config) -> None:
-  """Test the config command prints the resolved configuration."""
+  """Test the config command prints the resolved configuration and its path."""
+  mock_config.loaded_from = '/dummy/path/wpt-gen.yml'
   mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
 
   result = runner.invoke(app, ['config'])
@@ -710,6 +711,22 @@ def test_config_command(mocker: MockerFixture, mock_config: Config) -> None:
   assert result.exit_code == 0
   assert 'Resolved Configuration' in result.stdout
   assert 'provider:' in result.stdout
+  assert 'Reading configuration from:' in result.stdout
+  assert '/dummy/path/wpt-gen.yml' in result.stdout
+  assert 'loaded_from:' not in result.stdout  # Ensure it's not in the YAML dump
+  mock_load_config.assert_called_once_with(config_path=DEFAULT_CONFIG_PATH, require_api_key=False)
+
+
+def test_config_command_defaults(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test the config command prints the defaults message when no file is loaded."""
+  mock_config.loaded_from = None
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+
+  result = runner.invoke(app, ['config'])
+
+  assert result.exit_code == 0
+  assert 'Resolved Configuration' in result.stdout
+  assert 'Reading configuration from: Defaults (no config file found)' in result.stdout
   mock_load_config.assert_called_once_with(config_path=DEFAULT_CONFIG_PATH, require_api_key=False)
 
 

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -59,6 +59,7 @@ class Config:
   execution_timeout: int | float = 90  # Default 1.5 minutes
   max_parallel_requests: int = 10
   temperature: float | None = None
+  loaded_from: str | None = None
 
   def get_model_for_phase(self, phase_name: str) -> str | None:
     """Resolves the model name for a given workflow phase."""
@@ -158,16 +159,19 @@ def load_config(
   """
   path = Path(config_path)
   yaml_data: dict[str, Any] = {}
+  loaded_from: str | None = None
 
   if path.exists():
     with open(path, encoding='utf-8') as f:
       yaml_data = yaml.safe_load(f) or {}
+    loaded_from = str(path.resolve())
   elif config_path == DEFAULT_CONFIG_PATH:
     # Fallback to global config if the default local path does not exist
     global_path = Path(_get_global_config_path())
     if global_path.exists():
       with open(global_path, encoding='utf-8') as f:
         yaml_data = yaml.safe_load(f) or {}
+      loaded_from = str(global_path.resolve())
 
   # Determine the active provider
   # CLI override takes precedence, then YAML default.
@@ -290,4 +294,5 @@ def load_config(
     temperature=temperature_override
     if temperature_override is not None
     else yaml_data.get('temperature'),
+    loaded_from=loaded_from,
   )

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -384,6 +384,14 @@ def config_command(
     if config_dict.get('api_key'):
       config_dict['api_key'] = '********'
 
+    if config.loaded_from:
+      console.print(f'Reading configuration from: [cyan]{config.loaded_from}[/cyan]')
+    else:
+      console.print('Reading configuration from: [yellow]Defaults (no config file found)[/yellow]')
+
+    # Remove internal fields from display
+    config_dict.pop('loaded_from', None)
+
     yaml_str = yaml.dump(config_dict, sort_keys=False, default_flow_style=False)
     console.print(
       Panel(yaml_str, title='Resolved Configuration', border_style='blue', expand=False)


### PR DESCRIPTION
## Description
This pull request addresses the lack of visibility regarding the configuration file path in the `wpt-gen config` output. 

It explicitly states the absolute path of the configuration file it is reading from (e.g., the default `wpt-gen.yml` file, a custom path passed via `--config`, or environment defaults) to improve the developer experience and make the CLI more transparent.

## Changes Made
- Modified the `Config` dataclass in `wptgen/config.py` to include a `loaded_from` attribute.
- Updated `load_config` in `wptgen/config.py` to populate the `loaded_from` path.
- Updated the `config_command` in `wptgen/main.py` to display the configuration path prior to printing the configuration table.
- Filtered `loaded_from` out of the YAML display to avoid redundancy.
- Added comprehensive unit tests in `tests/test_config.py` and `tests/test_main.py` to ensure the correct path logic and CLI output.

Resolves #161

## Verification
- Validated via `make presubmit` with no errors.
