### PR TITLE
feat: integrate ./wpt lint into evaluation phase

### DIFF
--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -33,6 +33,27 @@ from wptgen.utils import (
 )
 
 
+async def _run_wpt_lint(paths: list[Path], wpt_dir: Path) -> str | None:
+  """Runs ./wpt lint on the given paths and returns the error output if any."""
+  try:
+    # Use paths relative to wpt_dir for cleaner output
+    rel_paths = [str(p.relative_to(wpt_dir)) for p in paths]
+    process = await asyncio.create_subprocess_exec(
+      './wpt',
+      'lint',
+      *rel_paths,
+      cwd=wpt_dir,
+      stdout=asyncio.subprocess.PIPE,
+      stderr=asyncio.subprocess.STDOUT,
+    )
+    stdout, _ = await process.communicate()
+    if process.returncode != 0:
+      return stdout.decode('utf-8').strip()
+    return None
+  except Exception as e:
+    return f'Failed to run ./wpt lint: {e}'
+
+
 async def run_test_evaluation(
   context: WorkflowContext,
   config: Config,
@@ -73,11 +94,16 @@ async def run_test_evaluation(
     guide_filename = STYLE_GUIDE_MAP.get(test_type_enum, 'javascript_html_style_guide.md')
     test_type_guide = (resources_path / guide_filename).read_text(encoding='utf-8')
 
+    # Run linting for the grouped test paths
+    group_paths = [p for p, _ in group]
+    lint_errors = await _run_wpt_lint(group_paths, Path(config.wpt_path))
+
     # Render the system instruction with both general and type-specific rules
     system_instruction = system_template.render(
       wpt_style_guide=wpt_style_guide,
       test_type=test_type_enum.value,
       test_type_guide=test_type_guide,
+      has_lint_errors=bool(lint_errors),
     )
 
     # Format the code content, using multi-file partitioning for Reftests ONLY
@@ -106,6 +132,7 @@ async def run_test_evaluation(
     prompt = evaluation_template.render(
       test_suggestion_xml=suggestion_xml,
       generated_code_content=generated_code_content.strip(),
+      lint_errors=lint_errors,
     )
     tasks.append(
       _evaluate_and_update(group, prompt, llm, ui, config, system_instruction, test_type_enum)

--- a/wptgen/templates/evaluation.jinja
+++ b/wptgen/templates/evaluation.jinja
@@ -7,3 +7,9 @@ Review the following generated WPT code against its source blueprint.
 <generated_code>
 {{generated_code_content}}
 </generated_code>
+{% if lint_errors %}
+<lint_errors>
+The following errors were reported by `./wpt lint`:
+{{lint_errors}}
+</lint_errors>
+{% endif %}

--- a/wptgen/templates/evaluation_system.jinja
+++ b/wptgen/templates/evaluation_system.jinja
@@ -39,6 +39,10 @@ You must evaluate the provided `<generated_code>` against the WPT Style Guide ab
 2. WPT Standards Compliance:
   * Does it properly follow the principles laid out in the WPT GENERAL STYLE GUIDE?
   * Does it properly follow the principles laid out in the {{ test_type }} STYLE_GUIDE & RULES?
+{% if has_lint_errors -%}
+3. Lint Errors:
+  * You MUST fix all errors reported in `<lint_errors>`. These are critical failures that must be resolved.
+{% endif -%}
 
 # OUTPUT PROTOCOL
 You are a machine in an automated pipeline. You have two possible outputs:


### PR DESCRIPTION
Resolves #203

## Background
Integrating `./wpt lint` into the evaluation step to identify and auto-fix simple styling and standards issues directly within the LLM pipeline.

## Proposed Changes
- Execute `./wpt lint` on generated test files during the evaluation phase.
- Update `wptgen/templates/evaluation.jinja` to include linting logs only when errors are present.
- Update `wptgen/templates/evaluation_system.jinja` with specific instructions for the LLM to auto-fix reported errors.

All local changes have been verified and tested using `make presubmit`.
