### PR TITLE
feat: Add `wpt-gen config set` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ phase_model_mapping:
   generation: lightweight
 ```
 
+### 3. Managing Configuration via CLI
+You can use the built-in `config` command group to view or modify your settings without opening the YAML file manually.
+
+- **View Configuration:**
+  ```bash
+  wpt-gen config show
+  ```
+- **Update Configuration:** Use dot-notation to set specific values.
+  ```bash
+  wpt-gen config set default_provider "openai"
+  wpt-gen config set providers.gemini.default_model "gemini-3.1-pro-preview"
+  ```
+
 ## Usage
 
 The primary interface is the `generate` command, which requires a **Web Feature ID** (as defined in the [web-features](https://github.com/web-platform-dx/web-features) repository).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -80,3 +80,42 @@ Print the current version of `wpt-gen`.
 ```bash
 wpt-gen version
 ```
+
+---
+
+## `wpt-gen config`
+
+Manage WPT-Gen configuration without manually editing the YAML file. If run without subcommands, it displays the currently active configuration.
+
+**Usage:**
+```bash
+wpt-gen config [COMMAND]
+```
+
+### Commands
+
+| Command | Description |
+| :--- | :--- |
+| `show` | Display the currently active, fully resolved configuration. |
+| `set` | Update an individual configuration setting using dot-notation. |
+
+### `wpt-gen config set`
+
+Update an individual configuration setting. Modifies the local or global `wpt-gen.yml` file.
+
+**Usage:**
+```bash
+wpt-gen config set <KEY> <VALUE> [OPTIONS]
+```
+
+**Examples:**
+```bash
+wpt-gen config set default_provider openai
+wpt-gen config set providers.gemini.default_model gemini-3.1-pro-preview
+wpt-gen config set show_responses true
+```
+
+#### Options
+| Option | Shorthand | Description |
+| :--- | :--- | :--- |
+| `--config` | `-c` | Path to a custom `wpt-gen.yml` file. |

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -891,3 +891,87 @@ def test_generate_draft(mocker: MockerFixture, mock_config: Config) -> None:
     max_parallel_requests_override=None,
     temperature_override=None,
   )
+
+
+def test_config_show_command(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test the explicit config show command."""
+  mock_config.loaded_from = '/dummy/path/wpt-gen.yml'
+  mocker.patch('wptgen.main.load_config', return_value=mock_config)
+
+  result = runner.invoke(app, ['config', 'show'])
+
+  assert result.exit_code == 0
+  assert 'Resolved Configuration' in result.stdout
+
+
+def test_config_set_command_flat(mocker: MockerFixture) -> None:
+  """Test setting a flat configuration value."""
+  from pathlib import Path
+
+  import yaml
+
+  with runner.isolated_filesystem():
+    config_file = Path('wpt-gen.yml')
+    config_file.write_text('default_provider: openai\n')
+
+    result = runner.invoke(
+      app, ['config', 'set', 'default_provider', 'gemini', '--config', str(config_file)]
+    )
+
+    assert result.exit_code == 0
+    assert 'Set default_provider = gemini' in result.stdout
+
+    with open(config_file) as f:
+      data = yaml.safe_load(f)
+    assert data['default_provider'] == 'gemini'
+
+
+def test_config_set_command_nested(mocker: MockerFixture) -> None:
+  """Test setting a nested configuration value."""
+  from pathlib import Path
+
+  import yaml
+
+  with runner.isolated_filesystem():
+    config_file = Path('wpt-gen.yml')
+    config_file.write_text('providers:\n  gemini:\n    default_model: old-model\n')
+
+    result = runner.invoke(
+      app,
+      [
+        'config',
+        'set',
+        'providers.gemini.default_model',
+        'new-model',
+        '--config',
+        str(config_file),
+      ],
+    )
+
+    assert result.exit_code == 0
+
+    with open(config_file) as f:
+      data = yaml.safe_load(f)
+    assert data['providers']['gemini']['default_model'] == 'new-model'
+
+
+def test_config_set_command_types(mocker: MockerFixture) -> None:
+  """Test type conversion for config set."""
+  from pathlib import Path
+
+  import yaml
+
+  with runner.isolated_filesystem():
+    config_file = Path('wpt-gen.yml')
+    config_file.write_text('')
+
+    runner.invoke(app, ['config', 'set', 'timeout', '120', '--config', str(config_file)])
+    runner.invoke(app, ['config', 'set', 'show_responses', 'true', '--config', str(config_file)])
+    runner.invoke(app, ['config', 'set', 'temperature', '0.5', '--config', str(config_file)])
+
+    with open(config_file) as f:
+      data = yaml.safe_load(f)
+
+    assert data['timeout'] == 120
+    assert data['show_responses'] is True
+    assert data['temperature'] == 0.5

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -380,15 +380,14 @@ def doctor_command(
     raise typer.Exit(code=1)
 
 
-@app.command(name='config')
-def config_command(
-  config_path: Annotated[
-    str, typer.Option('--config', '-c', help='Path to a custom wpt-gen.yml file.')
-  ] = DEFAULT_CONFIG_PATH,
-) -> None:
-  """
-  Display the currently active, fully resolved configuration.
-  """
+config_app = typer.Typer(
+  help='Manage WPT-Gen configuration.',
+  add_completion=False,
+)
+app.add_typer(config_app, name='config')
+
+
+def _display_config(config_path: str) -> None:
   try:
     import dataclasses
 
@@ -412,6 +411,101 @@ def config_command(
     )
   except Exception as e:
     console.print(f'[bold red]Error:[/bold red] {str(e)}')
+    raise typer.Exit(code=1) from e
+
+
+@config_app.callback(invoke_without_command=True)
+def config_callback(
+  ctx: typer.Context,
+  config_path: Annotated[
+    str, typer.Option('--config', '-c', help='Path to a custom wpt-gen.yml file.')
+  ] = DEFAULT_CONFIG_PATH,
+) -> None:
+  """
+  Manage WPT-Gen configuration. Displays active configuration if no subcommand is provided.
+  """
+  if ctx.invoked_subcommand is None:
+    _display_config(config_path)
+
+
+@config_app.command(name='show')
+def config_show(
+  config_path: Annotated[
+    str, typer.Option('--config', '-c', help='Path to a custom wpt-gen.yml file.')
+  ] = DEFAULT_CONFIG_PATH,
+) -> None:
+  """
+  Display the currently active, fully resolved configuration.
+  """
+  _display_config(config_path)
+
+
+@config_app.command(name='set')
+def config_set(
+  key: Annotated[
+    str, typer.Argument(help='Configuration key using dot-notation (e.g., default_provider).')
+  ],
+  value: Annotated[str, typer.Argument(help='Value to set for the configuration key.')],
+  config_path: Annotated[
+    str, typer.Option('--config', '-c', help='Path to a custom wpt-gen.yml file.')
+  ] = DEFAULT_CONFIG_PATH,
+) -> None:
+  """
+  Update an individual configuration setting using dot-notation.
+  """
+  from pathlib import Path
+  from typing import Any
+
+  import yaml
+
+  path = Path(config_path)
+  target_file = path
+
+  if not path.exists() and config_path == DEFAULT_CONFIG_PATH:
+    global_path = Path(_get_global_config_path())
+    if global_path.exists():
+      target_file = global_path
+
+  yaml_data: dict[str, Any] = {}
+  if target_file.exists():
+    try:
+      with open(target_file, encoding='utf-8') as f:
+        yaml_data = yaml.safe_load(f) or {}
+    except Exception as e:
+      console.print(f'[bold red]Error reading config file:[/bold red] {e}')
+      raise typer.Exit(code=1) from e
+
+  keys = key.split('.')
+  current = yaml_data
+  for k in keys[:-1]:
+    if k not in current or not isinstance(current[k], dict):
+      current[k] = {}
+    current = current[k]
+
+  typed_value: Any
+  val_lower = value.lower()
+  if val_lower == 'true':
+    typed_value = True
+  elif val_lower == 'false':
+    typed_value = False
+  elif value.isdigit():
+    typed_value = int(value)
+  else:
+    try:
+      typed_value = float(value)
+    except ValueError:
+      typed_value = value
+
+  current[keys[-1]] = typed_value
+
+  try:
+    with open(target_file, 'w', encoding='utf-8') as f:
+      yaml.dump(yaml_data, f, sort_keys=False, default_flow_style=False)
+    console.print(
+      f'[bold green]✔[/bold green] Set [cyan]{key}[/cyan] = [yellow]{typed_value}[/yellow] in [magenta]{target_file.resolve()}[/magenta]'
+    )
+  except Exception as e:
+    console.print(f'[bold red]Error writing config file:[/bold red] {e}')
     raise typer.Exit(code=1) from e
 
 


### PR DESCRIPTION
## Background
Resolves #177.

Currently, WPT-Gen provides a `wpt-gen config` command that displays the active configuration, but lacks a way to update an individual setting directly from the CLI. 

## Proposed Changes
- Refactored the `config` command into a Typer command group.
- Added a `wpt-gen config show` command to retain the existing display behavior (this remains the default behavior when invoking `wpt-gen config`).
- Introduced a new `wpt-gen config set <key> <value>` command.
- Implemented dot-notation parsing to update nested YAML configuration entries (e.g., `providers.gemini.default_model`).
- Added robust type coercion so integer, float, and boolean values are saved with the proper types in YAML.
- Added comprehensive unit tests for both flat and nested configuration updates.
- Added documentation for using the new CLI config functionality in both `README.md` and `docs/cli.md`.
