### PR TITLE
feat: standardize global configuration directory for wpt-gen

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -756,7 +756,7 @@ def test_init_command_global(mocker: MockerFixture) -> None:
     # 3. '' (lightweight model - accept default)
     # 4. '' (reasoning model - accept default)
     # 5. '/fake/wpt' (wpt_path)
-    result = runner.invoke(app, ['init', '--global'], input='gemini\n\n\n\n/fake/wpt\n')
+    result = runner.invoke(app, ['init'], input='gemini\n\n\n\n/fake/wpt\n')
 
     assert result.exit_code == 0
     assert 'Configuration saved successfully' in result.stdout

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -731,19 +731,16 @@ def version() -> None:
 @app.command(name='init')
 def init(
   config_path: Annotated[
-    str, typer.Option('--config', '-c', help='Path to a custom wpt-gen.yml file.')
-  ] = DEFAULT_CONFIG_PATH,
-  global_config: Annotated[
-    bool, typer.Option('--global', help='Initialize the global configuration file.')
-  ] = False,
+    str | None, typer.Option('--config', '-c', help='Path to a custom wpt-gen.yml file.')
+  ] = None,
 ) -> None:
   """
   Initialize a new wpt-gen configuration file interactively.
   """
-  if global_config:
-    resolved_path = Path(_get_global_config_path())
-  else:
+  if config_path:
     resolved_path = Path(config_path)
+  else:
+    resolved_path = Path(_get_global_config_path())
 
   # Ensure the directory exists
   resolved_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Resolves #169

## Background & Motivation
To align with standard CLI conventions and reduce repository clutter, `wpt-gen` now defaults to standard platform-specific configuration directories instead of dumping `wpt-gen.yml` directly into the current working directory.

## Changes Included
* `wpt-gen init` automatically resolves and writes the configuration file to the appropriate global standard directory (`~/.config/wpt-gen/config.yml` on Linux, etc.).
* The `--global` flag has been removed from the `wpt-gen init` command since standard global placement is now the default behavior.
* `wpt-gen init --config wpt-gen.yml` can still be used if a local project-level configuration file is needed.
* Existing configurations maintain the local-first, global-fallback resolution behavior, which inherently works with `wpt-gen config` to pull either the local or the global settings.
* Automated tests for `wpt-gen init` were updated to correctly cover this fallback logic.
