### PR TITLE
Refactor: Combine ensure_trailing_newline and strip_trailing_whitespace helpers

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -436,26 +436,20 @@ def test_fix_reftest_link_prepend() -> None:
   assert result == '<link rel="match" href="ref.html">\n<div>No head or html tags here</div>'
 
 
-def test_ensure_trailing_newline() -> None:
-  from wptgen.utils import ensure_trailing_newline
+def test_clean_file_content() -> None:
+  from wptgen.utils import clean_file_content
 
-  assert ensure_trailing_newline('') == '\n'
-  assert ensure_trailing_newline('test') == 'test\n'
-  assert ensure_trailing_newline('test\n') == 'test\n'
-  assert ensure_trailing_newline('test\r\n') == 'test\n'
-  assert ensure_trailing_newline('test\n\n\n') == 'test\n'
-  assert ensure_trailing_newline('test \n') == 'test \n'
-
-
-def test_strip_trailing_whitespace() -> None:
-  from wptgen.utils import strip_trailing_whitespace
-
-  assert strip_trailing_whitespace('') == ''
-  assert strip_trailing_whitespace('test  ') == 'test'
-  assert strip_trailing_whitespace('test \nline 2 \t') == 'test\nline 2'
-  assert strip_trailing_whitespace('  test') == '  test'
-  assert strip_trailing_whitespace('line1  \nline2') == 'line1\nline2'
-  assert strip_trailing_whitespace('line1 \r\nline2 \r\n') == 'line1\r\nline2\r\n'
+  assert clean_file_content('') == '\n'
+  assert clean_file_content('test') == 'test\n'
+  assert clean_file_content('test\n') == 'test\n'
+  assert clean_file_content('test\r\n') == 'test\n'
+  assert clean_file_content('test\n\n\n') == 'test\n'
+  assert clean_file_content('test \n') == 'test\n'
+  assert clean_file_content('test  ') == 'test\n'
+  assert clean_file_content('test \nline 2 \t') == 'test\nline 2\n'
+  assert clean_file_content('  test') == '  test\n'
+  assert clean_file_content('line1  \nline2') == 'line1\nline2\n'
+  assert clean_file_content('line1 \r\nline2 \r\n') == 'line1\r\nline2\n'
 
 
 def test_ensure_testharness_imports_already_present() -> None:

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -25,11 +25,10 @@ from wptgen.phases.utils import generate_safe
 from wptgen.ui import UIProvider
 from wptgen.utils import (
   MARKDOWN_CODE_BLOCK_RE,
-  ensure_trailing_newline,
+  clean_file_content,
   extract_xml_tag,
   fix_reftest_link,
   parse_multi_file_response,
-  strip_trailing_whitespace,
 )
 
 
