### PR TITLE
Fix #220: Programmatically Ensure testharness.js Imports in Generated HTML Non-Reftests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -456,3 +456,63 @@ def test_strip_trailing_whitespace() -> None:
   assert strip_trailing_whitespace('  test') == '  test'
   assert strip_trailing_whitespace('line1  \nline2') == 'line1\nline2'
   assert strip_trailing_whitespace('line1 \r\nline2 \r\n') == 'line1\r\nline2\r\n'
+
+
+def test_ensure_testharness_imports_already_present() -> None:
+  from wptgen.utils import ensure_testharness_imports
+
+  content = """<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body></body>
+</html>"""
+  assert ensure_testharness_imports(content) == content
+
+
+def test_ensure_testharness_imports_missing_both_with_head() -> None:
+  from wptgen.utils import ensure_testharness_imports
+
+  content = """<!DOCTYPE html>
+<html>
+<head>
+<title>Test</title>
+</head>
+<body></body>
+</html>"""
+  result = ensure_testharness_imports(content)
+  assert '<script src="/resources/testharness.js"></script>' in result
+  assert '<script src="/resources/testharnessreport.js"></script>' in result
+  assert '<head>\n<script' in result
+
+
+def test_ensure_testharness_imports_missing_both_with_html_no_head() -> None:
+  from wptgen.utils import ensure_testharness_imports
+
+  content = '<html><body></body></html>'
+  result = ensure_testharness_imports(content)
+  assert '<html>\n<head>\n<script src="/resources/testharness.js"></script>' in result
+  assert '</head>\n<body>' in result
+
+
+def test_ensure_testharness_imports_missing_both_no_html() -> None:
+  from wptgen.utils import ensure_testharness_imports
+
+  content = '<body>Just body</body>'
+  result = ensure_testharness_imports(content)
+  assert result.startswith(
+    '<script src="/resources/testharness.js"></script>\n<script src="/resources/testharnessreport.js"></script>\n<body>'
+  )
+
+
+def test_ensure_testharness_imports_partial() -> None:
+  from wptgen.utils import ensure_testharness_imports
+
+  content = """<head>
+<script src="/resources/testharness.js"></script>
+</head>"""
+  result = ensure_testharness_imports(content)
+  assert result.count('/resources/testharness.js') == 1
+  assert result.count('/resources/testharnessreport.js') == 1

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -24,6 +24,7 @@ from wptgen.phases.utils import confirm_prompts, generate_safe
 from wptgen.ui import UIProvider
 from wptgen.utils import (
   MARKDOWN_CODE_BLOCK_RE,
+  ensure_testharness_imports,
   ensure_trailing_newline,
   extract_xml_tag,
   fix_reftest_link,
@@ -209,10 +210,12 @@ async def _generate_and_save(
 
   # Check if we have multiple files (Reftests)
   multi_files = parse_multi_file_response(content, strip_tentative=not config.tentative)
-  if multi_files:
-    raw_test_type = extract_xml_tag(suggestion_xml, 'test_type') or ''
-    is_reftest = raw_test_type.lower() == 'reftest'
+  raw_test_type = extract_xml_tag(suggestion_xml, 'test_type') or ''
+  test_type_lower = raw_test_type.lower()
+  is_reftest = test_type_lower == 'reftest'
+  is_crashtest = test_type_lower == 'crashtest'
 
+  if multi_files:
     # Pre-calculate filenames to know the reference name
     filenames = []
     for i, (suffix, _) in enumerate(multi_files, 1):
@@ -231,6 +234,9 @@ async def _generate_and_save(
       if i == 0 and is_reftest and len(filenames) >= 2:
         clean_content = fix_reftest_link(clean_content, filenames[1])
 
+      if fname.endswith('.html') and not is_reftest and not is_crashtest:
+        clean_content = ensure_testharness_imports(clean_content)
+
       output_path = output_dir / fname
       output_path.write_text(
         ensure_trailing_newline(strip_trailing_whitespace(clean_content)), encoding='utf-8'
@@ -240,6 +246,10 @@ async def _generate_and_save(
   else:
     # Single file fallback - if the LLM failed to use partitioning tags, default to .html
     clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', content).strip()
+
+    if not is_reftest and not is_crashtest:
+      clean_content = ensure_testharness_imports(clean_content)
+
     output_path = output_dir / f'{root_name}.html'
     output_path.write_text(
       ensure_trailing_newline(strip_trailing_whitespace(clean_content)), encoding='utf-8'

--- a/wptgen/utils.py
+++ b/wptgen/utils.py
@@ -256,3 +256,42 @@ def retry(
     return wrapper
 
   return decorator
+
+
+def ensure_testharness_imports(content: str) -> str:
+  """Ensures testharness.js and testharnessreport.js are imported in HTML tests."""
+  th_js = '<script src="/resources/testharness.js"></script>'
+  thr_js = '<script src="/resources/testharnessreport.js"></script>'
+
+  has_th = '/resources/testharness.js' in content
+  has_thr = '/resources/testharnessreport.js' in content
+
+  if has_th and has_thr:
+    return content
+
+  imports_to_add = []
+  if not has_th:
+    imports_to_add.append(th_js)
+  if not has_thr:
+    imports_to_add.append(thr_js)
+
+  import_str = '\n'.join(imports_to_add)
+
+  # Try to inject inside <head>
+  head_match = re.search(r'(<head[^>]*>)', content, re.IGNORECASE)
+  if head_match:
+    return content[: head_match.end()] + '\n' + import_str + '\n' + content[head_match.end() :]
+
+  # Try to inject inside <html>
+  html_match = re.search(r'(<html[^>]*>)', content, re.IGNORECASE)
+  if html_match:
+    return (
+      content[: html_match.end()]
+      + '\n<head>\n'
+      + import_str
+      + '\n</head>\n'
+      + content[html_match.end() :]
+    )
+
+  # Fallback: prepend
+  return import_str + '\n' + content


### PR DESCRIPTION
## Background
Resolves #220. Currently, the test generation pipeline sometimes omits the required `<script src="/resources/testharness.js"></script>` and `<script src="/resources/testharnessreport.js"></script>` imports in generated `.html` files, causing downstream test runner execution failures.

## Proposed Changes
- Added a programmatic post-generation check (`ensure_testharness_imports`) in `wptgen/utils.py` specifically targeting `.html` non-reftests and non-crashtests.
- Scans the generated HTML content for the presence of both the `testharness.js` and `testharnessreport.js` script tags, and safely injects them immediately inside `<head>`, `<html>`, or as a fallback, prepended to the top of the file.
- Properly hooked this step into the `generation` phase's file writing logic.
- Included comprehensive unit tests in `tests/test_utils.py` handling various cases (existing tags, partial tags, missing structures).

## Acceptance Criteria Met
- [x] A validation step is added to check for testharness imports.
- [x] Automatically injects the missing scripts if omitted.
- [x] Correctly skips reftests, crashtests, and JS-only files.
- [x] Added unit tests for programmatic injection.
