### PR TITLE
feat: Add model verification to instantiated LLMClients

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -19,7 +19,13 @@ from google.genai import types
 from pytest_mock import MockerFixture
 
 from wptgen.config import Config
-from wptgen.llm import GeminiClient, OpenAIClient, get_llm_client
+from wptgen.llm import (
+  AnthropicClient,
+  GeminiClient,
+  InvalidModelError,
+  OpenAIClient,
+  get_llm_client,
+)
 
 
 @pytest.fixture
@@ -385,3 +391,33 @@ def test_llm_client_custom_retries(mocker: MockerFixture, gemini_config: Config)
     client.generate_content('test')
 
   assert mock_instance.models.generate_content.call_count == 5
+
+
+def test_gemini_client_invalid_model(mocker: MockerFixture) -> None:
+  """Test that GeminiClient raises InvalidModelError on bad model."""
+  mock_client_class = mocker.patch('wptgen.llm.genai.Client')
+  mock_instance = mock_client_class.return_value
+  mock_instance.models.get.side_effect = Exception('Model not found')
+
+  with pytest.raises(InvalidModelError, match="Failed to verify Gemini model 'bad-model'"):
+    GeminiClient(api_key='mock', model='bad-model')
+
+
+def test_openai_client_invalid_model(mocker: MockerFixture) -> None:
+  """Test that OpenAIClient raises InvalidModelError on bad model."""
+  mock_client_class = mocker.patch('wptgen.llm.OpenAI')
+  mock_instance = mock_client_class.return_value
+  mock_instance.models.retrieve.side_effect = Exception('Model not found')
+
+  with pytest.raises(InvalidModelError, match="Failed to verify OpenAI model 'bad-model'"):
+    OpenAIClient(api_key='mock', model='bad-model')
+
+
+def test_anthropic_client_invalid_model(mocker: MockerFixture) -> None:
+  """Test that AnthropicClient raises InvalidModelError on bad model."""
+  mock_client_class = mocker.patch('wptgen.llm.anthropic.Anthropic')
+  mock_instance = mock_client_class.return_value
+  mock_instance.models.retrieve.side_effect = Exception('Model not found')
+
+  with pytest.raises(InvalidModelError, match="Failed to verify Anthropic model 'bad-model'"):
+    AnthropicClient(api_key='mock', model='bad-model')

--- a/wptgen/llm.py
+++ b/wptgen/llm.py
@@ -38,6 +38,12 @@ class LLMTimeoutError(Exception):
   pass
 
 
+class InvalidModelError(Exception):
+  """Raised when the provided model is invalid or inaccessible."""
+
+  pass
+
+
 class LLMClient(ABC):
   """Abstract base class for all LLM providers."""
 
@@ -52,6 +58,11 @@ class LLMClient(ABC):
     self.model = model
     self.max_retries = max_retries
     self.timeout = timeout
+
+  @abstractmethod
+  def verify_model(self) -> None:
+    """Verifies that the requested model is valid and accessible."""
+    pass  # pragma: no cover
 
   @abstractmethod
   def count_tokens(self, prompt: str, model: str | None = None) -> int:
@@ -90,6 +101,13 @@ class GeminiClient(LLMClient):
       api_key=self.api_key,
       http_options=types.HttpOptions(timeout=int(self.timeout * 1000)),
     )
+    self.verify_model()
+
+  def verify_model(self) -> None:
+    try:
+      self.client.models.get(model=self.model)
+    except Exception as e:
+      raise InvalidModelError(f"Failed to verify Gemini model '{self.model}': {e}") from e
 
   @retry(exceptions=Exception, max_attempts_attr='max_retries')
   def count_tokens(self, prompt: str, model: str | None = None) -> int:
@@ -163,6 +181,13 @@ class OpenAIClient(LLMClient):
   ):
     super().__init__(api_key, model, max_retries, timeout)
     self.client = OpenAI(api_key=self.api_key, timeout=float(self.timeout))
+    self.verify_model()
+
+  def verify_model(self) -> None:
+    try:
+      self.client.models.retrieve(self.model)
+    except Exception as e:
+      raise InvalidModelError(f"Failed to verify OpenAI model '{self.model}': {e}") from e
 
   def count_tokens(self, prompt: str, model: str | None = None) -> int:
     """Returns the total number of tokens for the given prompt using tiktoken."""
@@ -235,6 +260,13 @@ class AnthropicClient(LLMClient):
   ):
     super().__init__(api_key, model, max_retries, timeout)
     self.client = anthropic.Anthropic(api_key=self.api_key, timeout=float(self.timeout))
+    self.verify_model()
+
+  def verify_model(self) -> None:
+    try:
+      self.client.models.retrieve(self.model)
+    except Exception as e:
+      raise InvalidModelError(f"Failed to verify Anthropic model '{self.model}': {e}") from e
 
   @retry(exceptions=Exception, max_attempts_attr='max_retries')
   def count_tokens(self, prompt: str, model: str | None = None) -> int:


### PR DESCRIPTION
## Description
This pull request introduces active model validation when an `LLMClient` is instantiated, resolving an issue where invalid models cause delayed errors during application runtime.

### Background
Previously, `GeminiClient`, `OpenAIClient`, and `AnthropicClient` stored their `model` string without validating it against the provider's API. This delayed failure until a substantive request was made.

### Proposed Changes
- Added a custom `InvalidModelError` exception to easily identify model resolution failures.
- Updated `GeminiClient`, `OpenAIClient`, and `AnthropicClient` initializers to actively call the provider's model API upon object instantiation (e.g., retrieving model metadata) and fail fast if invalid.
- Expanded `tests/test_llm.py` with unit tests for each provider's client to ensure invalid models successfully throw `InvalidModelError`.

Resolves #29
