### PR TITLE
fix: strip hallucinated `.tentative` flags from generated file names

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -101,6 +101,7 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
   )
@@ -138,6 +139,7 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
   )
@@ -171,6 +173,7 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
   )
@@ -204,6 +207,7 @@ def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
   )
@@ -237,6 +241,7 @@ def test_generate_max_retries(mocker: MockerFixture, mock_config: Config) -> Non
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
   )
@@ -270,6 +275,7 @@ def test_generate_detailed_requirements(mocker: MockerFixture, mock_config: Conf
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
   )
@@ -302,6 +308,7 @@ def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) ->
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=True,
+    tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
   )
@@ -329,6 +336,7 @@ def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) ->
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=True,
+    tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
   )
@@ -393,6 +401,7 @@ def test_generate_spec_urls(mocker: MockerFixture, mock_config: Config) -> None:
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
   )
@@ -426,6 +435,7 @@ def test_generate_description(mocker: MockerFixture, mock_config: Config) -> Non
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
   )
@@ -459,6 +469,7 @@ def test_generate_resume(mocker: MockerFixture, mock_config: Config) -> None:
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
   )
@@ -492,6 +503,7 @@ def test_generate_use_lightweight(mocker: MockerFixture, mock_config: Config) ->
     use_lightweight_override=True,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
   )
@@ -525,6 +537,7 @@ def test_generate_use_reasoning(mocker: MockerFixture, mock_config: Config) -> N
     use_lightweight_override=False,
     use_reasoning_override=True,
     skip_evaluation_override=False,
+    tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
   )
@@ -558,6 +571,7 @@ def test_generate_categorized_requirements(mocker: MockerFixture, mock_config: C
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
   )
@@ -591,6 +605,7 @@ def test_generate_max_parallel_requests(mocker: MockerFixture, mock_config: Conf
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    tentative_override=False,
     max_parallel_requests_override=5,
     temperature_override=None,
   )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -302,6 +302,32 @@ content 3
   assert parse_multi_file_response(raw_text) == expected
 
 
+def test_parse_multi_file_response_strip_tentative() -> None:
+  from wptgen.utils import parse_multi_file_response
+
+  raw_text = """
+[FILE_1: .tentative.https.html]
+content 1
+[/FILE_1]
+[FILE_2: my-test.tentative.any.js]
+content 2
+[/FILE_2]
+"""
+  # Default behavior (strip_tentative=False)
+  expected_no_strip = [
+    ('.tentative.https.html', 'content 1'),
+    ('.tentative.any.js', 'content 2'),
+  ]
+  assert parse_multi_file_response(raw_text) == expected_no_strip
+
+  # Stripped behavior (strip_tentative=True)
+  expected_stripped = [
+    ('.https.html', 'content 1'),
+    ('.any.js', 'content 2'),
+  ]
+  assert parse_multi_file_response(raw_text, strip_tentative=True) == expected_stripped
+
+
 def test_parse_multi_file_response_empty() -> None:
   from wptgen.utils import parse_multi_file_response
 

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -71,6 +71,7 @@ class Config:
   use_lightweight: bool = False
   use_reasoning: bool = False
   skip_evaluation: bool = False
+  tentative: bool = False
   max_correction_retries: int = 2
   wpt_browser: str = 'chrome'
   wpt_channel: str = 'canary'