@@ -252,9 +251,7 @@ async def _evaluate_and_update(
         p_old, old_content = test_path_item
         if p_test_new != p_old:
           p_old.unlink(missing_ok=True)
-        p_test_new.write_text(
-          ensure_trailing_newline(strip_trailing_whitespace(c_test_new)), encoding='utf-8'
-        )
+        p_test_new.write_text(clean_file_content(c_test_new), encoding='utf-8')
         ui.report_evaluation_result(p_test_new.name, success=True, updated=True)
         ui.print_diff(old_content, c_test_new, p_test_new.name)
 
@@ -262,9 +259,7 @@ async def _evaluate_and_update(
         p_old, old_content = ref_path_item
         if p_ref_new != p_old:
           p_old.unlink(missing_ok=True)
-        p_ref_new.write_text(
-          ensure_trailing_newline(strip_trailing_whitespace(c_ref_new)), encoding='utf-8'
-        )
+        p_ref_new.write_text(clean_file_content(c_ref_new), encoding='utf-8')
         ui.report_evaluation_result(p_ref_new.name, success=True, updated=True)
         ui.print_diff(old_content, c_ref_new, p_ref_new.name)
     else:
@@ -287,9 +282,7 @@ async def _evaluate_and_update(
         else:
           clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', clean_response).strip()
 
-        path.write_text(
-          ensure_trailing_newline(strip_trailing_whitespace(clean_content)), encoding='utf-8'
-        )
+        path.write_text(clean_file_content(clean_content), encoding='utf-8')
         ui.report_evaluation_result(path.name, success=True, updated=True)
         ui.print_diff(old_content, clean_content, path.name)
       else:

--- a/wptgen/phases/execution.py
+++ b/wptgen/phases/execution.py
@@ -27,9 +27,8 @@ from wptgen.phases.utils import generate_safe
 from wptgen.ui import UIProvider
 from wptgen.utils import (
   MARKDOWN_CODE_BLOCK_RE,
-  ensure_trailing_newline,
+  clean_file_content,
   parse_multi_file_response,
-  strip_trailing_whitespace,
 )
 
 
@@ -205,9 +204,7 @@ async def _correct_test(
       final_content = MARKDOWN_CODE_BLOCK_RE.sub('', corrected_content).strip()
 
     if final_content:
-      full_path.write_text(
-        ensure_trailing_newline(strip_trailing_whitespace(final_content)), encoding='utf-8'
-      )
+      full_path.write_text(clean_file_content(final_content), encoding='utf-8')
       ui.success(f'Updated {matched_path}')
       ui.print_diff(test_source_code, final_content, matched_path)
 

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -24,14 +24,13 @@ from wptgen.phases.utils import confirm_prompts, generate_safe
 from wptgen.ui import UIProvider
 from wptgen.utils import (
   MARKDOWN_CODE_BLOCK_RE,
+  clean_file_content,
   ensure_testharness_imports,
-  ensure_trailing_newline,
   extract_xml_tag,
   fix_reftest_link,
   get_next_available_root,
   parse_multi_file_response,
   parse_suggestions,
-  strip_trailing_whitespace,
 )
 
 
@@ -238,9 +237,7 @@ async def _generate_and_save(
         clean_content = ensure_testharness_imports(clean_content)
 
       output_path = output_dir / fname
-      output_path.write_text(
-        ensure_trailing_newline(strip_trailing_whitespace(clean_content)), encoding='utf-8'
-      )
+      output_path.write_text(clean_file_content(clean_content), encoding='utf-8')
       ui.report_test_generated(root_name, success=True, path=output_path)
       results.append((output_path, clean_content, suggestion_xml))
   else:
@@ -251,9 +248,7 @@ async def _generate_and_save(
       clean_content = ensure_testharness_imports(clean_content)
 
     output_path = output_dir / f'{root_name}.html'
-    output_path.write_text(
-      ensure_trailing_newline(strip_trailing_whitespace(clean_content)), encoding='utf-8'
-    )
+    output_path.write_text(clean_file_content(clean_content), encoding='utf-8')
     ui.report_test_generated(root_name, success=True, path=output_path, fallback=True)
     results.append((output_path, clean_content, suggestion_xml))
 

--- a/wptgen/utils.py
+++ b/wptgen/utils.py
@@ -36,18 +36,12 @@ MAX_DELAY = 60.0
 MAX_RETRIES = 5
 
 
-def ensure_trailing_newline(content: str) -> str:
-  """Ensures the string ends with exactly one newline character."""
+def clean_file_content(content: str) -> str:
+  """Removes trailing whitespace from every line and ensures exactly one trailing newline."""
   if not content:
     return '\n'
+  content = re.sub(r'[ \t]+(\r?)$', r'\1', content, flags=re.MULTILINE)
   return content.rstrip('\r\n') + '\n'
-
-
-def strip_trailing_whitespace(content: str) -> str:
-  """Removes trailing whitespace from every line in a string."""
-  if not content:
-    return content
-  return re.sub(r'[ \t]+(\r?)$', r'\1', content, flags=re.MULTILINE)
 
 
 def extract_xml_tag(text: str, tag: str) -> str | None:


### PR DESCRIPTION
## Background
This PR resolves #205 by combining the two separate file formatting helper functions `ensure_trailing_newline` and `strip_trailing_whitespace` into a single, cohesive utility called `clean_file_content` in `wptgen/utils.py`.

## Proposed Changes
- **Refactored `wptgen/utils.py`:** Removed `ensure_trailing_newline` and `strip_trailing_whitespace` and added `clean_file_content`.
- **Updated Phase Modules:** Replaced all nested `ensure_trailing_newline(strip_trailing_whitespace(...))` calls across `wptgen/phases/evaluation.py`, `wptgen/phases/generation.py`, and `wptgen/phases/execution.py` with the new single helper function.
- **Tests Updated:** Updated the test suite in `tests/test_utils.py` to comprehensively test the combined `clean_file_content` functionality.

## Verification
- Validated that `make presubmit` passes successfully, running all linting, type-checking, and test pipelines without errors.

Resolves #205
