### PR TITLE
fix: correct specification passing in categorized extraction and add clear-cache make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ help:
 	@echo "  make presubmit  - Run lint-fix, typecheck, and test"
 	@echo "  make build      - Build source and wheel distributions"
 	@echo "  make publish    - Upload the package to PyPI"
+	@echo "  make clear-cache- Clear ruff, mypy, and pytest caches"
 	@echo "  make clean      - Remove build artifacts and caches"
 
 install:
@@ -53,6 +54,9 @@ build: clean
 publish: build
 	$(PYTHON) -m twine upload dist/*
 
-clean:
-	rm -rf .pytest_cache .mypy_cache .ruff_cache build/ dist/ *.egg-info
+clear-cache:
+	rm -rf .pytest_cache .mypy_cache .ruff_cache
 	find . -type d -name "__pycache__" -exec rm -rf {} +
+
+clean: clear-cache
+	rm -rf build/ dist/ *.egg-info

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -127,11 +127,8 @@ async def run_requirements_extraction_categorized(
       ).render(
         feature_name=metadata.name,
         feature_description=metadata.description,
-        spec_url=metadata.specs[0],
-        spec_contents=context.spec_contents,
+        specs=context.spec_contents,
         mdn_contents=context.mdn_contents,
-        category_name=category_name,
-        category_description=category_description,
       )
       extraction_system_prompt = jinja_env.get_template(
         'requirements_extraction_categorized_system.jinja'


### PR DESCRIPTION
### Summary
This PR addresses two separate items:
1. **Bug Fix in Categorized Requirements Extraction:** The `requirements_extraction_categorized.jinja` template expects a `specs` variable to ingest specification content. However, the orchestrator in `requirements_extraction.py` was incorrectly passing `spec_contents=context.spec_contents`, resulting in the template silently omitting the specification entirely. This PR corrects the parameter to `specs=context.spec_contents` and removes unused context variables that are only needed by the system prompt.
2. **New Makefile Target:** Adds a new `make clear-cache` command to isolate the removal of tool caches (`.pytest_cache`, `.mypy_cache`, `.ruff_cache`, and `__pycache__`) from the broader `make clean` command. `make clean` has been updated to depend on `clear-cache`.
