### PR TITLE
feat: add --wpt-path option to init command (Resolves #185)

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -838,6 +838,38 @@ def test_init_command_local(mocker: MockerFixture) -> None:
     assert str(Path('/fake/wpt').resolve()) == config_data['wpt_path']
 
 
+def test_init_command_with_wpt_path_flag(mocker: MockerFixture) -> None:
+  """Test the init command accepts --wpt-path and skips the prompt."""
+  import yaml
+
+  with runner.isolated_filesystem():
+    local_config_path = str(Path('wpt-gen.yml').resolve())
+
+    # Inputs:
+    # 1. 'gemini' (provider)
+    # 2. '' (default model - accept default)
+    # 3. '' (lightweight model - accept default)
+    # 4. '' (reasoning model - accept default)
+    # NO WPT PATH PROMPT because of the flag
+    result = runner.invoke(
+      app,
+      ['init', '--config', 'wpt-gen.yml', '--wpt-path', '/flag/wpt'],
+      input='gemini\n\n\n\n',
+    )
+
+    assert result.exit_code == 0
+    assert 'Configuration saved successfully' in result.stdout
+
+    config_path = Path(local_config_path)
+    assert config_path.exists()
+
+    with open(config_path, encoding='utf-8') as f:
+      config_data = yaml.safe_load(f)
+
+    assert config_data['default_provider'] == 'gemini'
+    assert str(Path('/flag/wpt').resolve()) == config_data['wpt_path']
+
+
 def test_audit_success(mocker: MockerFixture, mock_config: Config) -> None:
   """Test the happy path execution of the audit command."""
   mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -850,6 +850,10 @@ def init(
   config_path: Annotated[
     str | None, typer.Option('--config', '-c', help='Path to a custom wpt-gen.yml file.')
   ] = None,
+  wpt_path: Annotated[
+    str | None,
+    typer.Option('--wpt-path', help='Absolute path to local web-platform-tests directory.'),
+  ] = None,
 ) -> None:
   """
   Initialize a new wpt-gen configuration file interactively.
@@ -882,9 +886,10 @@ def init(
   lightweight_model = Prompt.ask('Lightweight model', default=defaults['lightweight'])
   reasoning_model = Prompt.ask('Reasoning model', default=defaults['reasoning'])
 
-  wpt_path = Prompt.ask(
-    '\nAbsolute path to local web-platform-tests directory', default=str(Path.home() / 'wpt')
-  )
+  if wpt_path is None:
+    wpt_path = Prompt.ask(
+      '\nAbsolute path to local web-platform-tests directory', default=str(Path.home() / 'wpt')
+    )
 
   config_data = {
     'default_provider': provider,


### PR DESCRIPTION
## Background & Motivation
Currently, the `wpt-gen init` command asks for the local Web Platform Tests directory path interactively. Adding a `--wpt-path` CLI option to the `init` command allows users to leverage their shell's built-in file and directory auto-completion capabilities, bypassing the interactive prompt.

## Proposed Changes
- Added the `--wpt-path` option via `typer.Option` to the `init` command in `wptgen/main.py`.
- Modified the interactive flow to skip the WPT path prompt if `--wpt-path` is provided, using the CLI value instead.
- Fallbacked to the existing interactive prompt behavior if the option is not provided.
- The provided path is correctly resolved and saved to the generated configuration file.
- Added corresponding unit tests in `tests/test_main.py` to cover the new `--wpt-path` option behavior.

Resolves #185
