### PR TITLE
fix: proactively remove trailing whitespace from generated tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -445,3 +445,14 @@ def test_ensure_trailing_newline() -> None:
   assert ensure_trailing_newline('test\r\n') == 'test\n'
   assert ensure_trailing_newline('test\n\n\n') == 'test\n'
   assert ensure_trailing_newline('test \n') == 'test \n'
+
+
+def test_strip_trailing_whitespace() -> None:
+  from wptgen.utils import strip_trailing_whitespace
+
+  assert strip_trailing_whitespace('') == ''
+  assert strip_trailing_whitespace('test  ') == 'test'
+  assert strip_trailing_whitespace('test \nline 2 \t') == 'test\nline 2'
+  assert strip_trailing_whitespace('  test') == '  test'
+  assert strip_trailing_whitespace('line1  \nline2') == 'line1\nline2'
+  assert strip_trailing_whitespace('line1 \r\nline2 \r\n') == 'line1\r\nline2\r\n'

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -29,6 +29,7 @@ from wptgen.utils import (
   extract_xml_tag,
   fix_reftest_link,
   parse_multi_file_response,
+  strip_trailing_whitespace,
 )
 
 
@@ -199,7 +200,9 @@ async def _evaluate_and_update(
         p_old, old_content = test_path_item
         if p_test_new != p_old:
           p_old.unlink(missing_ok=True)
-        p_test_new.write_text(ensure_trailing_newline(c_test_new), encoding='utf-8')
+        p_test_new.write_text(
+          ensure_trailing_newline(strip_trailing_whitespace(c_test_new)), encoding='utf-8'
+        )
         ui.report_evaluation_result(p_test_new.name, success=True, updated=True)
         ui.print_diff(old_content, c_test_new, p_test_new.name)
 
@@ -207,7 +210,9 @@ async def _evaluate_and_update(
         p_old, old_content = ref_path_item
         if p_ref_new != p_old:
           p_old.unlink(missing_ok=True)
-        p_ref_new.write_text(ensure_trailing_newline(c_ref_new), encoding='utf-8')
+        p_ref_new.write_text(
+          ensure_trailing_newline(strip_trailing_whitespace(c_ref_new)), encoding='utf-8'
+        )
         ui.report_evaluation_result(p_ref_new.name, success=True, updated=True)
         ui.print_diff(old_content, c_ref_new, p_ref_new.name)
     else:
@@ -215,7 +220,9 @@ async def _evaluate_and_update(
       if len(files) == 1:
         path, old_content = files[0]
         clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', clean_response).strip()
-        path.write_text(ensure_trailing_newline(clean_content), encoding='utf-8')
+        path.write_text(
+          ensure_trailing_newline(strip_trailing_whitespace(clean_content)), encoding='utf-8'
+        )
         ui.report_evaluation_result(path.name, success=True, updated=True)
         ui.print_diff(old_content, clean_content, path.name)
       else:

--- a/wptgen/phases/execution.py
+++ b/wptgen/phases/execution.py
@@ -25,7 +25,12 @@ from wptgen.llm import LLMClient
 from wptgen.models import WorkflowContext
 from wptgen.phases.utils import generate_safe
 from wptgen.ui import UIProvider
-from wptgen.utils import MARKDOWN_CODE_BLOCK_RE, ensure_trailing_newline, parse_multi_file_response
+from wptgen.utils import (
+  MARKDOWN_CODE_BLOCK_RE,
+  ensure_trailing_newline,
+  parse_multi_file_response,
+  strip_trailing_whitespace,
+)
 
 
 def _match_test_id_to_path(test_id: str, valid_rel_paths: list[str]) -> str | None:
@@ -199,7 +204,9 @@ async def _correct_test(
       final_content = MARKDOWN_CODE_BLOCK_RE.sub('', corrected_content).strip()
 
     if final_content:
-      full_path.write_text(ensure_trailing_newline(final_content), encoding='utf-8')
+      full_path.write_text(
+        ensure_trailing_newline(strip_trailing_whitespace(final_content)), encoding='utf-8'
+      )
       ui.success(f'Updated {matched_path}')
       ui.print_diff(test_source_code, final_content, matched_path)
 

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -30,6 +30,7 @@ from wptgen.utils import (
   get_next_available_root,
   parse_multi_file_response,
   parse_suggestions,
+  strip_trailing_whitespace,
 )
 
 
@@ -231,14 +232,18 @@ async def _generate_and_save(
         clean_content = fix_reftest_link(clean_content, filenames[1])
 
       output_path = output_dir / fname
-      output_path.write_text(ensure_trailing_newline(clean_content), encoding='utf-8')
+      output_path.write_text(
+        ensure_trailing_newline(strip_trailing_whitespace(clean_content)), encoding='utf-8'
+      )
       ui.report_test_generated(root_name, success=True, path=output_path)
       results.append((output_path, clean_content, suggestion_xml))
   else:
     # Single file fallback - if the LLM failed to use partitioning tags, default to .html
     clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', content).strip()
     output_path = output_dir / f'{root_name}.html'
-    output_path.write_text(ensure_trailing_newline(clean_content), encoding='utf-8')
+    output_path.write_text(
+      ensure_trailing_newline(strip_trailing_whitespace(clean_content)), encoding='utf-8'
+    )
     ui.report_test_generated(root_name, success=True, path=output_path, fallback=True)
     results.append((output_path, clean_content, suggestion_xml))
 

--- a/wptgen/utils.py
+++ b/wptgen/utils.py
@@ -43,6 +43,13 @@ def ensure_trailing_newline(content: str) -> str:
   return content.rstrip('\r\n') + '\n'
 
 
+def strip_trailing_whitespace(content: str) -> str:
+  """Removes trailing whitespace from every line in a string."""
+  if not content:
+    return content
+  return re.sub(r'[ \t]+(\r?)$', r'\1', content, flags=re.MULTILINE)
+
+
 def extract_xml_tag(text: str, tag: str) -> str | None:
   """Extracts the content of an XML-like tag from a string."""
   match = re.search(f'<{tag}>(.*?)</{tag}>', text, re.DOTALL)


### PR DESCRIPTION
## Background
Generated WPT test files sometimes contain trailing whitespace on individual lines, which causes linting failures when upstreaming to the Web Platform Tests repository.

## Proposed Changes
- Added a \`strip_trailing_whitespace\` utility function in \`wptgen/utils.py\`.
- Applied this new utility to all \`write_text\` sites in the Generation, Evaluation, and Execution phases to ensure the formatting is proactively applied.
- Added a new unit test in \`test_utils.py\` to verify the whitespace stripping logic across various inputs, explicitly preserving \`\n\` and \`\r\n\` line endings.

Resolves #202
