### PR TITLE
docs: Update style guides with rules on timers, timeouts, and state cleanup

### DIFF
--- a/wptgen/templates/resources/crashtest_style_guide.md
+++ b/wptgen/templates/resources/crashtest_style_guide.md
@@ -54,6 +54,12 @@ The most effective crashtests are the most minimal. Avoid any extraneous HTML, C
 
 By default, the test runner finishes a crashtest once the `load` event fires and the initial paint is complete. If your test needs to perform work after the initial load, use `test-wait`.
 
+### Avoid Timers (**Do NOT** use `setTimeout`)
+The use of timers (like `setTimeout`) in tests is strongly discouraged because it is an observed source of instability in CI environments. Instead of guessing an appropriate timeout, always prefer event-driven approaches:
+- Wait for explicit events (e.g., `load`, `DOMContentLoaded`, or custom events) to indicate readiness.
+- Use **two** `requestAnimationFrame` calls to ensure rendering steps have completed.
+These alternatives improve reliability and consistency across different environments. If a test must fail when something doesn't happen, let it run to the full harness timeout rather than guessing a shorter timeout.
+
 ### The `test-wait` Class
 Add the `test-wait` class to the root element (`<html>`). The test will remain active until this class is removed.
 
@@ -87,6 +93,13 @@ The test runner fires a `TestRendered` event at the root element when it's ready
 
 ## 5. Advanced Features
 
+### Long Timeouts
+Execution of tests on a page is subject to a global timeout (defaulting to 10s). If your crashtest includes computationally heavy steps, large memory allocations, or an intentional long-running operation, it may incorrectly time out before the browser has a chance to settle. In this case, opt into a longer timeout (defaulting to 60s) by providing a `<meta>` element:
+
+```html
+<meta name="timeout" content="long">
+```
+
 ### User Interactions (`testdriver.js`)
 If a crash is triggered by user interaction, use `testdriver.js`.
 
@@ -116,6 +129,8 @@ You can use standard WPT filename flags with crashtests:
 - [ ] **Descriptive Filenames**: Use a concise, descriptive name (e.g., `flex-direction-change-crash.html`).
 - [ ] **UTF-8 Encoding**: Always include `<meta charset="utf-8">`.
 - [ ] **Cross-Browser Compatibility**: Ensure the test doesn't rely on features exclusive to one browser, unless testing that specific browser's behavior.
+- [ ] **Avoid Timers**: Never use `setTimeout`. Instead, use two `requestAnimationFrame` calls or wait for explicit events to manage test pacing and avoid flakiness.
+- [ ] **Handle Timeouts Correctly**: If a test needs more time, use `<meta name="timeout" content="long">` instead of shortening timers or trying to bypass the global timeout.
 - [ ] **Regressions**: If the test is a fix for a bug, include a `link` with `rel="help"` pointing to the bug report.
 - [ ] **CSS Metadata**: For tests in the `css/` directory, a `link` with `rel="help"` pointing to the relevant specification section is **required**.
 - [ ] **Lint Your Test**: Run `./wpt lint` before submitting to ensure your test follows all style and formatting rules.

--- a/wptgen/templates/resources/javascript_html_style_guide.md
+++ b/wptgen/templates/resources/javascript_html_style_guide.md
@@ -86,6 +86,10 @@ promise_test(async t => {
 }, "Fetch data test");
 ```
 
+**Important Rules for Promise Tests:**
+*   **Sequential Execution:** Unlike asynchronous tests, `testharness.js` queues promise tests so the next test won't start until the previous one finishes.
+*   **Do Not Mix with Async Steps:** Avoid mixing `promise_test` logic with callback functions like `t.step_func()`. This produces confusing tests and can cause the next test to begin before the promise settles. Wrap asynchronous behaviors into the promise chain instead.
+
 ### 4.3 Asynchronous Tests (`async_test`)
 Use for callback-based APIs. You must manually manage `step`, `done`, and `step_func`.
 ```javascript
