### PR TITLE
fix: Variable test execution timeout in wpt-gen generate workflow

### DIFF
--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -62,7 +62,6 @@ def mock_config(tmp_path: Path) -> Config:
     output_dir=str(tmp_path / 'output'),
     wpt_browser='chrome',
     wpt_channel='canary',
-    execution_timeout=300,
   )
 
 
@@ -196,26 +195,18 @@ async def test_run_test_execution_timeout(
 
   context = WorkflowContext(feature_id='feat')
 
-  mock_config.execution_timeout = 0.01
-
   mock_process = AsyncMock()
   mock_process.kill = MagicMock()
-
-  async def slow_communicate() -> tuple[bytes, bytes]:
-    await asyncio.sleep(1)
-    return b'stdout', b'stderr'
-
-  mock_process.communicate = slow_communicate
+  mock_process.communicate = AsyncMock()
 
   with patch('asyncio.create_subprocess_exec', return_value=mock_process):
-    await run_test_execution(
-      context, mock_config, mock_llm, mock_ui, mock_jinja_env, generated_tests
-    )
+    with patch('asyncio.wait_for', side_effect=asyncio.TimeoutError):
+      await run_test_execution(
+        context, mock_config, mock_llm, mock_ui, mock_jinja_env, generated_tests
+      )
 
-    mock_process.kill.assert_called_once()
-    mock_ui.error.assert_called_with(
-      f'Test execution timed out after {mock_config.execution_timeout}s.'
-    )
+      mock_process.kill.assert_called_once()
+      mock_ui.error.assert_called_with('Test execution timed out after 30s.')
 
 
 @pytest.mark.asyncio
@@ -415,7 +406,7 @@ async def test_execute_wpt_run_success(
   mock_process.returncode = 0
   with patch('asyncio.create_subprocess_exec', return_value=mock_process) as mock_exec:
     returncode, output = await _execute_wpt_run(
-      wpt_executable, wpt_root, ['test1.html'], '/tmp/log.json', mock_config, mock_ui
+      wpt_executable, wpt_root, ['test1.html'], '/tmp/log.json', mock_config, mock_ui, 30
     )
     mock_exec.assert_called_once()
     assert returncode == 0
@@ -429,17 +420,17 @@ async def test_execute_wpt_run_timeout(
   wpt_root = tmp_path / 'wpt'
   wpt_root.mkdir()
   wpt_executable = wpt_root / 'wpt'
-  mock_config.execution_timeout = 0.01
+
   mock_process = AsyncMock()
   mock_process.kill = MagicMock()
 
   async def slow_communicate() -> tuple[bytes, bytes]:
-    await asyncio.sleep(1)
+    await asyncio.sleep(0.02)
     return b'', b''
 
   mock_process.communicate = slow_communicate
   with patch('asyncio.create_subprocess_exec', return_value=mock_process):
     returncode, output = await _execute_wpt_run(
-      wpt_executable, wpt_root, ['test1.html'], '/tmp/log.json', mock_config, mock_ui
+      wpt_executable, wpt_root, ['test1.html'], '/tmp/log.json', mock_config, mock_ui, 0.01
     )
     assert returncode == -1

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -77,7 +77,6 @@ class Config:
   max_correction_retries: int = 2
   wpt_browser: str = 'chrome'
   wpt_channel: str = 'canary'
-  execution_timeout: int | float = 90  # Default 1.5 minutes
   max_parallel_requests: int = 10
   temperature: float | None = None
   loaded_from: str | None = None
@@ -323,7 +322,6 @@ def load_config(
     tentative=tentative,
     wpt_browser=yaml_data.get('wpt_browser', 'chrome'),
     wpt_channel=yaml_data.get('wpt_channel', 'canary'),
-    execution_timeout=yaml_data.get('execution_timeout', 90),
     max_parallel_requests=max_parallel_requests,
     temperature=temperature_override
     if temperature_override is not None

--- a/wptgen/phases/execution.py
+++ b/wptgen/phases/execution.py
@@ -78,6 +78,7 @@ async def _execute_wpt_run(
   log_path: str,
   config: Config,
   ui: UIProvider,
+  execution_timeout: int | float,
 ) -> tuple[int, str]:
   """Executes the `wpt run` subprocess and captures output."""
   cmd = [
@@ -95,11 +96,11 @@ async def _execute_wpt_run(
   )
 
   try:
-    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=config.execution_timeout)
+    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=execution_timeout)
   except asyncio.TimeoutError:
     process.kill()
     await process.wait()
-    ui.error(f'Test execution timed out after {config.execution_timeout}s.')
+    ui.error(f'Test execution timed out after {execution_timeout}s.')
     return -1, ''
 
   output = ''
@@ -302,16 +303,18 @@ async def run_test_execution(
         f'\n[bold yellow]Automatic Test Correction (Attempt {retry}/{max_retries})[/bold yellow]'
       )
 
+    execution_timeout = min(30 * len(valid_rel_paths), 900)
+
     ui.print(
       f'Running [cyan]{len(valid_rel_paths)}[/cyan] tests with {config.wpt_browser} {config.wpt_channel} '
-      f'(timeout: {config.execution_timeout}s)...'
+      f'(timeout: {execution_timeout}s)...'
     )
 
     with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
       log_path = f.name
 
     returncode, output = await _execute_wpt_run(
-      wpt_executable, wpt_root, valid_rel_paths, log_path, config, ui
+      wpt_executable, wpt_root, valid_rel_paths, log_path, config, ui, execution_timeout
     )
 
     if returncode == -1 and not output:


### PR DESCRIPTION
## Description
This PR resolves the issue of having a flat 90-second timeout during the `wpt-gen generate` workflow's execution phase, which caused false failures for large batches of tests.

## Proposed Changes
- The execution timeout is now dynamically calculated based on the number of tests: `30 seconds * number of tests`.
- The calculated timeout has a maximum upper bound of 15 minutes (900 seconds) to ensure the process does not hang indefinitely.
- The old `execution_timeout` config parameter has been entirely removed to prevent conflicts.
- Unit tests have been updated and refactored using `asyncio.wait_for` to verify the dynamic timeout calculation.

Resolves #212
