### PR TITLE
feat: Handle token limit exceeded in coverage audit phase

### DIFF
--- a/tests/test_coverage_audit.py
+++ b/tests/test_coverage_audit.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from jinja2 import Environment
+
+from wptgen.config import Config
+from wptgen.models import WorkflowContext, WPTContext
+from wptgen.phases.coverage_audit import run_coverage_audit
+
+
+@pytest.fixture
+def mock_ui() -> MagicMock:
+  ui = MagicMock()
+  ui.status.return_value.__enter__.return_value = None
+  return ui
+
+
+@pytest.fixture
+def mock_config(tmp_path: Path) -> Config:
+  return Config(
+    provider='test',
+    default_model='test-model',
+    api_key='test-key',
+    wpt_path=str(tmp_path),
+    categories={},
+    phase_model_mapping={},
+  )
+
+
+@pytest.mark.asyncio
+async def test_run_coverage_audit_token_limit_exceeded(
+  mock_config: Config, mock_ui: MagicMock
+) -> None:
+  wpt_context = WPTContext()
+  context = WorkflowContext(
+    feature_id='test',
+    requirements_xml='<requirements><requirement id="R1">Test requirement</requirement></requirements>',
+    wpt_context=wpt_context,
+  )
+
+  mock_llm = MagicMock()
+  mock_llm.prompt_exceeds_input_token_limit.return_value = True
+
+  jinja_env = MagicMock(spec=Environment)
+  mock_template = MagicMock()
+  mock_template.render.return_value = 'Rendered Prompt'
+  jinja_env.get_template.return_value = mock_template
+
+  result = await run_coverage_audit(context, mock_config, mock_llm, mock_ui, jinja_env)
+
+  assert result is None
+  mock_ui.error.assert_called_once_with('This test suite to too large to audit.')

--- a/wptgen/phases/coverage_audit.py
+++ b/wptgen/phases/coverage_audit.py
@@ -98,6 +98,13 @@ async def run_coverage_audit(
       requirements_list_xml=req_xml,
       wpt_context=context.wpt_context,
     )
+
+    if llm.prompt_exceeds_input_token_limit(
+      prompt, model=config.get_model_for_phase('coverage_audit')
+    ):
+      ui.error('This test suite to too large to audit.')
+      return None
+
     req_count = len(re.findall(r'<requirement\b[^>]*>', req_xml))
     task_name = (
       f'Coverage Audit (Partition {i + 1}/{len(req_partitions)}: {req_count} requirements)'


### PR DESCRIPTION
This pull request introduces a safeguard during the "coverage audit" phase to gracefully handle test suites that exceed the LLM's context window.

Previously, encountering a test suite context larger than the model's supported limit would cause the LLM call to fail unexpectedly or hang. This update introduces an early check using the `prompt_exceeds_input_token_limit` helper. If the constructed prompt exceeds the model's token limit, the workflow correctly aborts and alerts the user with:
`This test suite to too large to audit.`

## Changes
- Updated `run_coverage_audit` in `wptgen/phases/coverage_audit.py` to evaluate the token limit of generated partition prompts.
- Created `tests/test_coverage_audit.py` with a new unit test, ensuring the workflow aborts and the specific error message is printed when the limit is exceeded.
