### PR TITLE
fix: dynamically reference requirement categories and fix evaluation lint message

### DIFF
--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -81,6 +81,7 @@ async def run_test_evaluation(
   system_template = jinja_env.get_template('evaluation_system.jinja')
 
   tasks = []
+  ui.print('Running `./wpt lint` on generated tests.')
   for suggestion_xml, group in grouped_tests.items():
     # Extract and normalize test type
     raw_test_type = extract_xml_tag(suggestion_xml, 'test_type') or 'JavaScript Test'
@@ -95,7 +96,6 @@ async def run_test_evaluation(
     test_type_guide = (resources_path / guide_filename).read_text(encoding='utf-8')
 
     # Run linting for the grouped test paths
-    ui.print('Running `./wpt lint` on generated tests.')
     lint_errors_dict = {}
     for p, _ in group:
       errs = await _run_wpt_lint(p, Path(config.wpt_path))

--- a/wptgen/templates/coverage_audit_system.jinja
+++ b/wptgen/templates/coverage_audit_system.jinja
@@ -18,7 +18,8 @@ You must process the inputs and output your response in TWO distinct XML blocks.
 ## BLOCK 1: <audit_worksheet>
 You must perform your mapping here.
 1. Read every requirement provided in the `<requirements_list>`.
-2. For each requirement, scan the `<test_suite>`.
+2. Group your output by the exact `<category>` variations present in the `<requirements_list>`.
+3. For each requirement, scan the `<test_suite>`.
    - **Check for Receipts:** Pay special attention to HTML/JS comments in the test files that explicitly quote spec requirements. If a test comments that it covers a requirement, trust it.
    - If covered, cite the specific test file and mark it `[COVERED]`.
    - If missing, mark it `[UNCOVERED]`.
@@ -40,11 +41,11 @@ If there are `[UNCOVERED]` requirements, you MUST generate exactly one `<test_su
 Your entire response must follow this exact structure, with no text outside the tags. Do not wrap your response in markdown blocks:
 
 <audit_worksheet>
-[Existence]
+[Category 1 Name Derived from <requirements_list>]
 R1: [Requirement Text] -> [COVERED by filename.html]
 R2: [Requirement Text] -> [UNCOVERED]
 
-[Common Use Cases]
+[Category 2 Name Derived from <requirements_list>]
 R3: [Requirement Text] -> [COVERED by filename.html]
 </audit_worksheet>
 


### PR DESCRIPTION
## Background
- The coverage audit system template (`coverage_audit_system.jinja`) previously used hardcoded category examples ("Existence" and "Common Use Cases") in the `<audit_worksheet>` output example. This could cause the LLM to get confused when the input `<requirements_list>` contained different `<category>` headers.
- The evaluation phase (`evaluation.py`) printed the "Running `./wpt lint` on generated tests." message repeatedly for each test group, resulting in overly verbose console output.

## Changes
- Updated the `BLOCK 1` instructions in `coverage_audit_system.jinja` to explicitly direct the LLM to group its output by the exact `<category>` variations present in the `<requirements_list>`.
- Replaced the hardcoded categories in the `# STRICT OUTPUT FORMAT` section with dynamic placeholders (e.g., `[Category 1 Name Derived from <requirements_list>]`).
- Moved the `ui.print('Running `./wpt lint` on generated tests.')` statement outside the `grouped_tests` loop in `evaluation.py` so it only prints once per evaluation phase.