@@ -167,6 +168,7 @@ def load_config(
   use_lightweight_override: bool = False,
   use_reasoning_override: bool = False,
   skip_evaluation_override: bool = False,
+  tentative_override: bool = False,
   require_api_key: bool = True,
   max_parallel_requests_override: int | None = None,
   temperature_override: float | None = None,
@@ -256,6 +258,7 @@ def load_config(
 
   cache_path = yaml_data.get('cache_path') or _get_default_cache_path()
   skip_evaluation = skip_evaluation_override or yaml_data.get('skip_evaluation', False)
+  tentative = tentative_override or yaml_data.get('tentative', False)
 
   # Load model categories and phase mapping
   default_model = provider_settings.get('default_model', default_model_name)
@@ -298,6 +301,7 @@ def load_config(
     use_lightweight=use_lightweight_override,
     use_reasoning=use_reasoning_override,
     skip_evaluation=skip_evaluation,
+    tentative=tentative,
     wpt_browser=yaml_data.get('wpt_browser', 'chrome'),
     wpt_channel=yaml_data.get('wpt_channel', 'canary'),
     execution_timeout=yaml_data.get('execution_timeout', 90),

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -176,6 +176,13 @@ def generate(
       help='Skip the evaluation phase after generating tests.',
     ),
   ] = False,
+  tentative: Annotated[
+    bool,
+    typer.Option(
+      '--tentative',
+      help='Generate test files with the .tentative flag.',
+    ),
+  ] = False,
   max_parallel_requests: Annotated[
     int | None,
     typer.Option(
@@ -245,6 +252,7 @@ def generate(
       use_lightweight_override=use_lightweight,
       use_reasoning_override=use_reasoning,
       skip_evaluation_override=skip_evaluation,
+      tentative_override=tentative,
       max_parallel_requests_override=max_parallel_requests,
       temperature_override=temperature,
     )
@@ -611,6 +619,7 @@ def audit(
       use_lightweight_override=use_lightweight,
       use_reasoning_override=use_reasoning,
       skip_evaluation_override=True,
+      tentative_override=False,
       max_parallel_requests_override=max_parallel_requests,
       temperature_override=temperature,
     )

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -163,7 +163,7 @@ async def _evaluate_and_update(
   else:
     # If it's not PASS, it should be the corrected file content
     # Check if we have multiple files in the response
-    multi_files = parse_multi_file_response(clean_response)
+    multi_files = parse_multi_file_response(clean_response, strip_tentative=not config.tentative)
     if multi_files:
       # For Reftests, we expect FILE_1 to be test and FILE_2 to be ref
       # We need to find which path is which

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -205,7 +205,7 @@ async def _generate_and_save(
   output_dir.mkdir(parents=True, exist_ok=True)
 
   # Check if we have multiple files (Reftests)
-  multi_files = parse_multi_file_response(content)
+  multi_files = parse_multi_file_response(content, strip_tentative=not config.tentative)
   if multi_files:
     raw_test_type = extract_xml_tag(suggestion_xml, 'test_type') or ''
     is_reftest = raw_test_type.lower() == 'reftest'

--- a/wptgen/utils.py
+++ b/wptgen/utils.py
@@ -47,7 +47,9 @@ def parse_suggestions(raw_text: str) -> list[str]:
   return SUGGESTION_BLOCK_RE.findall(raw_text)
 
 
-def parse_multi_file_response(raw_text: str) -> list[tuple[str, str]]:
+def parse_multi_file_response(
+  raw_text: str, strip_tentative: bool = False
+) -> list[tuple[str, str]]:
   """Extracts multiple files from a partitioned LLM response.
 
   Expected format:
@@ -61,6 +63,10 @@ def parse_multi_file_response(raw_text: str) -> list[tuple[str, str]]:
   files = []
   for match in MULTI_FILE_RE.finditer(raw_text):
     suffix = match.group(2).strip()
+
+    if strip_tentative:
+      suffix = suffix.replace('.tentative', '')
+
     # Shave off the start if it doesn't lead with a period
     if suffix and not suffix.startswith('.'):
       dot_idx = suffix.find('.')


### PR DESCRIPTION
## Background & Motivation
This PR addresses an issue where LLMs infer from a feature's name or description that a specification is still in draft/development. As a result, they proactively (and incorrectly) append a `.tentative` flag to the generated test file names (e.g., `[FILE_1: .tentative.https.html]`).

## Proposed Changes
- **Parser Update:** Modified `parse_multi_file_response` in `wptgen/utils.py` to accept a new parameter, `strip_tentative`, that actively removes `.tentative` flags from the parsed suffix when `True`.
- **Phase Integration:** Passed `strip_tentative=not config.tentative` to the parser during both the generation and evaluation phases.
- **CLI Configuration:** Added a new `--tentative` boolean flag to the Typer CLI (`wptgen/main.py`) and integrated it with the global config (`wptgen/config.py`).
- **Validation:** Added a specific unit test for this edge case in `tests/test_utils.py` and updated the CLI configuration mocks in `tests/test_main.py`.

Resolves #134 and resolves #135