### PR TITLE
feat: dynamically set syntax highlighting for LLM responses based on generated file suffix

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -100,10 +100,63 @@ def test_report_token_usage(ui: RichUIProvider, mock_console: MagicMock) -> None
   mock_console.print.assert_called_once()
 
 
-def test_report_llm_response(ui: RichUIProvider, mock_console: MagicMock) -> None:
-  """Test report_llm_response semantic method."""
-  ui.report_llm_response('response', 'Task')
+@patch('wptgen.ui.Syntax')
+def test_report_llm_response_js_suffix(
+  mock_syntax: MagicMock, ui: RichUIProvider, mock_console: MagicMock
+) -> None:
+  """Test report_llm_response uses 'javascript' lexer when a .js file is generated."""
+  response = "[FILE_1: test.any.js]\nconsole.log('test');\n[/FILE_1]"
+  ui.report_llm_response(response, 'Task')
+  mock_syntax.assert_called_once()
+  args, kwargs = mock_syntax.call_args
+  assert args[0] == response
+  assert args[1] == 'javascript'
   mock_console.print.assert_called_once()
+
+
+@patch('wptgen.ui.Syntax')
+def test_report_llm_response_html_suffix(
+  mock_syntax: MagicMock, ui: RichUIProvider, mock_console: MagicMock
+) -> None:
+  """Test report_llm_response uses 'html' lexer when a .html file is generated."""
+  response = '[FILE_1: test.html]\n<div></div>\n[/FILE_1]'
+  ui.report_llm_response(response, 'Task')
+  mock_syntax.assert_called_once()
+  assert mock_syntax.call_args[0][1] == 'html'
+  mock_console.print.assert_called_once()
+
+
+@patch('wptgen.ui.Syntax')
+def test_report_llm_response_fallback_gen(
+  mock_syntax: MagicMock, ui: RichUIProvider, mock_console: MagicMock
+) -> None:
+  """Test report_llm_response falls back to 'html' if task_name contains 'gen:' and no files are found."""
+  response = 'Some standard markdown response'
+  ui.report_llm_response(response, 'Gen: phase')
+  mock_syntax.assert_called_once()
+  assert mock_syntax.call_args[0][1] == 'html'
+
+
+@patch('wptgen.ui.Syntax')
+def test_report_llm_response_fallback_eval(
+  mock_syntax: MagicMock, ui: RichUIProvider, mock_console: MagicMock
+) -> None:
+  """Test report_llm_response falls back to 'html' if task_name contains 'eval:' and no files are found."""
+  response = 'Some standard markdown response'
+  ui.report_llm_response(response, 'Eval: phase')
+  mock_syntax.assert_called_once()
+  assert mock_syntax.call_args[0][1] == 'html'
+
+
+@patch('wptgen.ui.Syntax')
+def test_report_llm_response_fallback_default(
+  mock_syntax: MagicMock, ui: RichUIProvider, mock_console: MagicMock
+) -> None:
+  """Test report_llm_response falls back to 'xml' default if no files and not gen/eval task."""
+  response = 'Some standard markdown response'
+  ui.report_llm_response(response, 'Audit Phase')
+  mock_syntax.assert_called_once()
+  assert mock_syntax.call_args[0][1] == 'xml'
 
 
 def test_report_coverage_audit(ui: RichUIProvider, mock_console: MagicMock) -> None:

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -29,6 +29,8 @@ from rich.prompt import Confirm
 from rich.syntax import Syntax
 from rich.table import Table
 
+from wptgen.utils import parse_multi_file_response
+
 if TYPE_CHECKING:
   from wptgen.models import WebFeatureMetadata
 
@@ -228,8 +230,18 @@ class RichUIProvider:
   def report_llm_response(self, response: str, task_name: str) -> None:
     # Determine syntax highlighting based on content (defaulting to xml).
     syntax_lexer = 'xml'
-    if 'gen:' in task_name.lower():
-      syntax_lexer = 'html'
+    parsed_files = parse_multi_file_response(response)
+
+    if parsed_files:
+      suffix = parsed_files[0][0].lower()
+      if suffix.endswith('.js'):
+        syntax_lexer = 'javascript'
+      elif suffix.endswith('.html'):
+        syntax_lexer = 'html'
+    else:
+      # Fallback to current logic if no file tags found
+      if 'gen:' in task_name.lower() or 'eval:' in task_name.lower():
+        syntax_lexer = 'html'
 
     syntax = Syntax(response, syntax_lexer, theme='monokai', line_numbers=True, word_wrap=True)
     self.console.print(


### PR DESCRIPTION
## Description
This pull request addresses the problem where raw JavaScript code generated by the LLM was being displayed with HTML syntax highlighting, making it difficult to read in the console when using the `--show-responses` flag.

The syntax highlighter will now dynamically adapt based on the generated file type by extracting the suffix from the `[FILE_x: ...]` tags in the response string. 

## Changes Made
- Imported `parse_multi_file_response` into `wptgen/ui.py`.
- Updated `report_llm_response` to inspect the response for file suffixes.
- Dynamically assigns the `javascript` lexer for `.js` extensions and `html` lexer for `.html`.
- Preserves the fallback behavior to `html` or `xml` when file tags aren't present (such as during audits and plain-text evaluation responses).
- Added comprehensive unit tests in `tests/test_ui.py` to cover permutations of this highlighting logic.

Resolves #162

## Verification
- Validated via `make presubmit` with no errors.