### PR TITLE
Implement Fine-Grained Task Persistence and Granular Resume

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -292,6 +292,7 @@ async def test_engine_skip_phase_4(mocker: MockerFixture, mock_config: Config) -
     requirements_xml='<xml></xml>',
     audit_response='mock_audit',
     generated_tests=[(Path('mock_test_1.html'), 'content', '<xml>')],
+    completed_sub_tasks={'phase_2_extraction', 'phase_4_generation'},
   )
 
   mocker.patch(

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -121,6 +121,7 @@ async def test_run_async_workflow_resume_skips_phases(
     metadata=WebFeatureMetadata(name='Test', description='Desc', specs=[]),
     wpt_context=WPTContext(),
     requirements_xml='<reqs/>',
+    completed_sub_tasks={'phase_2_extraction'},
   )
   engine._save_resume_state(context)
 

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -108,22 +108,41 @@ class WPTGenEngine:
       self._save_resume_state(context)
 
     # Phase 2: Requirements Extraction
-    if not context.requirements_xml:
+    if not context.is_sub_task_complete('phase_2_extraction'):
       if self.config.single_prompt_requirements:
         requirements_xml = await run_requirements_extraction(
-          context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
+          context,
+          self.config,
+          self.llm,
+          self.ui,
+          self.jinja_env,
+          self.cache_dir,
+          self._save_resume_state,
         )
       elif self.config.detailed_requirements:
         requirements_xml = await run_requirements_extraction_iterative(
-          context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
+          context,
+          self.config,
+          self.llm,
+          self.ui,
+          self.jinja_env,
+          self.cache_dir,
+          self._save_resume_state,
         )
       else:
         requirements_xml = await run_requirements_extraction_categorized(
-          context, self.config, self.llm, self.ui, self.jinja_env, self.cache_dir
+          context,
+          self.config,
+          self.llm,
+          self.ui,
+          self.jinja_env,
+          self.cache_dir,
+          self._save_resume_state,
         )
       if not requirements_xml:
         raise WorkflowError('Phase 2: Requirements Extraction failed.')
       context.requirements_xml = requirements_xml
+      context.mark_sub_task_complete('phase_2_extraction')
       self._save_resume_state(context)
 
     # Phase 3: Coverage Audit
@@ -146,11 +165,11 @@ class WPTGenEngine:
       return
 
     # Phase 4: User Selection & Generation
-    if not context.generated_tests:
-      generated_tests = await run_test_generation(
-        context, self.config, self.llm, self.ui, self.jinja_env
+    if not context.is_sub_task_complete('phase_4_generation'):
+      context.generated_tests = await run_test_generation(
+        context, self.config, self.llm, self.ui, self.jinja_env, self._save_resume_state
       )
-      context.generated_tests = generated_tests
+      context.mark_sub_task_complete('phase_4_generation')
       self._save_resume_state(context)
     else:
       self.ui.success('Skipping Phase 4: Tests already generated.')
@@ -158,7 +177,13 @@ class WPTGenEngine:
     # Phase 5: Evaluation
     if context.generated_tests and not self.config.skip_evaluation:
       await run_test_evaluation(
-        context, self.config, self.llm, self.ui, self.jinja_env, context.generated_tests
+        context,
+        self.config,
+        self.llm,
+        self.ui,
+        self.jinja_env,
+        context.generated_tests,
+        self._save_resume_state,
       )
     elif context.generated_tests and self.config.skip_evaluation:
       self.ui.info('Skipping Phase 5: Evaluation.')
@@ -166,7 +191,13 @@ class WPTGenEngine:
     # Phase 6: Test Execution
     if context.generated_tests and not self.config.skip_execution:
       await run_test_execution(
-        context, self.config, self.llm, self.ui, self.jinja_env, context.generated_tests
+        context,
+        self.config,
+        self.llm,
+        self.ui,
+        self.jinja_env,
+        context.generated_tests,
+        self._save_resume_state,
       )
     elif context.generated_tests and self.config.skip_execution:
       self.ui.info('Skipping Phase 6: Test Execution.')

--- a/wptgen/models.py
+++ b/wptgen/models.py
@@ -96,6 +96,13 @@ class WorkflowContext:
   approved_suggestions_xml: list[str] = field(default_factory=list)
   mdn_contents: list[str] | None = None
   generated_tests: list[tuple[Path, str, str]] | None = None
+  completed_sub_tasks: set[str] = field(default_factory=set)
+
+  def mark_sub_task_complete(self, task_id: str) -> None:
+    self.completed_sub_tasks.add(task_id)
+
+  def is_sub_task_complete(self, task_id: str) -> bool:
+    return task_id in self.completed_sub_tasks
 
   def to_dict(self) -> dict[str, Any]:
     data = {
@@ -111,6 +118,7 @@ class WorkflowContext:
       'generated_tests': (
         [(str(p), c, s) for p, c, s in self.generated_tests] if self.generated_tests else None
       ),
+      'completed_sub_tasks': list(self.completed_sub_tasks),
     }
     return data
 
@@ -139,4 +147,5 @@ class WorkflowContext:
       approved_suggestions_xml=data.get('approved_suggestions_xml', []),
       mdn_contents=data.get('mdn_contents'),
       generated_tests=generated_tests,
+      completed_sub_tasks=set(data.get('completed_sub_tasks', [])),
     )

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import asyncio
+import hashlib
 from collections import defaultdict
+from collections.abc import Callable
 from pathlib import Path
 
 from jinja2 import Environment
@@ -60,6 +62,7 @@ async def run_test_evaluation(
   ui: UIProvider,
   jinja_env: Environment,
   generated_tests: list[tuple[Path, str, str]],
+  save_state_callback: Callable[[WorkflowContext], None] | None = None,
 ) -> None:
   """Runs the evaluation phase for generated tests."""
   ui.on_phase_start(5, 'Evaluation')
@@ -79,9 +82,14 @@ async def run_test_evaluation(
   evaluation_template = jinja_env.get_template('evaluation.jinja')
   system_template = jinja_env.get_template('evaluation_system.jinja')
 
-  tasks = []
   ui.print('Running `./wpt lint` on generated tests.')
+  tasks = []
   for suggestion_xml, group in grouped_tests.items():
+    task_id = f'eval_{hashlib.md5(suggestion_xml.encode("utf-8")).hexdigest()}'
+    if context.is_sub_task_complete(task_id):
+      ui.info('Skipping already evaluated group.')
+      continue
+
     # Extract and normalize test type
     raw_test_type = extract_xml_tag(suggestion_xml, 'test_type') or 'JavaScript Test'
     test_type_enum = TestType.JAVASCRIPT
@@ -158,8 +166,17 @@ async def run_test_evaluation(
       generated_code_content=generated_code_content.strip(),
       lint_errors=lint_errors_str,
     )
+
+    async def evaluate_and_update_wrapper(
+      g: list[tuple[Path, str]], p: str, si: str, tt: TestType, tid: str
+    ) -> None:
+      await _evaluate_and_update(g, p, llm, ui, config, si, tt)
+      context.mark_sub_task_complete(tid)
+      if save_state_callback:
+        save_state_callback(context)
+
     tasks.append(
-      _evaluate_and_update(group, prompt, llm, ui, config, system_instruction, test_type_enum)
+      evaluate_and_update_wrapper(group, prompt, system_instruction, test_type_enum, task_id)
     )
 
   total_tasks = len(tasks)

--- a/wptgen/phases/execution.py
+++ b/wptgen/phases/execution.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import os
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 
 from jinja2 import Environment, Template
@@ -243,15 +244,24 @@ async def _correct_failing_tests(
   llm: LLMClient,
   ui: UIProvider,
   config: Config,
+  context: WorkflowContext,
+  save_state_callback: Callable[[WorkflowContext], None] | None = None,
 ) -> None:
   """Handles the loop that renders templates and corrects failing tests concurrently."""
+  import hashlib
+
   semaphore = asyncio.Semaphore(getattr(config, 'max_parallel_requests', 5))
   tasks = []
   for test_id, error_log in failing_tests.items():
-    tasks.append(
-      _correct_test(
-        test_id=test_id,
-        error_log=error_log,
+    task_id = f'exec_corr_{hashlib.md5((test_id + error_log).encode("utf-8")).hexdigest()}'
+    if context.is_sub_task_complete(task_id):
+      ui.info(f'Skipping already attempted correction for {test_id}')
+      continue
+
+    async def correct_and_update(tid: str, el: str, t_id: str) -> None:
+      await _correct_test(
+        test_id=tid,
+        error_log=el,
         valid_rel_paths=valid_rel_paths,
         wpt_root=wpt_root,
         correction_template=correction_template,
@@ -262,7 +272,11 @@ async def _correct_failing_tests(
         config=config,
         semaphore=semaphore,
       )
-    )
+      context.mark_sub_task_complete(t_id)
+      if save_state_callback:
+        save_state_callback(context)
+
+    tasks.append(correct_and_update(test_id, error_log, task_id))
 
   total_tasks = len(tasks)
   completed_tasks = 0
@@ -287,6 +301,7 @@ async def run_test_execution(
   ui: UIProvider,
   jinja_env: Environment,
   generated_tests: list[tuple[Path, str, str]],
+  save_state_callback: Callable[[WorkflowContext], None] | None = None,
 ) -> None:
   """Runs the execution phase for generated tests using ./wpt run."""
   ui.on_phase_start(6, 'Test Execution')
@@ -384,6 +399,8 @@ async def run_test_execution(
       llm,
       ui,
       config,
+      context,
+      save_state_callback,
     )
 
   ui.on_phase_complete('Test Execution')

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import asyncio
+import hashlib
+from collections.abc import Callable
 from pathlib import Path
 
 from jinja2 import Environment
@@ -40,18 +42,23 @@ async def run_test_generation(
   llm: LLMClient,
   ui: UIProvider,
   jinja_env: Environment,
+  save_state_callback: Callable[[WorkflowContext], None] | None = None,
 ) -> list[tuple[Path, str, str]]:
   ui.on_phase_start(4, 'User Selection & Generation')
 
   assert context.audit_response is not None
   assert context.metadata is not None
 
+  # Initialize generated tests list if None
+  if context.generated_tests is None:
+    context.generated_tests = []
+
   # Check for satisfaction status
   status = extract_xml_tag(context.audit_response, 'status')
   if status and status.strip() == 'SATISFIED':
     ui.success('All identified test requirements have been satisfied.')
     ui.info('No new test suggestions were generated because existing coverage is sufficient.')
-    return []
+    return context.generated_tests
 
   # Display the audit worksheet in a formatted table
   audit_worksheet = extract_xml_tag(context.audit_response, 'audit_worksheet')
@@ -62,7 +69,7 @@ async def run_test_generation(
 
   if not suggestions:
     ui.warning('No valid <test_suggestion> blocks found in the LLM response.')
-    return []
+    return context.generated_tests
 
   ui.success(f'{len(suggestions)} new test suggestions found!\n')
 
@@ -72,13 +79,21 @@ async def run_test_generation(
     description = extract_xml_tag(suggestion, 'description') or 'No description provided.'
     test_type = extract_xml_tag(suggestion, 'test_type') or 'Unknown'
 
+    task_id = f'test_gen_{hashlib.md5(suggestion.encode("utf-8")).hexdigest()}'
+    if context.is_sub_task_complete(task_id):
+      ui.info(f'Skipping already completed test: {title}')
+      continue
+
     ui.report_test_suggestion(i + 1, title, description, test_type)
     if config.yes_tests or ui.confirm('Generate this test?'):
-      approved_suggestions_xml.append(suggestion)
+      approved_suggestions_xml.append((suggestion, task_id))
 
   if not approved_suggestions_xml:
-    ui.warning('No tests selected. Exiting.')
-    return []
+    if context.generated_tests:
+      ui.success('All selected tests were already generated in a previous run.')
+    else:
+      ui.warning('No tests selected. Exiting.')
+    return context.generated_tests
 
   # Load the general style guide
   resources_path = Path(__file__).parent.parent / 'templates' / 'resources'
@@ -89,13 +104,13 @@ async def run_test_generation(
   system_template = jinja_env.get_template('test_generation_system.jinja')
 
   spec_urls = context.metadata.specs if context.metadata and context.metadata.specs else []
-  prompts_to_confirm: list[tuple[str, str, str, str]] = []
+  prompts_to_confirm: list[tuple[str, str, str, str, str]] = []
 
   # Keep track of filenames used in this run to avoid collisions
   used_names: set[str] = set()
   output_dir = Path(config.output_dir or '.')
 
-  for suggestion_xml in approved_suggestions_xml:
+  for suggestion_xml, task_id in approved_suggestions_xml:
     # Inject specification URLs if available
     if spec_urls:
       spec_url_tags = '\n'.join([f'  <spec_url>{url}</spec_url>' for url in spec_urls])
@@ -132,11 +147,13 @@ async def run_test_generation(
       test_suggestion_xml_block=suggestion_xml,
     )
 
-    prompts_to_confirm.append((final_prompt, root_name, suggestion_xml, system_instruction))
+    prompts_to_confirm.append(
+      (final_prompt, root_name, suggestion_xml, system_instruction, task_id)
+    )
 
   # Single confirmation for ALL tests
   await confirm_prompts(
-    [(p, f'{r}.*') for p, r, s, si in prompts_to_confirm],
+    [(p, f'{r}.*') for p, r, s, si, t in prompts_to_confirm],
     f'Generate {len(prompts_to_confirm)} Tests',
     llm,
     ui,
@@ -146,11 +163,25 @@ async def run_test_generation(
 
   ui.report_generation_start(len(prompts_to_confirm))
 
-  tasks = [
-    _generate_and_save(
+  async def generate_and_update(
+    prompt: str, root_name: str, suggestion_xml: str, system_instruction: str, task_id: str
+  ) -> list[tuple[Path, str, str]]:
+    result_files = await _generate_and_save(
       prompt, root_name, suggestion_xml, llm, ui, config, system_instruction, temperature=0.1
     )
-    for prompt, root_name, suggestion_xml, system_instruction in prompts_to_confirm
+
+    assert context.generated_tests is not None
+    context.generated_tests.extend(result_files)
+    context.mark_sub_task_complete(task_id)
+
+    if save_state_callback:
+      save_state_callback(context)
+
+    return result_files
+
+  tasks = [
+    generate_and_update(prompt, root_name, suggestion_xml, system_instruction, task_id)
+    for prompt, root_name, suggestion_xml, system_instruction, task_id in prompts_to_confirm
   ]
 
   results = []
@@ -172,7 +203,7 @@ async def run_test_generation(
 
   ui.report_generation_summary(final_results)
 
-  return final_results
+  return context.generated_tests
 
 
 async def _generate_and_save(

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import re
+from collections.abc import Callable
 from pathlib import Path
 
 from jinja2 import Environment
@@ -32,6 +33,7 @@ async def run_requirements_extraction(
   ui: UIProvider,
   jinja_env: Environment,
   cache_dir: Path,
+  save_state_callback: Callable[[WorkflowContext], None] | None = None,
 ) -> str | None:
   ui.on_phase_start(2, 'Requirements Extraction')
 
@@ -98,6 +100,7 @@ async def run_requirements_extraction_categorized(
   ui: UIProvider,
   jinja_env: Environment,
   cache_dir: Path,
+  save_state_callback: Callable[[WorkflowContext], None] | None = None,
 ) -> str | None:
   ui.on_phase_start(2, 'Requirements Extraction (Categorized)')
 
@@ -241,6 +244,7 @@ async def run_requirements_extraction_iterative(
   ui: UIProvider,
   jinja_env: Environment,
   cache_dir: Path,
+  save_state_callback: Callable[[WorkflowContext], None] | None = None,
 ) -> str | None:
   ui.on_phase_start(2, 'Requirements Extraction (Iterative)')
 
@@ -320,6 +324,12 @@ async def run_requirements_extraction_iterative(
         )
         all_requirements.append(re_indexed)
         requirement_counter += 1
+
+      context.requirements_xml = (
+        '<requirements_list>\n  ' + '\n  '.join(all_requirements) + '\n</requirements_list>'
+      )
+      if save_state_callback:
+        save_state_callback(context)
 
       iteration += 1
     else:


### PR DESCRIPTION
## Resolves #239

This PR introduces fine-grained task persistence and granular resume to WPT-Gen, preventing the waste of tokens and time when restarting large features.

### Changes
*   Added `completed_sub_tasks` tracking to `WorkflowContext` to record granular progress.
*   Updated `_run_async_workflow` in `WPTGenEngine` to inject `_save_resume_state` callbacks into the various phases.
*   Modified Phase 2 (Requirements Extraction), Phase 4 (Test Generation), Phase 5 (Evaluation), and Phase 6 (Execution) to skip previously completed sub-tasks by hashing their inputs and checking `is_sub_task_complete`.
*   Ensured partial results are correctly managed and cached when resuming.