### PR TITLE
Fix: Ensure trailing newline in all generated test files

### DIFF
--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -101,7 +101,7 @@ async def test_run_test_evaluation_correction(
   with patch('wptgen.phases.evaluation.Path.read_text', return_value=style_guide_content):
     await run_test_evaluation(context, mock_config, mock_llm, mock_ui, jinja_env, generated_tests)
 
-  assert test_path.read_text() == 'corrected content'
+  assert test_path.read_text() == 'corrected content\n'
   mock_ui.report_evaluation_result.assert_any_call(test_path.name, success=True, updated=True)
 
 
@@ -168,7 +168,7 @@ async def test_run_test_evaluation_with_markdown(
   with patch('wptgen.phases.evaluation.Path.read_text', return_value=style_guide_content):
     await run_test_evaluation(context, mock_config, mock_llm, mock_ui, jinja_env, generated_tests)
 
-  assert test_path.read_text() == 'corrected markdown content'
+  assert test_path.read_text() == 'corrected markdown content\n'
   mock_ui.report_evaluation_result.assert_any_call(test_path.name, success=True, updated=True)
 
 
@@ -230,7 +230,7 @@ corrected ref content
 
   assert '<link rel="match" href="test-ref.html">' in test_path.read_text()
   assert 'corrected test content' in test_path.read_text()
-  assert ref_path.read_text() == 'corrected ref content'
+  assert ref_path.read_text() == 'corrected ref content\n'
   mock_ui.report_evaluation_result.assert_any_call('test.html', success=True, updated=True)
   mock_ui.report_evaluation_result.assert_any_call('test-ref.html', success=True, updated=True)
 
@@ -347,7 +347,7 @@ new ref content
   assert not test_path.exists()
 
   assert new_ref_path.exists()
-  assert new_ref_path.read_text() == 'new ref content'
+  assert new_ref_path.read_text() == 'new ref content\n'
   assert not ref_path.exists()
 
   mock_ui.report_evaluation_result.assert_any_call(

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -337,7 +337,7 @@ async def test_run_test_execution_correction_loop_and_diff(
       mock_generate_safe.assert_called_once()
 
       # Assert the file was updated
-      assert test_path.read_text(encoding='utf-8') == 'new code'
+      assert test_path.read_text(encoding='utf-8') == 'new code\n'
 
       # Assert ui.print_diff was called
       mock_ui.print_diff.assert_called_once_with('old code\n', 'new code', 'test_fail.html')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -434,3 +434,14 @@ def test_fix_reftest_link_prepend() -> None:
   content = '<div>No head or html tags here</div>'
   result = fix_reftest_link(content, 'ref.html')
   assert result == '<link rel="match" href="ref.html">\n<div>No head or html tags here</div>'
+
+
+def test_ensure_trailing_newline() -> None:
+  from wptgen.utils import ensure_trailing_newline
+
+  assert ensure_trailing_newline('') == '\n'
+  assert ensure_trailing_newline('test') == 'test\n'
+  assert ensure_trailing_newline('test\n') == 'test\n'
+  assert ensure_trailing_newline('test\r\n') == 'test\n'
+  assert ensure_trailing_newline('test\n\n\n') == 'test\n'
+  assert ensure_trailing_newline('test \n') == 'test \n'

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -25,6 +25,7 @@ from wptgen.phases.utils import generate_safe
 from wptgen.ui import UIProvider
 from wptgen.utils import (
   MARKDOWN_CODE_BLOCK_RE,
+  ensure_trailing_newline,
   extract_xml_tag,
   fix_reftest_link,
   parse_multi_file_response,
@@ -198,7 +199,7 @@ async def _evaluate_and_update(
         p_old, old_content = test_path_item
         if p_test_new != p_old:
           p_old.unlink(missing_ok=True)
-        p_test_new.write_text(c_test_new, encoding='utf-8')
+        p_test_new.write_text(ensure_trailing_newline(c_test_new), encoding='utf-8')
         ui.report_evaluation_result(p_test_new.name, success=True, updated=True)
         ui.print_diff(old_content, c_test_new, p_test_new.name)
 
@@ -206,7 +207,7 @@ async def _evaluate_and_update(
         p_old, old_content = ref_path_item
         if p_ref_new != p_old:
           p_old.unlink(missing_ok=True)
-        p_ref_new.write_text(c_ref_new, encoding='utf-8')
+        p_ref_new.write_text(ensure_trailing_newline(c_ref_new), encoding='utf-8')
         ui.report_evaluation_result(p_ref_new.name, success=True, updated=True)
         ui.print_diff(old_content, c_ref_new, p_ref_new.name)
     else:
@@ -214,7 +215,7 @@ async def _evaluate_and_update(
       if len(files) == 1:
         path, old_content = files[0]
         clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', clean_response).strip()
-        path.write_text(clean_content, encoding='utf-8')
+        path.write_text(ensure_trailing_newline(clean_content), encoding='utf-8')
         ui.report_evaluation_result(path.name, success=True, updated=True)
         ui.print_diff(old_content, clean_content, path.name)
       else:

--- a/wptgen/phases/execution.py
+++ b/wptgen/phases/execution.py
@@ -25,7 +25,7 @@ from wptgen.llm import LLMClient
 from wptgen.models import WorkflowContext
 from wptgen.phases.utils import generate_safe
 from wptgen.ui import UIProvider
-from wptgen.utils import MARKDOWN_CODE_BLOCK_RE, parse_multi_file_response
+from wptgen.utils import MARKDOWN_CODE_BLOCK_RE, ensure_trailing_newline, parse_multi_file_response
 
 
 def _match_test_id_to_path(test_id: str, valid_rel_paths: list[str]) -> str | None:
@@ -199,7 +199,7 @@ async def _correct_test(
       final_content = MARKDOWN_CODE_BLOCK_RE.sub('', corrected_content).strip()
 
     if final_content:
-      full_path.write_text(final_content, encoding='utf-8')
+      full_path.write_text(ensure_trailing_newline(final_content), encoding='utf-8')
       ui.success(f'Updated {matched_path}')
       ui.print_diff(test_source_code, final_content, matched_path)
 

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -24,6 +24,7 @@ from wptgen.phases.utils import confirm_prompts, generate_safe
 from wptgen.ui import UIProvider
 from wptgen.utils import (
   MARKDOWN_CODE_BLOCK_RE,
+  ensure_trailing_newline,
   extract_xml_tag,
   fix_reftest_link,
   get_next_available_root,
@@ -230,14 +231,14 @@ async def _generate_and_save(
         clean_content = fix_reftest_link(clean_content, filenames[1])
 
       output_path = output_dir / fname
-      output_path.write_text(clean_content, encoding='utf-8')
+      output_path.write_text(ensure_trailing_newline(clean_content), encoding='utf-8')
       ui.report_test_generated(root_name, success=True, path=output_path)
       results.append((output_path, clean_content, suggestion_xml))
   else:
     # Single file fallback - if the LLM failed to use partitioning tags, default to .html
     clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', content).strip()
     output_path = output_dir / f'{root_name}.html'
-    output_path.write_text(clean_content, encoding='utf-8')
+    output_path.write_text(ensure_trailing_newline(clean_content), encoding='utf-8')
     ui.report_test_generated(root_name, success=True, path=output_path, fallback=True)
     results.append((output_path, clean_content, suggestion_xml))
 

--- a/wptgen/utils.py
+++ b/wptgen/utils.py
@@ -36,6 +36,13 @@ MAX_DELAY = 60.0
 MAX_RETRIES = 5
 
 
+def ensure_trailing_newline(content: str) -> str:
+  """Ensures the string ends with exactly one newline character."""
+  if not content:
+    return '\n'
+  return content.rstrip('\r\n') + '\n'
+
+
 def extract_xml_tag(text: str, tag: str) -> str | None:
   """Extracts the content of an XML-like tag from a string."""
   match = re.search(f'<{tag}>(.*?)</{tag}>', text, re.DOTALL)


### PR DESCRIPTION
Resolves #193

## Background & Motivation
Generated Web Platform Tests (WPT) might not end with a blank new line when they are saved by the various agentic phases (Generation, Evaluation, Execution). It is a standard best practice and often a linting/formatting requirement to end source files with a single trailing newline.

## Changes Made
- Created the `ensure_trailing_newline` utility function in `wptgen/utils.py`.
- Integrated this utility in `wptgen/phases/generation.py`, `wptgen/phases/evaluation.py`, and `wptgen/phases/execution.py` to sanitize written content before calling `.write_text()`.
- Added a specific test for the utility and updated existing test assertions to expect a trailing newline, validating the new behavior across all phases.
