### PR TITLE
feat: make categorized requirements extraction the default

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -84,7 +84,7 @@ async def test_run_async_workflow_full_path(engine: WPTGenEngine, mocker: Mocker
 
   mock_assembly = mocker.patch('wptgen.engine.run_context_assembly', return_value=context)
   mock_extraction = mocker.patch(
-    'wptgen.engine.run_requirements_extraction', return_value=requirements
+    'wptgen.engine.run_requirements_extraction_categorized', return_value=requirements
   )
   mock_extraction_iterative = mocker.patch(
     'wptgen.engine.run_requirements_extraction_iterative', return_value=requirements
@@ -115,12 +115,12 @@ async def test_run_async_workflow_phase_failures(
 
   # Phase 2 failure
   mocker.patch('wptgen.engine.run_context_assembly', return_value=WorkflowContext(feature_id='f'))
-  mocker.patch('wptgen.engine.run_requirements_extraction', return_value=None)
+  mocker.patch('wptgen.engine.run_requirements_extraction_categorized', return_value=None)
   with pytest.raises(WorkflowError, match='Phase 2: Requirements Extraction failed.'):
     await engine._run_async_workflow('feat-id')
 
   # Phase 3 failure
-  mocker.patch('wptgen.engine.run_requirements_extraction', return_value='reqs')
+  mocker.patch('wptgen.engine.run_requirements_extraction_categorized', return_value='reqs')
   mocker.patch('wptgen.engine.run_coverage_audit', return_value=None)
   with pytest.raises(WorkflowError, match='Phase 3: Coverage Audit failed.'):
     await engine._run_async_workflow('feat-id')
@@ -142,7 +142,7 @@ async def test_run_async_workflow_suggestions_only(
   context = WorkflowContext(feature_id='test-feat', audit_response='audit')
 
   mocker.patch('wptgen.engine.run_context_assembly', return_value=context)
-  mocker.patch('wptgen.engine.run_requirements_extraction', return_value='reqs')
+  mocker.patch('wptgen.engine.run_requirements_extraction_categorized', return_value='reqs')
   mocker.patch('wptgen.engine.run_coverage_audit', return_value='audit')
   mock_provide = mocker.patch('wptgen.engine.provide_coverage_report', return_value=None)
   mock_gen = mocker.patch('wptgen.engine.run_test_generation', return_value=[])
@@ -164,7 +164,7 @@ async def test_run_async_workflow_detailed_requirements(
 
   mocker.patch('wptgen.engine.run_context_assembly', return_value=context)
   mock_extraction = mocker.patch(
-    'wptgen.engine.run_requirements_extraction', return_value=requirements
+    'wptgen.engine.run_requirements_extraction_categorized', return_value=requirements
   )
   mock_extraction_iterative = mocker.patch(
     'wptgen.engine.run_requirements_extraction_iterative', return_value=requirements
@@ -197,7 +197,7 @@ async def test_run_async_workflow_skip_evaluation(
   generated_tests = [('path', 'content', 'suggestion')]
 
   mocker.patch('wptgen.engine.run_context_assembly', return_value=context)
-  mocker.patch('wptgen.engine.run_requirements_extraction', return_value=requirements)
+  mocker.patch('wptgen.engine.run_requirements_extraction_categorized', return_value=requirements)
   mocker.patch('wptgen.engine.run_coverage_audit', return_value=audit)
   mocker.patch('wptgen.engine.run_test_generation', return_value=generated_tests)
   mock_eval = mocker.patch('wptgen.engine.run_test_evaluation', return_value=None)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -98,7 +98,7 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     feature_description_override=None,
     detailed_requirements_override=False,
     draft_override=False,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -137,7 +137,7 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     feature_description_override=None,
     detailed_requirements_override=False,
     draft_override=False,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -172,7 +172,7 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     feature_description_override=None,
     detailed_requirements_override=False,
     draft_override=False,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -207,7 +207,7 @@ def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -
     feature_description_override=None,
     detailed_requirements_override=False,
     draft_override=False,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -242,7 +242,7 @@ def test_generate_max_retries(mocker: MockerFixture, mock_config: Config) -> Non
     feature_description_override=None,
     detailed_requirements_override=False,
     draft_override=False,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -277,7 +277,7 @@ def test_generate_detailed_requirements(mocker: MockerFixture, mock_config: Conf
     feature_description_override=None,
     detailed_requirements_override=True,
     draft_override=False,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -311,7 +311,7 @@ def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) ->
     feature_description_override=None,
     detailed_requirements_override=False,
     draft_override=False,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=True,
@@ -340,7 +340,7 @@ def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) ->
     feature_description_override=None,
     detailed_requirements_override=False,
     draft_override=False,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=True,
@@ -406,7 +406,7 @@ def test_generate_spec_urls(mocker: MockerFixture, mock_config: Config) -> None:
     feature_description_override=None,
     detailed_requirements_override=False,
     draft_override=False,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -441,7 +441,7 @@ def test_generate_description(mocker: MockerFixture, mock_config: Config) -> Non
     feature_description_override='Test Description',
     detailed_requirements_override=False,
     draft_override=False,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -476,7 +476,7 @@ def test_generate_resume(mocker: MockerFixture, mock_config: Config) -> None:
     feature_description_override=None,
     detailed_requirements_override=False,
     draft_override=False,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -511,7 +511,7 @@ def test_generate_use_lightweight(mocker: MockerFixture, mock_config: Config) ->
     feature_description_override=None,
     detailed_requirements_override=False,
     draft_override=False,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=True,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -546,7 +546,7 @@ def test_generate_use_reasoning(mocker: MockerFixture, mock_config: Config) -> N
     feature_description_override=None,
     detailed_requirements_override=False,
     draft_override=False,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=True,
     skip_evaluation_override=False,
@@ -556,13 +556,13 @@ def test_generate_use_reasoning(mocker: MockerFixture, mock_config: Config) -> N
   )
 
 
-def test_generate_categorized_requirements(mocker: MockerFixture, mock_config: Config) -> None:
-  """Test that the --categorized-requirements flag is correctly passed to load_config."""
+def test_generate_single_prompt_requirements(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test that the --single-prompt-requirements flag is correctly passed to load_config."""
   mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
   mocker.patch('wptgen.main.WPTGenEngine')
 
-  # Run with --categorized-requirements
-  result = runner.invoke(app, ['generate', 'grid', '--categorized-requirements'])
+  # Run with --single-prompt-requirements
+  result = runner.invoke(app, ['generate', 'grid', '--single-prompt-requirements'])
 
   assert result.exit_code == 0
   mock_load_config.assert_called_once_with(
@@ -581,7 +581,7 @@ def test_generate_categorized_requirements(mocker: MockerFixture, mock_config: C
     feature_description_override=None,
     detailed_requirements_override=False,
     draft_override=False,
-    categorized_requirements_override=True,
+    single_prompt_requirements_override=True,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -616,7 +616,7 @@ def test_generate_max_parallel_requests(mocker: MockerFixture, mock_config: Conf
     feature_description_override=None,
     detailed_requirements_override=False,
     draft_override=False,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
@@ -643,11 +643,11 @@ def test_generate_mutually_exclusive_requirements(
   mocker.patch('wptgen.main.load_config', return_value=mock_config)
 
   result = runner.invoke(
-    app, ['generate', 'grid', '--detailed-requirements', '--categorized-requirements']
+    app, ['generate', 'grid', '--detailed-requirements', '--single-prompt-requirements']
   )
 
   assert result.exit_code == 1
-  assert 'Cannot use both --detailed-requirements and --categorized-requirements' in result.stdout
+  assert 'Cannot use both --detailed-requirements and --single-prompt-requirements' in result.stdout
 
 
 def test_version_not_found(mocker: MockerFixture) -> None:
@@ -883,7 +883,7 @@ def test_generate_draft(mocker: MockerFixture, mock_config: Config) -> None:
     feature_description_override=None,
     detailed_requirements_override=False,
     draft_override=True,
-    categorized_requirements_override=False,
+    single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -125,7 +125,7 @@ async def test_run_async_workflow_resume_skips_phases(
   engine._save_resume_state(context)
 
   mock_assembly = mocker.patch('wptgen.engine.run_context_assembly')
-  mock_extraction = mocker.patch('wptgen.engine.run_requirements_extraction')
+  mock_extraction = mocker.patch('wptgen.engine.run_requirements_extraction_categorized')
   mock_audit = mocker.patch('wptgen.engine.run_coverage_audit', return_value='audit')
   mock_gen = mocker.patch('wptgen.engine.run_test_generation', return_value=[])
 
@@ -150,7 +150,7 @@ async def test_run_async_workflow_cleans_up_resume_file(
   assert resume_file.exists()
 
   mocker.patch('wptgen.engine.run_context_assembly', return_value=context)
-  mocker.patch('wptgen.engine.run_requirements_extraction', return_value='<reqs/>')
+  mocker.patch('wptgen.engine.run_requirements_extraction_categorized', return_value='<reqs/>')
   mocker.patch('wptgen.engine.run_coverage_audit', return_value='audit')
   mocker.patch('wptgen.engine.run_test_generation', return_value=[])
 
@@ -167,7 +167,7 @@ async def test_run_async_workflow_saves_after_each_phase(
   context = WorkflowContext(feature_id='test-feat')
 
   mocker.patch('wptgen.engine.run_context_assembly', return_value=context)
-  mocker.patch('wptgen.engine.run_requirements_extraction', return_value='<reqs/>')
+  mocker.patch('wptgen.engine.run_requirements_extraction_categorized', return_value='<reqs/>')
   mocker.patch('wptgen.engine.run_coverage_audit', return_value='audit')
   mocker.patch('wptgen.engine.run_test_generation', return_value=[])
 

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -68,7 +68,7 @@ class Config:
   feature_description: str | None = None
   detailed_requirements: bool = False
   draft: bool = False
-  categorized_requirements: bool = False
+  single_prompt_requirements: bool = False
   use_lightweight: bool = False
   use_reasoning: bool = False
   skip_evaluation: bool = False
@@ -166,7 +166,7 @@ def load_config(
   feature_description_override: str | None = None,
   detailed_requirements_override: bool = False,
   draft_override: bool = False,
-  categorized_requirements_override: bool = False,
+  single_prompt_requirements_override: bool = False,
   use_lightweight_override: bool = False,
   use_reasoning_override: bool = False,
   skip_evaluation_override: bool = False,
@@ -243,8 +243,8 @@ def load_config(
   detailed_requirements = detailed_requirements_override or yaml_data.get(
     'detailed_requirements', False
   )
-  categorized_requirements = categorized_requirements_override or yaml_data.get(
-    'categorized_requirements', False
+  single_prompt_requirements = single_prompt_requirements_override or yaml_data.get(
+    'single_prompt_requirements', False
   )
   max_retries = max_retries_override or yaml_data.get('max_retries', 3)
   timeout = timeout_override or yaml_data.get('timeout', DEFAULT_LLM_TIMEOUT)
@@ -301,7 +301,7 @@ def load_config(
     feature_description=feature_description_override,
     detailed_requirements=detailed_requirements,
     draft=draft,
-    categorized_requirements=categorized_requirements,
+    single_prompt_requirements=single_prompt_requirements,
     use_lightweight=use_lightweight_override,
     use_reasoning=use_reasoning_override,
     skip_evaluation=skip_evaluation,

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -109,8 +109,8 @@ class WPTGenEngine:
 
     # Phase 2: Requirements Extraction
     if not context.requirements_xml:
-      if self.config.categorized_requirements:
-        requirements_xml = await run_requirements_extraction_categorized(
+      if self.config.single_prompt_requirements:
+        requirements_xml = await run_requirements_extraction(
           context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
         )
       elif self.config.detailed_requirements:
@@ -118,7 +118,7 @@ class WPTGenEngine:
           context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
         )
       else:
-        requirements_xml = await run_requirements_extraction(
+        requirements_xml = await run_requirements_extraction_categorized(
           context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
         )
       if not requirements_xml:

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -160,11 +160,11 @@ def generate(
       help='Enable fetching metadata from the draft features directory.',
     ),
   ] = False,
-  categorized_requirements: Annotated[
+  single_prompt_requirements: Annotated[
     bool,
     typer.Option(
-      '--categorized-requirements',
-      help='Use a parallel, categorized requirements extraction process.',
+      '--single-prompt-requirements',
+      help='Use a single-prompt requirements extraction process (legacy).',
     ),
   ] = False,
   use_lightweight: Annotated[
@@ -224,8 +224,8 @@ def generate(
     ui.error('Cannot use both --use-lightweight and --use-reasoning.')
     raise typer.Exit(code=1)
 
-  if detailed_requirements and categorized_requirements:
-    ui.error('Cannot use both --detailed-requirements and --categorized-requirements.')
+  if detailed_requirements and single_prompt_requirements:
+    ui.error('Cannot use both --detailed-requirements and --single-prompt-requirements.')
     raise typer.Exit(code=1)
 
   try:
@@ -256,7 +256,7 @@ def generate(
       feature_description_override=description,
       detailed_requirements_override=detailed_requirements,
       draft_override=draft,
-      categorized_requirements_override=categorized_requirements,
+      single_prompt_requirements_override=single_prompt_requirements,
       use_lightweight_override=use_lightweight,
       use_reasoning_override=use_reasoning,
       skip_evaluation_override=skip_evaluation,
@@ -644,11 +644,11 @@ def audit(
       help='Enable fetching metadata from the draft features directory.',
     ),
   ] = False,
-  categorized_requirements: Annotated[
+  single_prompt_requirements: Annotated[
     bool,
     typer.Option(
-      '--categorized-requirements',
-      help='Use a parallel, categorized requirements extraction process.',
+      '--single-prompt-requirements',
+      help='Use a single-prompt requirements extraction process (legacy).',
     ),
   ] = False,
   use_lightweight: Annotated[
@@ -693,8 +693,8 @@ def audit(
     ui.error('Cannot use both --use-lightweight and --use-reasoning.')
     raise typer.Exit(code=1)
 
-  if detailed_requirements and categorized_requirements:
-    ui.error('Cannot use both --detailed-requirements and --categorized-requirements.')
+  if detailed_requirements and single_prompt_requirements:
+    ui.error('Cannot use both --detailed-requirements and --single-prompt-requirements.')
     raise typer.Exit(code=1)
 
   try:
@@ -725,7 +725,7 @@ def audit(
       feature_description_override=description,
       detailed_requirements_override=detailed_requirements,
       draft_override=draft,
-      categorized_requirements_override=categorized_requirements,
+      single_prompt_requirements_override=single_prompt_requirements,
       use_lightweight_override=use_lightweight,
       use_reasoning_override=use_reasoning,
       skip_evaluation_override=True,

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -118,7 +118,11 @@ async def run_requirements_extraction_categorized(
     metadata = context.metadata
     assert metadata is not None
 
-    async def extract_for_category(category_name: str, category_description: str) -> str | None:
+    prompts_to_confirm = []
+    category_prompts = []
+    category_system_prompts = []
+
+    for category_name, category_description in REQUIREMENT_CATEGORIES:
       extraction_prompt = jinja_env.get_template(
         'requirements_extraction_categorized.jinja'
       ).render(
@@ -136,11 +140,22 @@ async def run_requirements_extraction_categorized(
         category_name=category_name,
         category_description=category_description,
       )
+      category_prompts.append(extraction_prompt)
+      category_system_prompts.append(extraction_system_prompt)
+      prompts_to_confirm.append((extraction_prompt, f'Requirements Extraction: {category_name}'))
 
-      # We don't confirm prompts individually for parallel requests to avoid UI mess
-      # Instead we could confirm the "template" once.
-      # For now, following the spirit of parallelized extraction.
+    await confirm_prompts(
+      prompts_to_confirm,
+      'Requirements Extraction (Categorized Parallel)',
+      llm,
+      ui,
+      config,
+      model=config.get_model_for_phase('requirements_extraction'),
+    )
 
+    async def extract_for_category(
+      category_name: str, extraction_prompt: str, extraction_system_prompt: str
+    ) -> str | None:
       return await generate_safe(
         extraction_prompt,
         f'Requirements Extraction: {category_name}',
@@ -156,9 +171,11 @@ async def run_requirements_extraction_categorized(
     total_tasks = len(REQUIREMENT_CATEGORIES)
     completed_count = 0
 
-    async def wrap_with_progress(name: str, desc: str) -> str | None:
+    async def wrap_with_progress(
+      name: str, extraction_prompt: str, extraction_system_prompt: str
+    ) -> str | None:
       nonlocal completed_count
-      res = await extract_for_category(name, desc)
+      res = await extract_for_category(name, extraction_prompt, extraction_system_prompt)
       completed_count += 1
       remaining = total_tasks - completed_count
       progress.update(
@@ -171,7 +188,12 @@ async def run_requirements_extraction_categorized(
       f'Extracting requirements... ({total_tasks} outstanding)', total=total_tasks
     ) as progress:
       responses = await asyncio.gather(
-        *[wrap_with_progress(name, desc) for name, desc in REQUIREMENT_CATEGORIES]
+        *[
+          wrap_with_progress(cat[0], prompt, sys_prompt)
+          for cat, prompt, sys_prompt in zip(
+            REQUIREMENT_CATEGORIES, category_prompts, category_system_prompts, strict=True
+          )
+        ]
       )
 
     all_requirements: list[str] = []


### PR DESCRIPTION
## Description
This pull request changes the default requirements extraction method in the `generate` workflow to use the parallel, categorized approach, improving accuracy and completeness. 

To manage API usage effectively, a confirmation prompt has been added that pauses the workflow to ask the user to confirm sending the 5 parallel requests. This confirmation can be bypassed by passing the `--yes-tokens` flag. 

Additionally, the original single-prompt extraction approach has been preserved and is now accessible via the new `--single-prompt-requirements` CLI flag.

Resolves #178
