### PR TITLE
Fix #223: Prevent LLM from modifying requirement comments during self-correction

### DIFF
--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -21,7 +21,7 @@ from jinja2 import Environment
 from wptgen.config import Config
 from wptgen.llm import LLMClient
 from wptgen.models import STYLE_GUIDE_MAP, TestType, WorkflowContext
-from wptgen.phases.utils import generate_safe
+from wptgen.phases.utils import generate_safe, validate_requirements_preserved
 from wptgen.ui import UIProvider
 from wptgen.utils import (
   MARKDOWN_CODE_BLOCK_RE,
@@ -249,6 +249,11 @@ async def _evaluate_and_update(
       # Now save
       if p_test_new and test_path_item and c_test_new is not None:
         p_old, old_content = test_path_item
+        if not validate_requirements_preserved(old_content, c_test_new):
+          ui.warning(
+            f'LLM altered requirement comments in {p_old.name}. Rejecting evaluation change.'
+          )
+          return
         if p_test_new != p_old:
           p_old.unlink(missing_ok=True)
         p_test_new.write_text(clean_file_content(c_test_new), encoding='utf-8')
@@ -257,6 +262,11 @@ async def _evaluate_and_update(
 
       if p_ref_new and ref_path_item and c_ref_new is not None:
         p_old, old_content = ref_path_item
+        if not validate_requirements_preserved(old_content, c_ref_new):
+          ui.warning(
+            f'LLM altered requirement comments in {p_old.name}. Rejecting evaluation change.'
+          )
+          return
         if p_ref_new != p_old:
           p_old.unlink(missing_ok=True)
         p_ref_new.write_text(clean_file_content(c_ref_new), encoding='utf-8')
@@ -281,6 +291,12 @@ async def _evaluate_and_update(
             path = new_path
         else:
           clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', clean_response).strip()
+
+        if not validate_requirements_preserved(old_content, clean_content):
+          ui.warning(
+            f'LLM altered requirement comments in {path.name}. Rejecting evaluation change.'
+          )
+          return
 
         path.write_text(clean_file_content(clean_content), encoding='utf-8')
         ui.report_evaluation_result(path.name, success=True, updated=True)

--- a/wptgen/phases/execution.py
+++ b/wptgen/phases/execution.py
@@ -23,7 +23,7 @@ from jinja2 import Environment, Template
 from wptgen.config import Config
 from wptgen.llm import LLMClient
 from wptgen.models import WorkflowContext
-from wptgen.phases.utils import generate_safe
+from wptgen.phases.utils import generate_safe, validate_requirements_preserved
 from wptgen.ui import UIProvider
 from wptgen.utils import (
   MARKDOWN_CODE_BLOCK_RE,
@@ -224,6 +224,10 @@ async def _correct_test(
       final_content = MARKDOWN_CODE_BLOCK_RE.sub('', corrected_content).strip()
 
     if final_content:
+      if not validate_requirements_preserved(test_source_code, final_content):
+        ui.warning(f'LLM altered requirement comments in {matched_path}. Rejecting change.')
+        return
+
       full_path.write_text(clean_file_content(final_content), encoding='utf-8')
       ui.success(f'Updated {matched_path}')
       ui.print_diff(test_source_code, final_content, matched_path)

--- a/wptgen/phases/utils.py
+++ b/wptgen/phases/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import re
 
 import typer
 
@@ -22,6 +23,39 @@ from wptgen.ui import UIProvider
 
 # Global semaphore to limit parallel LLM requests
 _llm_semaphore: asyncio.Semaphore | None = None
+
+
+def validate_requirements_preserved(original_code: str, new_code: str) -> bool:
+  """
+  Validates that requirement comments in the original code are preserved exactly in the new code.
+  Requirements are typically contained in block comments (/* ... */) or HTML comments (<!-- ... -->).
+  """
+
+  def extract_comments(code: str) -> list[str]:
+    comments = []
+    for match in re.finditer(r'/\*[\s\S]*?\*/|<!--[\s\S]*?-->', code):
+      normalized = re.sub(r'\s+', ' ', match.group(0)).strip()
+      if len(normalized) > 20:
+        comments.append(normalized)
+    return comments
+
+  original_comments = extract_comments(original_code)
+  new_code_normalized = re.sub(r'\s+', ' ', new_code)
+
+  for comment in original_comments:
+    if comment not in new_code_normalized:
+      return False
+
+  for line in original_code.split('\n'):
+    line = line.strip()
+    if line.startswith('// '):
+      cleaned = re.sub(r'^//\s*', '', line).strip()
+      if len(cleaned) > 20:
+        req_normalized = re.sub(r'\s+', ' ', cleaned)
+        if req_normalized not in new_code_normalized:
+          return False
+
+  return True
 
 
 def get_semaphore(config: Config) -> asyncio.Semaphore:

--- a/wptgen/templates/correction_system.jinja
+++ b/wptgen/templates/correction_system.jinja
@@ -6,6 +6,7 @@ Your task is to correct a failing web platform test based on its source code and
 1.  **Zero Conversation:** Do not output conversational filler, pleasantries, or explanatory text. Output ONLY the raw file contents.
 2.  **Formatting Strictness:** Output the exact HTML/JS file content. Do not wrap your final output in markdown code blocks unless specifically instructed.
 3.  **Fix the Error:** You will receive `<error_log>` and `<test_source_code>` XML blocks. Analyze the provided `<error_log>` and the `<test_source_code>`. Identify the root cause of the failure (e.g., syntax error, incorrect API usage, missing setup, or assertion failure) and modify the source code to fix it. Ensure side-effects are cleaned up.
+4.  **Strict Comment Preservation:** You are strictly forbidden from altering, relaxing, or removing the normative requirement comments (such as block comments or `// META` tags) that describe what the test is evaluating. Your job is to modify the test code so that it correctly evaluates the existing, unchanged normative requirements. Do not change the requirements to match current test behavior.
 
 # WPT GENERAL STYLE GUIDE
 {{ wpt_style_guide }}

--- a/wptgen/templates/evaluation_system.jinja
+++ b/wptgen/templates/evaluation_system.jinja
@@ -61,4 +61,4 @@ Output ONLY the raw, fully corrected file contents.
 * DO NOT explain your changes.
 * DO NOT output conversational filler or pleasantries.
 * DO NOT wrap the output in markdown code blocks (e.g., ```html). Output the raw file content only.
-* STRICT COMMENT PRESERVATION: You MUST preserve all original code comments from the input exactly as they appeared. Do not delete, move, or rewrite them.
+* STRICT COMMENT PRESERVATION: You are strictly forbidden from altering, relaxing, or removing the normative requirement comments (such as block comments or `// META` tags) that describe what the test is evaluating. Your job is to modify the test code so that it correctly evaluates the existing, unchanged normative requirements. Do not change the requirements to match current test behavior.


### PR DESCRIPTION
Resolves #223

## Background
During the self-correction execution phase, the LLM has occasionally modified the original normative requirement comments in the source code just to force a failing test to pass (rather than fixing the test implementation).

## Proposed Changes
*   **Prompt Updates**: Added a strict core directive in `correction_system.jinja` and `evaluation_system.jinja` preventing the LLM from altering or removing normative requirement comments (such as block comments or `// META` tags).
*   **Safeguard Implementation**: Added programmatic validation logic (`validate_requirements_preserved()`) in `utils.py` and implemented it in both `execution.py` and `evaluation.py` to enforce these rules across all code modification phases.
*   **Validation**: Verifies the exact textual content of all original block requirements (`/* ... */`, `<!-- ... -->`) and substantial line comments (`// ...`) are safely preserved across LLM correction and evaluation attempts. If they are tampered with, the generated output is correctly rejected.
