### PR TITLE
fix: deep merge nested config properties on load (Resolves #187)

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -311,3 +311,62 @@ def test_load_config_loaded_from_none(monkeypatch: pytest.MonkeyPatch) -> None:
 
   config = load_config(config_path='non_existent.yml', require_api_key=False)
   assert config.loaded_from is None
+
+
+def test_deep_merge_utility() -> None:
+  """Test the _deep_merge helper handles nested objects correctly."""
+  from wptgen.config import _deep_merge
+
+  target = {'a': 1, 'b': {'x': 10, 'y': 20}, 'c': {'z': 30}}
+  source = {'b': {'x': 100}, 'c': 40, 'd': 50}
+
+  merged = _deep_merge(target, source)
+  assert merged == {'a': 1, 'b': {'x': 100, 'y': 20}, 'c': 40, 'd': 50}
+  # Ensure original target is not mutated
+  assert target == {'a': 1, 'b': {'x': 10, 'y': 20}, 'c': {'z': 30}}
+
+
+def test_load_config_deep_merges_phase_mapping(
+  monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+  """Test that setting a single nested property preserves sibling defaults."""
+  monkeypatch.setenv('GEMINI_API_KEY', 'mock-key')
+
+  config_file = tmp_path / 'wpt-gen.yml'
+  # Simulate the YAML created by `config set phase_model_mapping.generation reasoning`
+  # when no other config exists.
+  config_file.write_text('phase_model_mapping:\n  generation: reasoning\n', encoding='utf-8')
+
+  config = load_config(config_path=str(config_file))
+
+  # The generation property should be overridden
+  assert config.phase_model_mapping['generation'] == 'reasoning'
+  # Default sibling properties should be preserved
+  assert config.phase_model_mapping['requirements_extraction'] == 'reasoning'
+  assert config.phase_model_mapping['coverage_audit'] == 'reasoning'
+  assert config.phase_model_mapping['evaluation'] == 'lightweight'
+
+
+def test_load_config_deep_merges_categories(
+  monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+  """Test that overriding a single category preserves other default categories."""
+  monkeypatch.setenv('GEMINI_API_KEY', 'mock-key')
+
+  config_file = tmp_path / 'wpt-gen.yml'
+  config_file.write_text(
+    """
+providers:
+  gemini:
+    categories:
+      lightweight: gemini-custom-flash
+""",
+    encoding='utf-8',
+  )
+
+  config = load_config(config_path=str(config_file))
+
+  # The lightweight category should be overridden
+  assert config.categories['lightweight'] == 'gemini-custom-flash'
+  # The reasoning default category should be preserved
+  assert config.categories['reasoning'] == 'gemini-3.1-pro-preview'

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -150,6 +150,17 @@ def validate_output_dir(output_dir: str) -> str:
   return str(path)
 
 
+def _deep_merge(target: dict[str, Any], source: dict[str, Any]) -> dict[str, Any]:
+  """Recursively merges source into target, returning a new dictionary."""
+  result = target.copy()
+  for key, value in source.items():
+    if isinstance(value, dict) and isinstance(result.get(key), dict):
+      result[key] = _deep_merge(result[key], value)
+    else:
+      result[key] = value
+  return result
+
+
 def load_config(
   config_path: str = DEFAULT_CONFIG_PATH,
   provider_override: str | None = None,
@@ -265,7 +276,7 @@ def load_config(
 
   # Load model categories and phase mapping
   default_model = provider_settings.get('default_model', default_model_name)
-  categories = provider_settings.get('categories', default_categories)
+  categories = _deep_merge(default_categories, provider_settings.get('categories', {}))
 
   if use_lightweight_override:
     default_model = categories.get('lightweight', default_model)
@@ -279,7 +290,7 @@ def load_config(
     'generation': 'lightweight',
     'evaluation': 'lightweight',
   }
-  phase_model_mapping = yaml_data.get('phase_model_mapping', default_phase_mapping)
+  phase_model_mapping = _deep_merge(default_phase_mapping, yaml_data.get('phase_model_mapping', {}))
 
   return Config(
     provider=active_provider,


### PR DESCRIPTION
## Background
Currently, when a user uses `wpt-gen config set` to mutate a nested property (e.g., `wpt-gen config set phase_model_mapping.generation reasoning`), the CLI parses the key using dot-notation, updates the raw YAML data, and writes it back to `wpt-gen.yml`. If the YAML file did not previously contain the parent object, it creates a new dictionary containing *only* the new key. When `load_config` loads this configuration, it uses `.get()`, completely overriding the default dictionary rather than merging with it. This effectively "deletes" all other essential phase mappings.

## Proposed Changes
- Added a `_deep_merge` helper function in `wptgen/config.py` to perform a dictionary deep-merge (recursive update) for nested configuration objects.
- Updated `load_config` to use `_deep_merge` for properties like `phase_model_mapping` and `categories` instead of a simple `.get()`. This ensures partial configurations in `wpt-gen.yml` always correctly fall back to defaults for missing keys.
- Added comprehensive unit tests in `tests/test_config.py` to verify that setting a single nested property preserves sibling defaults.

## Validation
- [x] Verified that running a fresh config preserves the default values for all other properties within nested objects.
- [x] Verified the resolved `Config` object contains the full set of defaults alongside the user's specific override.
- [x] Added unit tests and ran `make presubmit` successfully.

Fixes #187.
