### PR TITLE
fix: correct overall status calculation in coverage audit

### DIFF
--- a/tests/test_coverage_audit.py
+++ b/tests/test_coverage_audit.py
@@ -65,3 +65,29 @@ async def test_run_coverage_audit_token_limit_exceeded(
 
   assert result is None
   mock_ui.error.assert_called_once_with('This test suite to too large to audit.')
+
+
+def test_combine_audit_responses_all_satisfied() -> None:
+  from wptgen.phases.coverage_audit import combine_audit_responses
+
+  responses = [
+    '<status>SATISFIED</status>\n<audit_worksheet>W1</audit_worksheet>',
+    '<status>SATISFIED</status>\n<audit_worksheet>W2</audit_worksheet>',
+  ]
+  result = combine_audit_responses(responses)
+  assert '<status>SATISFIED</status>' in result
+  assert '<audit_worksheet>\nW1\nW2\n</audit_worksheet>' in result
+  assert 'test_suggestions' not in result
+
+
+def test_combine_audit_responses_with_suggestions() -> None:
+  from wptgen.phases.coverage_audit import combine_audit_responses
+
+  responses = [
+    '<status>SATISFIED</status>\n<audit_worksheet>W1</audit_worksheet>',
+    '<audit_worksheet>W2</audit_worksheet>\n<test_suggestions>\n<test_suggestion>T1</test_suggestion>\n</test_suggestions>',
+  ]
+  result = combine_audit_responses(responses)
+  assert '<status>TESTS_NEEDED</status>' in result
+  assert '<audit_worksheet>\nW1\nW2\n</audit_worksheet>' in result
+  assert '<test_suggestions>\n<test_suggestion>T1</test_suggestion>\n</test_suggestions>' in result

--- a/wptgen/phases/coverage_audit.py
+++ b/wptgen/phases/coverage_audit.py
@@ -55,15 +55,10 @@ def partition_requirements_xml(xml_string: str, max_threshold: int = 40) -> list
 
 
 def combine_audit_responses(responses: list[str]) -> str:
-  overall_status = 'SATISFIED'
   combined_worksheets = []
   combined_suggestions = []
 
   for resp in responses:
-    status = extract_xml_tag(resp, 'status')
-    if status == 'TESTS_NEEDED':
-      overall_status = 'TESTS_NEEDED'
-
     worksheet = extract_xml_tag(resp, 'audit_worksheet')
     if worksheet:
       combined_worksheets.append(worksheet.strip())
@@ -71,12 +66,16 @@ def combine_audit_responses(responses: list[str]) -> str:
     suggestions = parse_suggestions(resp)
     combined_suggestions.extend(suggestions)
 
+  overall_status = 'TESTS_NEEDED' if combined_suggestions else 'SATISFIED'
+
   final_response = f'<status>{overall_status}</status>\n'
   final_response += (
     '<audit_worksheet>\n' + '\n'.join(combined_worksheets) + '\n</audit_worksheet>\n'
   )
   if combined_suggestions:
-    final_response += '\n'.join(combined_suggestions)
+    final_response += (
+      '<test_suggestions>\n' + '\n'.join(combined_suggestions) + '\n</test_suggestions>\n'
+    )
 
   return final_response
 


### PR DESCRIPTION
## Description
This PR fixes a bug in the coverage audit phase where the `overall_status` was incorrectly hardcoded to `SATISFIED`. When processing a large specification, the requirements are partitioned into multiple LLM requests. If the audit phase produced test suggestions across these partitions, the generation phase would ignore them because the combined response still reported a `SATISFIED` status.

## Changes
- Dynamically determine `overall_status` in `combine_audit_responses`: if any `<test_suggestion>` blocks are found, set the status to `TESTS_NEEDED`, otherwise `SATISFIED`.
- Wrap combined test suggestions in a `<test_suggestions>` block to ensure well-formed XML is passed to the next phase.
- Add comprehensive unit tests in `tests/test_coverage_audit.py` to cover `combine_audit_responses`.
