### PR TITLE
feat: allow test generation for draft web-features

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ wpt-gen generate grid
 | `web_feature_id` | (Arg) | **Required.** The ID of the feature (e.g., `grid`, `popover`). |
 | `--provider` | `-p` | Override the default LLM provider (`gemini`, `openai`, `anthropic`). |
 | `--wpt-dir` | `-w` | Override the path to the local web-platform-tests repository. |
+| `--draft` | | Enable fetching metadata from the draft features directory. |
 | `--config` | `-c` | Path to a custom `wpt-gen.yml` file. |
 
 **Note:** For a full list of all 20+ options (including execution control, retries, and manual overrides), see the [CLI Command Reference](docs/cli.md).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,6 +51,7 @@ wpt-gen generate [OPTIONS] WEB_FEATURE_ID
 | `--spec-urls` | `-u` | Comma-separated list of W3C Spec URLs to use, bypassing automatic fetching. |
 | `--description` | `-d` | Provide a manual description/summary of the feature to the agent. |
 | `--detailed-requirements` | | Use an iterative process to extract highly granular requirements (slower). |
+| `--draft` | | Enable fetching metadata from the draft features directory. |
 | `--categorized-requirements` | | Extract requirements in parallel across technical categories (faster). |
 
 ---

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -432,3 +432,23 @@ def test_gather_local_test_context_exception(tmp_path: Path, mocker: MockerFixtu
 
   context = gather_local_test_context([str(test_html)], str(wpt_root))
   assert context.test_contents == {}
+
+
+def test_fetch_feature_yaml_draft(mocker: MockerFixture) -> None:
+  """Test that fetching a draft feature constructs the correct URL."""
+  mock_urlopen = mocker.patch('urllib.request.urlopen')
+
+  mock_response = mocker.MagicMock()
+  mock_response.read.return_value = b"name: 'Draft Feature'"
+  mock_urlopen.return_value.__enter__.return_value = mock_response
+
+  result = fetch_feature_yaml('draft-feature', draft=True)
+
+  assert result == {'name': 'Draft Feature'}
+  mock_urlopen.assert_called_once()
+
+  request_obj = mock_urlopen.call_args[0][0]
+  assert (
+    request_obj.full_url
+    == 'https://raw.githubusercontent.com/web-platform-dx/web-features/main/features/draft/spec/draft-feature.yml'
+  )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -97,6 +97,7 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    draft_override=False,
     categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
@@ -135,6 +136,7 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    draft_override=False,
     categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
@@ -169,6 +171,7 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    draft_override=False,
     categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
@@ -203,6 +206,7 @@ def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    draft_override=False,
     categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
@@ -237,6 +241,7 @@ def test_generate_max_retries(mocker: MockerFixture, mock_config: Config) -> Non
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    draft_override=False,
     categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
@@ -271,6 +276,7 @@ def test_generate_detailed_requirements(mocker: MockerFixture, mock_config: Conf
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=True,
+    draft_override=False,
     categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
@@ -304,6 +310,7 @@ def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) ->
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    draft_override=False,
     categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
@@ -332,6 +339,7 @@ def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) ->
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    draft_override=False,
     categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
@@ -397,6 +405,7 @@ def test_generate_spec_urls(mocker: MockerFixture, mock_config: Config) -> None:
     spec_urls_override=['https://url1.com', 'https://url2.com'],
     feature_description_override=None,
     detailed_requirements_override=False,
+    draft_override=False,
     categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
@@ -431,6 +440,7 @@ def test_generate_description(mocker: MockerFixture, mock_config: Config) -> Non
     spec_urls_override=None,
     feature_description_override='Test Description',
     detailed_requirements_override=False,
+    draft_override=False,
     categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
@@ -465,6 +475,7 @@ def test_generate_resume(mocker: MockerFixture, mock_config: Config) -> None:
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    draft_override=False,
     categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
@@ -499,6 +510,7 @@ def test_generate_use_lightweight(mocker: MockerFixture, mock_config: Config) ->
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    draft_override=False,
     categorized_requirements_override=False,
     use_lightweight_override=True,
     use_reasoning_override=False,
@@ -533,6 +545,7 @@ def test_generate_use_reasoning(mocker: MockerFixture, mock_config: Config) -> N
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    draft_override=False,
     categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=True,