@@ -95,6 +99,10 @@ async_test(t => {
   }));
 }, "DOMContentLoaded event");
 ```
+
+**Important Rules for Async Tests:**
+*   **Concurrency:** `testharness.js` doesn't impose scheduling on async tests; they run whenever step functions are invoked. Multiple tests in the same global can run concurrently. Take care not to let them interfere with each other.
+*   **Unreached Code:** For asynchronous callbacks that should never execute, use `t.unreached_func("Reason")`.
 
 ---
 
@@ -114,7 +122,7 @@ async_test(t => {
 ## 6. Core Best Practices
 
 ### 6.1 State Cleanup
-Always clean up global state (DOM, cookies, storage) to ensure test independence. Use `add_cleanup()`.
+Always clean up global state (DOM, cookies, storage) to ensure test independence. Use `add_cleanup()`. If the test was created using `promise_test`, cleanup functions may optionally return a Promise to delay the completion of the test until the cleanup promise settles.
 ```javascript
 promise_test(async t => {
   const el = document.createElement("div");
@@ -126,7 +134,7 @@ promise_test(async t => {
 ```
 
 ### 6.2 Avoid Timers
-Never use `setTimeout` with a hardcoded delay to "wait" for something.
+**DO NOT** use `setTimeout` with a hardcoded delay to "wait" for something.
 *   **Wait for an event**: Use `EventWatcher` or a Promise.
 *   **Check a condition**: Use `t.step_wait(() => condition)`.
 *   **Necessary delays**: Use `t.step_timeout(callback, delay)`.
@@ -135,6 +143,19 @@ Never use `setTimeout` with a hardcoded delay to "wait" for something.
 *   **UTF-8**: Always use UTF-8 (and `<meta charset=utf-8>` in HTML).
 *   **Independence**: Tests should not rely on external network resources or specific fonts (use [Ahem](/docs/writing-tests/ahem.md) for font testing).
 *   **Short & Focused**: Keep tests as concise as possible. Avoid testing unrelated features.
+
+
+### 6.4 AbortSignal Support
+Use `t.get_signal()` to get an `AbortSignal` that is automatically aborted when the test finishes. This is highly recommended when testing APIs that support `AbortSignal` to automatically clean up event listeners or fetch requests.
+```javascript
+promise_test(async t => {
+  const signal = t.get_signal();
+  document.body.addEventListener('click', () => {}, { once: true, signal });
+}, 'AbortSignal example');
+```
+
+### 6.5 Fetching JSON Data
+Use the helper `fetch_json('data.json')` instead of `fetch('data.json').then(r => r.json())`. This ensures compatibility with environments where `fetch()` is not exposed, such as `ShadowRealm`.
 
 ---
 
@@ -200,3 +221,42 @@ Cache-Control: no-cache
 
 ### 9.3 Static Responses (`.asis`)
 Use `.asis` files for byte-for-byte literal HTTP responses (including status line and headers). This is useful for testing invalid or edge-case HTTP responses.
+
+---
+
+## 10. Testing Across Globals
+
+You can consolidate tests from other documents or Web Workers into your main test document.
+
+### 10.1 Consolidating from other documents
+Use `fetch_tests_from_window(child_window)` to run tests in a child window or iframe and report them in the current context.
+
+### 10.2 Web Workers
+Use `fetch_tests_from_worker(worker)` to fetch test results from a worker. This function returns a promise that resolves once all remote tests have completed.
+
+```javascript
+(async function() {
+  await fetch_tests_from_worker(new Worker("worker-1.js"));
+  await fetch_tests_from_worker(new Worker("worker-2.js"));
+})();
+```
+
+**Worker Testing Quirks:**
+*   Workers rely on the client HTML document for reporting.
+*   The client document controls the test timeout.
+*   Dedicated and shared workers behave as if the `explicit_done` setup option is true, meaning `done()` must be called in the worker script to indicate completion (except for Service Workers which rely on the `install` event).
+
+---
+
+## 11. Harness Configuration (`setup()`)
+
+The `setup(options)` or `promise_setup(func)` functions configure the global test harness.
+
+**Common Options:**
+*   `explicit_done`: Wait for a manual call to `done()` before declaring all tests complete.
+*   `single_test`: Enables Single Page Test mode.
+*   `allow_uncaught_exception`: Disables treating uncaught exceptions as errors (useful when testing `window.onerror`).
+*   `hide_test_state`: Hides the test state UI during execution to prevent interference with visual tests.
+
+**Managing Timeouts Manually:**
+If a test has a race condition between the harness timing out and the test failing (e.g., waiting for an event that never occurs), you can use `t.force_timeout()` instead of `assert_unreached()`. This immediately fails the test with a status of `TIMEOUT` and should only be used as a last resort.

--- a/wptgen/templates/resources/reftest_style_guide.md
+++ b/wptgen/templates/resources/reftest_style_guide.md
@@ -102,6 +102,14 @@ If your test requires DOM manipulation or animation before the screenshot, use t
   });
 </script>
 ```
+
+**Waiting for events and avoiding timers:**
+The use of `setTimeout` in tests is strictly prohibited because it is an observed source of instability when running in CI. Instead, prefer event-driven approaches: wait for an event (e.g., `load`, `DOMContentLoaded`, or custom events) to indicate readiness, or use two `requestAnimationFrame` calls to ensure rendering steps have completed. These alternatives improve reliability and consistency across different environments.
+
+In some cases, such as reftests that compare frames after a specific animation duration (e.g., APNG tests), the use of a timeout may be acceptable. When doing so, consider documenting the reason.
+
+**DO NOT** Use `setTimeout` in your tests.
+
 The harness follows this sequence:
 1. Wait for `load` and fonts.
 2. Fire `TestRendered` on the root element.
@@ -134,6 +142,7 @@ Print reftests verify paginated output.
 ### Essential Metadata
 - **Charset**: Always include `<meta charset="utf-8">`.
 - **Conciseness**: Omit `<html>` and `<head>` tags if possible to keep the test focused.
+- **Timeouts**: Execution of tests is subject to a global timeout. Long-running tests may opt into a longer timeout by providing a `<meta>` element: `<meta name="timeout" content="long">`.
 - **Specification Links**:
     - **Required for CSS tests**, recommended for others.
     - Use `<link rel="help" href="...">` to link to the relevant spec section.

--- a/wptgen/templates/resources/wpt_style_guide.md
+++ b/wptgen/templates/resources/wpt_style_guide.md
@@ -84,6 +84,12 @@ Use a `<meta name="assert">` tag to provide a concise description of what the te
 <meta name="assert" content="Checks that flex-direction: row-reverse correctly mirrors the main axis.">
 ```
 
+### 2.4 Timeouts
+Execution of tests is subject to a global timeout (default 10s). Long-running tests may opt into a longer timeout (60s) by providing a `<meta>` element:
+```html
+<meta name="timeout" content="long">
+```
+
 ---
 
 ## 3. General Principles
@@ -109,6 +115,17 @@ Tests **must not** depend on external network resources. Use local support files
 
 ### 3.5 Be Self-Describing
 It should be obvious to a human reviewer whether the test passed or failed.
+
+### 3.6 Avoid Timers (DO NOT use `setTimeout`)
+The use of timers in tests is discouraged and `setTimeout` is strictly prohibited. This is due to an observed source of instability on test running in CI.
+*   **Do** prefer event-driven approaches: wait for an event (e.g., `load`, `DOMContentLoaded`, or custom events) to indicate readiness.
+*   **Do** use two `requestAnimationFrame` calls to ensure rendering steps have completed.
+*   **Do NOT** use standard `setTimeout` functions. If a timeout is strictly necessary (e.g., testing that an event is *not* fired), use harness-specific functions (like `step_timeout` for `testharness.js`) and consider documenting the reason.
+
+### 3.7 Test Independence and Cleanup
+Tests must be independent and not interfere with each other.
+*   **Do** clean up any state that will persist beyond the test itself (e.g., global variables, appended DOM elements) once the test has a result.
+*   For `testharness.js` tests, register cleanup callbacks using the `add_cleanup()` method to ensure state is reset when the test finishes.
 
 ---
 


### PR DESCRIPTION
This PR updates the WPT-Gen style guides with critical instructions on avoiding timers and properly managing state, improving test reliability in CI environments.

### Changes Included:
* **Crashtests**: Added strong warnings against `setTimeout`, instructions for event-driven approaches, and documentation on `<meta name="timeout" content="long">`.
* **JavaScript/HTML Tests**: Added rules for `promise_test` and `async_test` execution, detailed state cleanup with Promises, `AbortSignal` support, and `fetch_json`. Included documentation on testing across globals and manual harness configuration.
* **Reftests**: Explicitly prohibited `setTimeout` and detailed event-driven waiting logic (e.g., using `requestAnimationFrame`).
* **WPT General Guidelines**: Added global timeout instructions and rules around test independence and state cleanup.
