### PR TITLE
feat: Support multiple specifications during requirements extraction

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -73,7 +73,7 @@ async def test_requirements_cache_miss(
   context = WorkflowContext(
     feature_id='test-feat',
     metadata=metadata,
-    spec_contents='spec content',
+    spec_contents={'http://spec': 'spec content'},
   )
   cache_dir = tmp_path / 'cache'
   cache_dir.mkdir()
@@ -147,7 +147,7 @@ async def test_requirements_cache_hit_reject(
   context = WorkflowContext(
     feature_id=web_feature_id,
     metadata=metadata,
-    spec_contents='spec content',
+    spec_contents={'http://spec': 'spec content'},
   )
 
   # User rejects cache

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -88,7 +88,7 @@ async def test_run_context_assembly_success(mock_config: Config, mock_ui: MagicM
     assert context.feature_id == 'feat-id'
     assert context.metadata is not None
     assert context.metadata.name == 'Feat'
-    assert context.spec_contents == 'Spec Content'
+    assert context.spec_contents == {'http://spec': 'Spec Content'}
     mock_ui.on_phase_start.assert_called_once_with(1, 'Context Assembly')
     mock_ui.report_metadata.assert_called_once()
 
@@ -173,7 +173,7 @@ async def test_run_requirements_extraction_cached(
   context = WorkflowContext(
     feature_id='feat',
     metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    spec_contents='Spec',
+    spec_contents={'http://spec': 'Spec'},
   )
   cache_dir = tmp_path
   cache_file = cache_dir / 'feat__requirements.xml'
@@ -199,7 +199,7 @@ async def test_run_requirements_extraction_categorized(
   context = WorkflowContext(
     feature_id='feat',
     metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    spec_contents='Spec',
+    spec_contents={'http://spec': 'Spec'},
   )
   jinja_env = MagicMock()
   jinja_env.get_template.return_value.render.return_value = 'Mock Template'
@@ -238,7 +238,7 @@ async def test_run_requirements_extraction_categorized_partial_empty(
   context = WorkflowContext(
     feature_id='feat-partial',
     metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    spec_contents='Spec',
+    spec_contents={'http://spec': 'Spec'},
   )
   jinja_env = MagicMock()
   jinja_env.get_template.return_value.render.return_value = 'Mock Template'
@@ -274,7 +274,7 @@ async def test_run_requirements_extraction_categorized_with_rationale(
   context = WorkflowContext(
     feature_id='feat-rationale',
     metadata=WebFeatureMetadata('Feat', 'Desc', ['http://spec']),
-    spec_contents='Spec',
+    spec_contents={'http://spec': 'Spec'},
   )
   jinja_env = MagicMock()
   jinja_env.get_template.return_value.render.return_value = 'Mock Template'

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -66,7 +66,7 @@ def test_workflow_context_serialization() -> None:
   context = WorkflowContext(
     feature_id='test-feat',
     metadata=metadata,
-    spec_contents='Spec contents',
+    spec_contents={'http://spec': 'Spec contents'},
     wpt_context=wpt_context,
     requirements_xml='<reqs/>',
     audit_response='<audit/>',

--- a/wptgen/models.py
+++ b/wptgen/models.py
@@ -88,7 +88,7 @@ class WorkflowContext:
 
   feature_id: str
   metadata: WebFeatureMetadata | None = None
-  spec_contents: str | None = None
+  spec_contents: dict[str, str] | None = None
   wpt_context: WPTContext | None = None
   requirements_xml: str | None = None
   audit_response: str | None = None
@@ -122,10 +122,16 @@ class WorkflowContext:
     if data.get('generated_tests'):
       generated_tests = [(Path(p), c, s) for p, c, s in data['generated_tests']]
 
+    spec_contents = data.get('spec_contents')
+    if isinstance(spec_contents, str):
+      # Fallback for old cache format
+      spec_url = metadata.specs[0] if metadata and metadata.specs else 'unknown'
+      spec_contents = {spec_url: spec_contents}
+
     return cls(
       feature_id=data['feature_id'],
       metadata=metadata,
-      spec_contents=data.get('spec_contents'),
+      spec_contents=spec_contents,
       wpt_context=wpt_context,
       requirements_xml=data.get('requirements_xml'),
       audit_response=data.get('audit_response'),

--- a/wptgen/phases/context_assembly.py
+++ b/wptgen/phases/context_assembly.py
@@ -64,7 +64,10 @@ async def run_context_assembly(
 
   ui.print('\nFetching spec content...')
   with ui.status('Fetching and extracting text...'):
-    spec_contents = fetch_and_extract_text(metadata.specs[0])
+    results = await asyncio.gather(
+      *[asyncio.to_thread(fetch_and_extract_text, url) for url in metadata.specs]
+    )
+    spec_contents = {url: res for url, res in zip(metadata.specs, results, strict=True) if res}
 
   if not spec_contents:
     ui.error('Failed to extract spec content.')
@@ -90,7 +93,7 @@ async def run_context_assembly(
       ]
 
   ui.report_context_summary(
-    len(spec_contents),
+    sum(len(content) for content in spec_contents.values()),
     len(mdn_contents) if mdn_contents else 0,
     len(wpt_context.test_contents),
     len(wpt_context.dependency_contents),

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -86,7 +86,7 @@ async def run_test_generation(
   gen_template = jinja_env.get_template('test_generation.jinja')
   system_template = jinja_env.get_template('test_generation_system.jinja')
 
-  spec_url = context.metadata.specs[0] if context.metadata and context.metadata.specs else None
+  spec_urls = context.metadata.specs if context.metadata and context.metadata.specs else []
   prompts_to_confirm: list[tuple[str, str, str, str]] = []
 
   # Keep track of filenames used in this run to avoid collisions
@@ -94,10 +94,11 @@ async def run_test_generation(
   output_dir = Path(config.output_dir or '.')
 
   for suggestion_xml in approved_suggestions_xml:
-    # Inject specification URL if available
-    if spec_url:
+    # Inject specification URLs if available
+    if spec_urls:
+      spec_url_tags = '\n'.join([f'  <spec_url>{url}</spec_url>' for url in spec_urls])
       suggestion_xml = suggestion_xml.replace(
-        '</test_suggestion>', f'  <spec_url>{spec_url}</spec_url>\n</test_suggestion>'
+        '</test_suggestion>', f'{spec_url_tags}\n</test_suggestion>'
       )
 
     # Extract and normalize test type
@@ -125,7 +126,7 @@ async def run_test_generation(
     final_prompt = gen_template.render(
       feature_name=context.metadata.name,
       feature_description=context.metadata.description,
-      spec_contents=context.spec_contents,
+      specs=context.spec_contents,
       test_suggestion_xml_block=suggestion_xml,
     )
 

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -51,8 +51,7 @@ async def run_requirements_extraction(
     extraction_prompt = jinja_env.get_template('requirements_extraction.jinja').render(
       feature_name=context.metadata.name,
       feature_description=context.metadata.description,
-      spec_url=context.metadata.specs[0],
-      spec_contents=context.spec_contents,
+      specs=context.spec_contents,
       mdn_contents=context.mdn_contents,
     )
     extraction_system_prompt = jinja_env.get_template(
@@ -272,8 +271,7 @@ async def run_requirements_extraction_iterative(
       extraction_prompt = jinja_env.get_template('requirements_extraction_iterative.jinja').render(
         feature_name=context.metadata.name,
         feature_description=context.metadata.description,
-        spec_url=context.metadata.specs[0],
-        spec_contents=context.spec_contents,
+        specs=context.spec_contents,
         mdn_contents=context.mdn_contents,
         existing_requirements_xml=existing_requirements_xml,
       )

--- a/wptgen/templates/requirements_extraction.jinja
+++ b/wptgen/templates/requirements_extraction.jinja
@@ -5,9 +5,13 @@ Extract the core normative test requirements for the following feature and speci
   <feature_description>{{feature_description}}</feature_description>
 </feature_definition>
 
-<spec_document url="{{spec_url}}">
-{{spec_contents}}
+{% if specs -%}
+{% for url, content in specs.items() -%}
+<spec_document url="{{url}}">
+{{content}}
 </spec_document>
+{%- endfor %}
+{%- endif %}
 
 {% if mdn_contents -%}
 {% for content in mdn_contents -%}

--- a/wptgen/templates/requirements_extraction_categorized.jinja
+++ b/wptgen/templates/requirements_extraction_categorized.jinja
@@ -5,9 +5,13 @@ Extract the core normative test requirements for the following feature and speci
   <feature_description>{{feature_description}}</feature_description>
 </feature_definition>
 
-<spec_document url="{{spec_url}}">
-{{spec_contents}}
+{% if specs -%}
+{% for url, content in specs.items() -%}
+<spec_document url="{{url}}">
+{{content}}
 </spec_document>
+{%- endfor %}
+{%- endif %}
 
 {% if mdn_contents -%}
 {% for content in mdn_contents -%}

--- a/wptgen/templates/requirements_extraction_iterative.jinja
+++ b/wptgen/templates/requirements_extraction_iterative.jinja
@@ -5,9 +5,13 @@ Extract the normative test requirements for the following feature and specificat
   <feature_description>{{feature_description}}</feature_description>
 </feature_definition>
 
-<spec_document url="{{spec_url}}">
-{{spec_contents}}
+{% if specs -%}
+{% for url, content in specs.items() -%}
+<spec_document url="{{url}}">
+{{content}}
 </spec_document>
+{%- endfor %}
+{%- endif %}
 
 {% if mdn_contents -%}
 {% for content in mdn_contents -%}

--- a/wptgen/templates/test_generation.jinja
+++ b/wptgen/templates/test_generation.jinja
@@ -2,8 +2,12 @@ Generate a single WPT file for the feature "{{feature_name}}" ({{feature_descrip
 
 {{ test_suggestion_xml_block }}
 
-{% if spec_contents -%}
+{% if specs -%}
 # Specification Context
 The exact API definitions, interfaces, and expected behaviors for this feature:
-{{ spec_contents }}
+{% for url, content in specs.items() -%}
+<spec_document url="{{url}}">
+{{ content }}
+</spec_document>
+{%- endfor %}
 {%- endif %}


### PR DESCRIPTION
## Description

Fixes #109.

This pull request updates the context assembly phase to concurrently fetch all specification URLs defined in a web feature's metadata. 

By mapping specification URLs to their respective contents using a dictionary (`dict[str, str]`), both the requirements extraction and test generation phases can now ingest multiple specifications for a single web feature.

*   Updated `WorkflowContext.spec_contents` type to `dict[str, str]`.
*   Added fallback logic in `WorkflowContext.from_dict` to support backward compatibility for older cache files that store `spec_contents` as a single string.
*   Updated Jinja templates (`requirements_extraction*.jinja` and `test_generation.jinja`) to iterate over the `specs` dictionary, generating a `<spec_document>` block for each specification provided.
*   Updated `generation.py` to inject multiple `<spec_url>` tags into the test suggestion XML payload.
*   Updated mocked test context data to use dictionaries instead of strings.
