### PR TITLE
feat: partition test requirements for coverage audit LLM requests

### DIFF
--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -528,8 +529,8 @@ def test_partition_requirements_xml() -> None:
   reqs41 = '\n'.join(f'<requirement id="{i}">{i}</requirement>' for i in range(1, 42))
   parts41 = partition_requirements_xml(reqs41, max_threshold=40)
   assert len(parts41) == 2
-  assert parts41[0].count('<requirement ') == 21
-  assert parts41[1].count('<requirement ') == 20
+  assert len(re.findall(r'<requirement\b[^>]*>', parts41[0])) == 21
+  assert len(re.findall(r'<requirement\b[^>]*>', parts41[1])) == 20
   assert 'id="21"' in parts41[0]
   assert 'id="22"' in parts41[1]
 
@@ -537,8 +538,8 @@ def test_partition_requirements_xml() -> None:
   reqs42 = '\n'.join(f'<requirement id="{i}">{i}</requirement>' for i in range(1, 43))
   parts42 = partition_requirements_xml(reqs42, max_threshold=40)
   assert len(parts42) == 2
-  assert parts42[0].count('<requirement ') == 21
-  assert parts42[1].count('<requirement ') == 21
+  assert len(re.findall(r'<requirement\b[^>]*>', parts42[0])) == 21
+  assert len(re.findall(r'<requirement\b[^>]*>', parts42[1])) == 21
 
 
 def test_combine_audit_responses() -> None:

--- a/wptgen/phases/coverage_audit.py
+++ b/wptgen/phases/coverage_audit.py
@@ -32,7 +32,7 @@ FILENAME_SANITIZATION_RE = re.compile(r'[^a-z0-9_\-]')
 def partition_requirements_xml(xml_string: str, max_threshold: int = 40) -> list[str]:
   if not xml_string:
     return []
-  matches = list(re.finditer(r'(?s)<requirement.*?>.*?</requirement>', xml_string))
+  matches = list(re.finditer(r'(?s)<requirement\b[^>]*>.*?</requirement>', xml_string))
   if not matches:
     return [xml_string] if xml_string.strip() else []
 
@@ -98,7 +98,7 @@ async def run_coverage_audit(
       requirements_list_xml=req_xml,
       wpt_context=context.wpt_context,
     )
-    req_count = req_xml.count('<requirement ')
+    req_count = len(re.findall(r'<requirement\b[^>]*>', req_xml))
     task_name = (
       f'Coverage Audit (Partition {i + 1}/{len(req_partitions)}: {req_count} requirements)'
       if len(req_partitions) > 1

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -84,7 +84,7 @@ async def run_requirements_extraction(
     # Save to cache
     cache_file.write_text(requirements_xml, encoding='utf-8')
 
-  count = len(re.findall(r'<requirement.*?>', requirements_xml))
+  count = len(re.findall(r'<requirement\b[^>]*>', requirements_xml))
   ui.success(f'Extracted {count} test requirements.')
 
   context.requirements_xml = requirements_xml
@@ -200,7 +200,7 @@ async def run_requirements_extraction_categorized(
         continue
 
       # Extract individual <requirement> blocks.
-      new_reqs = re.findall(r'(<requirement.*?>.*?</requirement>)', response, re.DOTALL)
+      new_reqs = re.findall(r'(<requirement\b[^>]*>.*?</requirement>)', response, re.DOTALL)
 
       if not new_reqs:
         # If no requirements, look for a rationale.
@@ -228,7 +228,7 @@ async def run_requirements_extraction_categorized(
     # Save to cache
     cache_file.write_text(requirements_xml, encoding='utf-8')
 
-  count = len(re.findall(r'<requirement.*?>', requirements_xml))
+  count = len(re.findall(r'<requirement\b[^>]*>', requirements_xml))
   ui.success(f'Extracted {count} test requirements.')
   context.requirements_xml = requirements_xml
   return requirements_xml
@@ -305,7 +305,7 @@ async def run_requirements_extraction_iterative(
         break
 
       # Extract individual <requirement> blocks.
-      new_reqs = re.findall(r'(<requirement.*?>.*?</requirement>)', response, re.DOTALL)
+      new_reqs = re.findall(r'(<requirement\b[^>]*>.*?</requirement>)', response, re.DOTALL)
 
       if not new_reqs:
         ui.warning('No new requirements found in this iteration. Stopping.')
@@ -337,7 +337,7 @@ async def run_requirements_extraction_iterative(
     # Save to cache
     cache_file.write_text(requirements_xml, encoding='utf-8')
 
-  count = len(re.findall(r'<requirement.*?>', requirements_xml))
+  count = len(re.findall(r'<requirement\b[^>]*>', requirements_xml))
   ui.success(f'Extracted {count} test requirements.')
   context.requirements_xml = requirements_xml
   return requirements_xml


### PR DESCRIPTION
Resolves #186

### Background
During the coverage audit phase, processing a massive list of requirements in a single LLM request can lead to degraded performance or exceed token limits.

### Changes
- Implemented `partition_requirements_xml` to chunk requirements when they exceed a threshold of 40.
- Implemented an even-distribution algorithm so straggler requirements are avoided (e.g. 41 requirements splits into 21 and 20).
- Updated `run_coverage_audit` to dispatch the partitioned LLM requests concurrently using `asyncio.gather`.
- Added `combine_audit_responses` to aggregate the results from the parallel partitions into a single cohesive output block.
- Added comprehensive unit tests in `tests/test_phases.py` to verify partitioning math and response merging.

`make presubmit` has been run and passes cleanly.
