### PR TITLE
Style evaluation phase linting output

### DIFF
--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -95,15 +95,15 @@ async def run_test_evaluation(
     test_type_guide = (resources_path / guide_filename).read_text(encoding='utf-8')
 
     # Run linting for the grouped test paths
+    ui.print('Running `./wpt lint` on generated tests.')
     lint_errors_dict = {}
     for p, _ in group:
-      ui.print(f'Running `./wpt lint` on {p.name}...')
       errs = await _run_wpt_lint(p, Path(config.wpt_path))
       if errs:
-        ui.print(f'Lint errors found for {p.name}:\n{errs}')
+        ui.print(f'[yellow]Lint errors found for {p.name}:[/yellow]\n{errs}')
         lint_errors_dict[p] = errs
       else:
-        ui.print(f'No lint errors found for {p.name}.')
+        ui.print(f'[green]No lint errors found for {p.name}![/green]')
 
     # Format the code content, using multi-file partitioning for Reftests ONLY
     if test_type_enum == TestType.REFTEST and len(group) > 1:


### PR DESCRIPTION
### Background
The UI output during the evaluation phase for linting was verbose and unstyled, making it harder to read the results quickly.

### Changes
*   Consolidated the "running" message to a single generic output: `Running ./wpt lint on generated tests.`
*   Stylized the success message to be green and include an exclamation point.
*   Stylized the lint error message to use yellow (a gentle warning color) for the file name header.

### Testing
All local checks (`make check`) are passing.