@@ -567,6 +580,7 @@ def test_generate_categorized_requirements(mocker: MockerFixture, mock_config: C
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    draft_override=False,
     categorized_requirements_override=True,
     use_lightweight_override=False,
     use_reasoning_override=False,
@@ -601,6 +615,7 @@ def test_generate_max_parallel_requests(mocker: MockerFixture, mock_config: Conf
     spec_urls_override=None,
     feature_description_override=None,
     detailed_requirements_override=False,
+    draft_override=False,
     categorized_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
@@ -842,3 +857,37 @@ def test_audit_success(mocker: MockerFixture, mock_config: Config) -> None:
   assert kwargs['provider_override'] == 'gemini'
 
   mock_engine_instance.run_workflow.assert_called_once_with('grid')
+
+
+def test_generate_draft(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test that the --draft flag is correctly passed to load_config."""
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+  mocker.patch('wptgen.main.WPTGenEngine')
+
+  result = runner.invoke(app, ['generate', 'grid', '--draft'])
+
+  assert result.exit_code == 0
+  mock_load_config.assert_called_once_with(
+    config_path=DEFAULT_CONFIG_PATH,
+    provider_override=None,
+    wpt_dir_override=None,
+    output_dir_override=None,
+    show_responses=False,
+    yes_tokens_override=False,
+    yes_tests_override=False,
+    suggestions_only=False,
+    resume_override=False,
+    max_retries_override=3,
+    timeout_override=600,
+    spec_urls_override=None,
+    feature_description_override=None,
+    detailed_requirements_override=False,
+    draft_override=True,
+    categorized_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
+    skip_evaluation_override=False,
+    tentative_override=False,
+    max_parallel_requests_override=None,
+    temperature_override=None,
+  )

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -67,6 +67,7 @@ class Config:
   spec_urls: list[str] | None = None
   feature_description: str | None = None
   detailed_requirements: bool = False
+  draft: bool = False
   categorized_requirements: bool = False
   use_lightweight: bool = False
   use_reasoning: bool = False
@@ -164,6 +165,7 @@ def load_config(
   spec_urls_override: list[str] | None = None,
   feature_description_override: str | None = None,
   detailed_requirements_override: bool = False,
+  draft_override: bool = False,
   categorized_requirements_override: bool = False,
   use_lightweight_override: bool = False,
   use_reasoning_override: bool = False,
@@ -237,6 +239,7 @@ def load_config(
   yes_tests = yes_tests_override or yaml_data.get('yes_tests', False)
   suggestions_only = suggestions_only or yaml_data.get('suggestions_only', False)
   resume = resume_override or yaml_data.get('resume', False)
+  draft = draft_override or yaml_data.get('draft', False)
   detailed_requirements = detailed_requirements_override or yaml_data.get(
     'detailed_requirements', False
   )
@@ -297,6 +300,7 @@ def load_config(
     spec_urls=spec_urls_override,
     feature_description=feature_description_override,
     detailed_requirements=detailed_requirements,
+    draft=draft,
     categorized_requirements=categorized_requirements,
     use_lightweight=use_lightweight_override,
     use_reasoning=use_reasoning_override,

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -48,14 +48,17 @@ IGNORED_DEPENDENCIES = {
 MDN_MAPPINGS_URL = 'https://raw.githubusercontent.com/web-platform-dx/web-features-mappings/main/mappings/mdn-docs.json'
 
 
-def fetch_feature_yaml(web_feature_id: str) -> dict[str, Any] | None:
+def fetch_feature_yaml(web_feature_id: str, draft: bool = False) -> dict[str, Any] | None:
   """
   Fetches the YAML definition for a given web feature ID from the
   web-platform-dx/web-features repository.
 
   Returns the parsed YAML dictionary, or None if the feature ID is not found.
   """
-  url = f'https://raw.githubusercontent.com/web-platform-dx/web-features/main/features/{web_feature_id}.yml'
+  if draft:
+    url = f'https://raw.githubusercontent.com/web-platform-dx/web-features/main/features/draft/spec/{web_feature_id}.yml'
+  else:
+    url = f'https://raw.githubusercontent.com/web-platform-dx/web-features/main/features/{web_feature_id}.yml'
 
   try:
     # Use standard library to avoid bloating dependencies

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -153,6 +153,13 @@ def generate(
       help='Use a more detailed, iterative requirements extraction process.',
     ),
   ] = False,
+  draft: Annotated[
+    bool,
+    typer.Option(
+      '--draft',
+      help='Enable fetching metadata from the draft features directory.',
+    ),
+  ] = False,
   categorized_requirements: Annotated[
     bool,
     typer.Option(
@@ -248,6 +255,7 @@ def generate(
       spec_urls_override=spec_urls_list,
       feature_description_override=description,
       detailed_requirements_override=detailed_requirements,
+      draft_override=draft,
       categorized_requirements_override=categorized_requirements,
       use_lightweight_override=use_lightweight,
       use_reasoning_override=use_reasoning,
@@ -535,6 +543,13 @@ def audit(
       help='Use a more detailed, iterative requirements extraction process.',
     ),
   ] = False,
+  draft: Annotated[
+    bool,
+    typer.Option(
+      '--draft',
+      help='Enable fetching metadata from the draft features directory.',
+    ),
+  ] = False,
   categorized_requirements: Annotated[
     bool,
     typer.Option(
@@ -615,6 +630,7 @@ def audit(
       spec_urls_override=spec_urls_list,
       feature_description_override=description,
       detailed_requirements_override=detailed_requirements,
+      draft_override=draft,
       categorized_requirements_override=categorized_requirements,
       use_lightweight_override=use_lightweight,
       use_reasoning_override=use_reasoning,

--- a/wptgen/phases/context_assembly.py
+++ b/wptgen/phases/context_assembly.py
@@ -33,7 +33,7 @@ async def run_context_assembly(
 ) -> WorkflowContext | None:
   ui.on_phase_start(1, 'Context Assembly')
 
-  feature_data = fetch_feature_yaml(web_feature_id)
+  feature_data = fetch_feature_yaml(web_feature_id, draft=config.draft)
   if not feature_data:
     if config.spec_urls and config.feature_description:
       ui.warning(f'Feature {web_feature_id} not found in the web-features repository.')


### PR DESCRIPTION
## Background & Motivation
Resolves #66.

Currently, WPT-Gen exclusively supports fetching feature metadata from the production `web-features` repository. However, many upcoming features are located in the draft phase at `features/draft/spec/`. 

This PR introduces the `--draft` CLI flag to allow users to generate tests for these unlanded features.

## Proposed Changes
- Added a `--draft` CLI flag to the `generate` and `audit` commands.
- Updated `fetch_feature_yaml` in `wptgen/context.py` to conditionally fetch metadata from the `draft/spec` subdirectory.
- Propagated the `draft` flag through the `Config` object and phase assembly.
- Added unit tests verifying that draft feature metadata is fetched correctly and the CLI parses the flag properly.
- Updated `docs/cli.md` and `README.md` to document the new draft testing capability.
