### PR TITLE
chore: Bump project version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wpt-gen"
-version = "0.1.0"
+version = "0.2.0"
 description = "A CLI Tool for AI-Powered Web Platform Test Generation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/wptgen/__init__.py
+++ b/wptgen/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'


### PR DESCRIPTION
### Description
This pull request bumps the WPT-Gen project version number from `0.1.0` to `0.2.0`. 

### Changes Made
- Updated `version = "0.2.0"` in `pyproject.toml`
- Updated `__version__ = '0.2.0'` in `wptgen/__init__.py`