### PR TITLE
Fix broken Mermaid diagram in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ flowchart TD
     subgraph Generation[Test Generation & Execution]
         G --> H{{Test Generation}}
         H --> I{{Evaluation}}
-        I --> J[{{Test Execution & Self-Correction}}]
+        I --> J{{Test Execution & Self-Correction}}
     end
 
     classDef llm fill:#4B0082,stroke:#333,stroke-width:2px;


### PR DESCRIPTION
This PR fixes a syntax error in the Mermaid diagram within the "How it Works" section of the `README.md`.

Node `J` was using an invalid bracket combination (`[{{...}}]`), which caused the diagram to fail rendering on GitHub. I've updated it to use the standard hexagon syntax (`{{...}}`), consistent with the other LLM-driven phases in the workflow.

**Changes**:
- Updated `README.md` to fix Mermaid syntax for node `J`.

Resolves #225
