### PR TITLE
Fix #231: Resolve path error for ./wpt lint with relative --output-dir

### DIFF
--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -388,6 +388,41 @@ async def test_run_wpt_lint_exception(
 
 
 @pytest.mark.asyncio
+async def test_run_wpt_lint_relative_wpt_dir(
+  mocker: MagicMock, mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+) -> None:
+  import os
+
+  from wptgen.phases.evaluation import _run_wpt_lint
+
+  mock_process = mocker.AsyncMock()
+  mock_process.communicate.return_value = (b'', b'')
+  mock_process.returncode = 0
+  mock_exec = mocker.patch('asyncio.create_subprocess_exec', return_value=mock_process)
+
+  wpt_dir = tmp_path / 'wpt'
+  wpt_dir.mkdir(parents=True, exist_ok=True)
+  test_file = wpt_dir / 'test.html'
+  test_file.touch()
+
+  original_cwd = Path.cwd()
+  try:
+    os.chdir(tmp_path)
+    # The relative path from tmp_path to tmp_path/wpt is simply 'wpt'
+    rel_wpt_dir = Path('wpt')
+
+    # Run lint with absolute test_file path and relative wpt_dir path
+    result = await _run_wpt_lint(test_file.absolute(), rel_wpt_dir)
+
+    assert result is None
+    mock_exec.assert_called_once()
+    # Assert that the relative path passed to wpt lint is correct
+    assert mock_exec.call_args[0][2] == 'test.html'
+  finally:
+    os.chdir(original_cwd)
+
+
+@pytest.mark.asyncio
 async def test_run_test_evaluation_non_reftest_multi_file(
   mocker: MagicMock, mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
 ) -> None:

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -36,7 +36,7 @@ async def _run_wpt_lint(path: Path, wpt_dir: Path) -> str | None:
   """Runs ./wpt lint on the given path and returns the error output if any."""
   try:
     # Use path relative to wpt_dir for cleaner output
-    rel_path = str(path.relative_to(wpt_dir))
+    rel_path = str(path.resolve().relative_to(wpt_dir.resolve()))
     process = await asyncio.create_subprocess_exec(
       './wpt',
       'lint',


### PR DESCRIPTION
## Background & Motivation
Resolves #231.
When running the `wpt-gen generate` command from outside the `wpt` repository and specifying a relative `--output-dir` (e.g., `../wpt`), the evaluation phase crashes during linting. The root cause is `pathlib.Path.relative_to` throwing a `ValueError` when one path is absolute and the other is relative.

## Proposed Changes
- Updated `wptgen/phases/evaluation.py` to use `.resolve()` on both the test `path` and `wpt_dir` before calculating the relative path.
- Added a unit test `test_run_wpt_lint_relative_wpt_dir` to `tests/test_evaluation.py` to verify path resolution for `_run_wpt_lint` when `wpt_dir` is a relative path.
