### PR TITLE
feat: Add flag to skip execution phase in the generate workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ wpt-gen generate font-family
 | `--provider` | `-p` | Override the default LLM provider (`gemini`, `openai`, `anthropic`). |
 | `--wpt-dir` | `-w` | Override the path to the local web-platform-tests repository. |
 | `--draft` | | Enable fetching metadata from the draft features directory. |
+| `--skip-execution` | `--no-exec` | Skip the test execution phase (useful if the browser implementation is not completed). |
 | `--config` | `-c` | Path to a custom `wpt-gen.yml` file. |
 
 **Note:** You can run `wpt-gen generate --help` to see a full list of all 20+ options (including execution control, retries, and manual overrides). For more detailed information, see the [CLI Command Reference](docs/cli.md).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,6 +34,7 @@ wpt-gen generate [OPTIONS] WEB_FEATURE_ID
 | `--suggestions-only` | Stop after generating test blueprints/suggestions. Skip the actual test file generation. |
 | `--yes-tokens` | Automatically confirm all prompts related to LLM token counts. |
 | `--skip-evaluation`, `--no-eval` | Skip the Phase 5 (Evaluation) step. |
+| `--skip-execution`, `--no-exec` | Skip the Phase 6 (Test Execution) step (useful if the browser implementation is not completed). |
 | `--max-parallel-requests` | Limit the number of concurrent asynchronous LLM requests. |
 
 #### Model Configuration

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -206,3 +206,27 @@ async def test_run_async_workflow_skip_evaluation(
 
   mock_eval.assert_not_called()
   mock_ui.info.assert_called_with('Skipping Phase 5: Evaluation.')
+
+
+@pytest.mark.asyncio
+async def test_run_async_workflow_skip_execution(
+  engine: WPTGenEngine, mock_ui: MagicMock, mocker: MockerFixture
+) -> None:
+  """Verifies that Phase 6: Test Execution is skipped when config.skip_execution is True."""
+  engine.config.skip_execution = True
+  context = WorkflowContext(feature_id='feat-id')
+  requirements = 'reqs'
+  audit = 'audit'
+  generated_tests = [('path', 'content', 'suggestion')]
+
+  mocker.patch('wptgen.engine.run_context_assembly', return_value=context)
+  mocker.patch('wptgen.engine.run_requirements_extraction_categorized', return_value=requirements)
+  mocker.patch('wptgen.engine.run_coverage_audit', return_value=audit)
+  mocker.patch('wptgen.engine.run_test_generation', return_value=generated_tests)
+  mocker.patch('wptgen.engine.run_test_evaluation', return_value=None)
+  mock_exec = mocker.patch('wptgen.engine.run_test_execution', return_value=None)
+
+  await engine._run_async_workflow('feat-id')
+
+  mock_exec.assert_not_called()
+  mock_ui.info.assert_called_with('Skipping Phase 6: Test Execution.')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -102,6 +102,7 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -141,6 +142,7 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -176,6 +178,7 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -211,6 +214,7 @@ def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -246,6 +250,7 @@ def test_generate_max_retries(mocker: MockerFixture, mock_config: Config) -> Non
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -281,6 +286,7 @@ def test_generate_detailed_requirements(mocker: MockerFixture, mock_config: Conf
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -315,6 +321,7 @@ def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) ->
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=True,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -344,6 +351,7 @@ def test_generate_skip_evaluation(mocker: MockerFixture, mock_config: Config) ->
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=True,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -410,6 +418,7 @@ def test_generate_spec_urls(mocker: MockerFixture, mock_config: Config) -> None:
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -445,6 +454,7 @@ def test_generate_description(mocker: MockerFixture, mock_config: Config) -> Non
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -480,6 +490,7 @@ def test_generate_resume(mocker: MockerFixture, mock_config: Config) -> None:
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -515,6 +526,7 @@ def test_generate_use_lightweight(mocker: MockerFixture, mock_config: Config) ->
     use_lightweight_override=True,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -550,6 +562,7 @@ def test_generate_use_reasoning(mocker: MockerFixture, mock_config: Config) -> N
     use_lightweight_override=False,
     use_reasoning_override=True,
     skip_evaluation_override=False,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -585,6 +598,7 @@ def test_generate_single_prompt_requirements(mocker: MockerFixture, mock_config:
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -620,6 +634,7 @@ def test_generate_max_parallel_requests(mocker: MockerFixture, mock_config: Conf
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=5,
     temperature_override=None,
@@ -886,6 +901,7 @@ def test_audit_success(mocker: MockerFixture, mock_config: Config) -> None:
   kwargs = mock_load_config.call_args.kwargs
   assert kwargs['suggestions_only'] is True
   assert kwargs['skip_evaluation_override'] is True
+  assert kwargs['skip_execution_override'] is True
   assert kwargs['provider_override'] == 'gemini'
 
   mock_engine_instance.run_workflow.assert_called_once_with('grid')
@@ -919,6 +935,7 @@ def test_generate_draft(mocker: MockerFixture, mock_config: Config) -> None:
     use_lightweight_override=False,
     use_reasoning_override=False,
     skip_evaluation_override=False,
+    skip_execution_override=False,
     tentative_override=False,
     max_parallel_requests_override=None,
     temperature_override=None,
@@ -1007,3 +1024,68 @@ def test_config_set_command_types(mocker: MockerFixture) -> None:
     assert data['timeout'] == 120
     assert data['show_responses'] is True
     assert data['temperature'] == 0.5
+
+
+def test_generate_skip_execution(mocker: MockerFixture, mock_config: Config) -> None:
+  """Test that the --skip-execution/--no-exec flag is correctly passed to load_config."""
+  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
+  mocker.patch('wptgen.main.WPTGenEngine')
+
+  # Run with --skip-execution
+  result = runner.invoke(app, ['generate', 'grid', '--skip-execution'])
+  assert result.exit_code == 0
+  mock_load_config.assert_called_with(
+    config_path=DEFAULT_CONFIG_PATH,
+    provider_override=None,
+    wpt_dir_override=None,
+    output_dir_override=None,
+    show_responses=False,
+    yes_tokens_override=False,
+    yes_tests_override=False,
+    suggestions_only=False,
+    resume_override=False,
+    max_retries_override=3,
+    timeout_override=600,
+    spec_urls_override=None,
+    feature_description_override=None,
+    detailed_requirements_override=False,
+    draft_override=False,
+    single_prompt_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
+    skip_evaluation_override=False,
+    skip_execution_override=True,
+    tentative_override=False,
+    max_parallel_requests_override=None,
+    temperature_override=None,
+  )
+
+  # Run with --no-exec alias
+  mock_load_config.reset_mock()
+  result = runner.invoke(app, ['generate', 'grid', '--no-exec'])
+  assert result.exit_code == 0
+  mock_load_config.assert_called_with(
+    config_path=DEFAULT_CONFIG_PATH,
+    provider_override=None,
+    wpt_dir_override=None,
+    output_dir_override=None,
+    show_responses=False,
+    yes_tokens_override=False,
+    yes_tests_override=False,
+    suggestions_only=False,
+    resume_override=False,
+    max_retries_override=3,
+    timeout_override=600,
+    spec_urls_override=None,
+    feature_description_override=None,
+    detailed_requirements_override=False,
+    draft_override=False,
+    single_prompt_requirements_override=False,
+    use_lightweight_override=False,
+    use_reasoning_override=False,
+    skip_evaluation_override=False,
+    skip_execution_override=True,
+    tentative_override=False,
+    max_parallel_requests_override=None,
+    temperature_override=None,
+  )

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -72,6 +72,7 @@ class Config:
   use_lightweight: bool = False
   use_reasoning: bool = False
   skip_evaluation: bool = False
+  skip_execution: bool = False
   tentative: bool = False
   max_correction_retries: int = 2
   wpt_browser: str = 'chrome'
@@ -181,6 +182,7 @@ def load_config(
   use_lightweight_override: bool = False,
   use_reasoning_override: bool = False,
   skip_evaluation_override: bool = False,
+  skip_execution_override: bool = False,
   tentative_override: bool = False,
   require_api_key: bool = True,
   max_parallel_requests_override: int | None = None,
@@ -272,6 +274,7 @@ def load_config(
 
   cache_path = yaml_data.get('cache_path') or _get_default_cache_path()
   skip_evaluation = skip_evaluation_override or yaml_data.get('skip_evaluation', False)
+  skip_execution = skip_execution_override or yaml_data.get('skip_execution', False)
   tentative = tentative_override or yaml_data.get('tentative', False)
 
   # Load model categories and phase mapping
@@ -316,6 +319,7 @@ def load_config(
     use_lightweight=use_lightweight_override,
     use_reasoning=use_reasoning_override,
     skip_evaluation=skip_evaluation,
+    skip_execution=skip_execution,
     tentative=tentative,
     wpt_browser=yaml_data.get('wpt_browser', 'chrome'),
     wpt_channel=yaml_data.get('wpt_channel', 'canary'),

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -164,10 +164,12 @@ class WPTGenEngine:
       self.ui.info('Skipping Phase 5: Evaluation.')
 
     # Phase 6: Test Execution
-    if context.generated_tests:
+    if context.generated_tests and not self.config.skip_execution:
       await run_test_execution(
         context, self.config, self.llm, self.ui, self.jinja_env, context.generated_tests
       )
+    elif context.generated_tests and self.config.skip_execution:
+      self.ui.info('Skipping Phase 6: Test Execution.')
 
     # Final cleanup of resume file on success
     resume_file = self._get_resume_file_path(web_feature_id)

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -183,6 +183,14 @@ def generate(
       help='Skip the evaluation phase after generating tests.',
     ),
   ] = False,
+  skip_execution: Annotated[
+    bool,
+    typer.Option(
+      '--skip-execution',
+      '--no-exec',
+      help='Skip the test execution phase after generating tests.',
+    ),
+  ] = False,
   tentative: Annotated[
     bool,
     typer.Option(
@@ -260,6 +268,7 @@ def generate(
       use_lightweight_override=use_lightweight,
       use_reasoning_override=use_reasoning,
       skip_evaluation_override=skip_evaluation,
+      skip_execution_override=skip_execution,
       tentative_override=tentative,
       max_parallel_requests_override=max_parallel_requests,
       temperature_override=temperature,
@@ -729,6 +738,7 @@ def audit(
       use_lightweight_override=use_lightweight,
       use_reasoning_override=use_reasoning,
       skip_evaluation_override=True,
+      skip_execution_override=True,
       tentative_override=False,
       max_parallel_requests_override=max_parallel_requests,
       temperature_override=temperature,


### PR DESCRIPTION
## Background
When using the `wpt-gen generate` command, the current workflow automatically verifies the generated tests against the browser implementation. However, there are scenarios where the feature hasn't been implemented in the browser yet, or the user simply wants to generate the test files without running them. 

This PR adds a new CLI flag to skip the execution/verification phase for the `generate` workflow so users can bypass this step when necessary.

## Proposed Changes
* **CLI Option:** Added a new `--skip-execution` flag (and a `--no-exec` alias) to the `generate` command in `wptgen/main.py`.
* **Workflow Engine:** Updated the `WPTGenEngine` to respect this new flag and bypass the test execution phase when it is enabled.
* **Configuration:** Added `skip_execution` field to `Config` class, and passed the override via `load_config`.
* **Tests:** Added tests to `tests/test_main.py` and `tests/test_engine.py` to verify the correct parsing of the new CLI option and the updated engine behavior. Existing tests have also been correctly verified.
* **Documentation:** Updated `README.md` and `docs/cli.md` to document the new `--skip-execution` flag and its use case when browser implementation is incomplete.
* **Validation:** All changes pass `make presubmit` successfully.

Resolves #195
