### PR TITLE
Consolidate default LLM models into a single constant source of truth

### DIFF
--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -26,6 +26,24 @@ DEFAULT_LLM_TIMEOUT = 600
 # Minimum allowed timeout for Gemini API (10 seconds)
 MIN_LLM_TIMEOUT = 10
 
+DEFAULT_PROVIDER_MODELS = {
+  'gemini': {
+    'default': 'gemini-3.1-pro-preview',
+    'lightweight': 'gemini-3-flash-preview',
+    'reasoning': 'gemini-3.1-pro-preview',
+  },
+  'openai': {
+    'default': 'gpt-5.2-high',
+    'lightweight': 'gpt-5-mini',
+    'reasoning': 'gpt-5.2-high',
+  },
+  'anthropic': {
+    'default': 'claude-opus-4-6',
+    'lightweight': 'claude-sonnet-4-6',
+    'reasoning': 'claude-opus-4-6',
+  },
+}
+
 
 @dataclass
 class Config:
@@ -183,29 +201,22 @@ def load_config(
   provider_settings = providers_config.get(active_provider, {})
 
   # Provide sensible defaults if the YAML is missing the specific provider block
-  if active_provider == 'gemini':
-    default_model_name = 'gemini-3.1-pro-preview'
-    env_var_name = 'GEMINI_API_KEY'
-    default_categories = {
-      'lightweight': 'gemini-3-flash-preview',
-      'reasoning': 'gemini-3.1-pro-preview',
-    }
-  elif active_provider == 'openai':
-    default_model_name = 'gpt-5.2-high'
-    env_var_name = 'OPENAI_API_KEY'
-    default_categories = {
-      'lightweight': 'gpt-5-mini',
-      'reasoning': 'gpt-5.2-high',
-    }
-  elif active_provider == 'anthropic':
-    default_model_name = 'claude-opus-4-6'
-    env_var_name = 'ANTHROPIC_API_KEY'
-    default_categories = {
-      'lightweight': 'claude-sonnet-4-6',
-      'reasoning': 'claude-opus-4-6',
-    }
-  else:
+  if active_provider not in DEFAULT_PROVIDER_MODELS:
     raise ValueError(f"CRITICAL: Unsupported provider '{active_provider}' requested.")
+
+  provider_defaults = DEFAULT_PROVIDER_MODELS[active_provider]
+  default_model_name = provider_defaults['default']
+  default_categories = {
+    'lightweight': provider_defaults['lightweight'],
+    'reasoning': provider_defaults['reasoning'],
+  }
+
+  if active_provider == 'gemini':
+    env_var_name = 'GEMINI_API_KEY'
+  elif active_provider == 'openai':
+    env_var_name = 'OPENAI_API_KEY'
+  elif active_provider == 'anthropic':
+    env_var_name = 'ANTHROPIC_API_KEY'
 
   # Enforce the environment variable constraint for the active provider
   api_key = os.environ.get(env_var_name)

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -30,6 +30,7 @@ from rich.text import Text
 from wptgen.config import (
   DEFAULT_CONFIG_PATH,
   DEFAULT_LLM_TIMEOUT,
+  DEFAULT_PROVIDER_MODELS,
   _get_global_config_path,
   load_config,
 )
@@ -755,26 +756,7 @@ def init(
     'Preferred LLM Provider', choices=['gemini', 'openai', 'anthropic'], default='gemini'
   )
 
-  # Define the default models for each provider
-  provider_defaults = {
-    'gemini': {
-      'default': 'gemini-3.1-pro-preview',
-      'lightweight': 'gemini-3-flash-preview',
-      'reasoning': 'gemini-3.1-pro-preview',
-    },
-    'openai': {
-      'default': 'gpt-5.2-high',
-      'lightweight': 'gpt-5-mini',
-      'reasoning': 'gpt-5.2-high',
-    },
-    'anthropic': {
-      'default': 'claude-opus-4-6',
-      'lightweight': 'claude-sonnet-4-6',
-      'reasoning': 'claude-opus-4-6',
-    },
-  }
-
-  defaults = provider_defaults[provider]
+  defaults = DEFAULT_PROVIDER_MODELS[provider]
 
   console.print(f'\n[cyan]Configuring models for {provider}[/cyan]')
   default_model = Prompt.ask('Default model', default=defaults['default'])


### PR DESCRIPTION
### Background
Resolves #167.

Currently, default model names for Gemini, OpenAI, and Anthropic were hardcoded in multiple locations. This PR consolidates them into a single `DEFAULT_PROVIDER_MODELS` constant inside `wptgen/config.py` as requested.

### Proposed Changes
- Added a `DEFAULT_PROVIDER_MODELS` constant to `wptgen/config.py` defining `default`, `lightweight`, and `reasoning` models for each supported provider.
- Refactored `wptgen/config.py` to reference `DEFAULT_PROVIDER_MODELS`.
- Refactored `wptgen/main.py`'s `init` command to use the imported constant rather than redefining the defaults.

### Verification
- `make presubmit` has been run and all linting, type-checking, and tests are passing successfully.
