### PR TITLE
Remove strict requirement comment preservation checks from test generation

### DIFF
--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -21,7 +21,7 @@ from jinja2 import Environment
 from wptgen.config import Config
 from wptgen.llm import LLMClient
 from wptgen.models import STYLE_GUIDE_MAP, TestType, WorkflowContext
-from wptgen.phases.utils import generate_safe, validate_requirements_preserved
+from wptgen.phases.utils import generate_safe
 from wptgen.ui import UIProvider
 from wptgen.utils import (
   MARKDOWN_CODE_BLOCK_RE,
@@ -249,11 +249,6 @@ async def _evaluate_and_update(
       # Now save
       if p_test_new and test_path_item and c_test_new is not None:
         p_old, old_content = test_path_item
-        if not validate_requirements_preserved(old_content, c_test_new):
-          ui.warning(
-            f'LLM altered requirement comments in {p_old.name}. Rejecting evaluation change.'
-          )
-          return
         if p_test_new != p_old:
           p_old.unlink(missing_ok=True)
         p_test_new.write_text(clean_file_content(c_test_new), encoding='utf-8')
@@ -262,11 +257,6 @@ async def _evaluate_and_update(
 
       if p_ref_new and ref_path_item and c_ref_new is not None:
         p_old, old_content = ref_path_item
-        if not validate_requirements_preserved(old_content, c_ref_new):
-          ui.warning(
-            f'LLM altered requirement comments in {p_old.name}. Rejecting evaluation change.'
-          )
-          return
         if p_ref_new != p_old:
           p_old.unlink(missing_ok=True)
         p_ref_new.write_text(clean_file_content(c_ref_new), encoding='utf-8')
@@ -291,12 +281,6 @@ async def _evaluate_and_update(
             path = new_path
         else:
           clean_content = MARKDOWN_CODE_BLOCK_RE.sub('', clean_response).strip()
-
-        if not validate_requirements_preserved(old_content, clean_content):
-          ui.warning(
-            f'LLM altered requirement comments in {path.name}. Rejecting evaluation change.'
-          )
-          return
 
         path.write_text(clean_file_content(clean_content), encoding='utf-8')
         ui.report_evaluation_result(path.name, success=True, updated=True)

--- a/wptgen/phases/execution.py
+++ b/wptgen/phases/execution.py
@@ -23,7 +23,7 @@ from jinja2 import Environment, Template
 from wptgen.config import Config
 from wptgen.llm import LLMClient
 from wptgen.models import WorkflowContext
-from wptgen.phases.utils import generate_safe, validate_requirements_preserved
+from wptgen.phases.utils import generate_safe
 from wptgen.ui import UIProvider
 from wptgen.utils import (
   MARKDOWN_CODE_BLOCK_RE,
@@ -226,10 +226,6 @@ async def _correct_test(
       final_content = MARKDOWN_CODE_BLOCK_RE.sub('', corrected_content).strip()
 
     if final_content:
-      if not validate_requirements_preserved(test_source_code, final_content):
-        ui.warning(f'LLM altered requirement comments in {matched_path}. Rejecting change.')
-        return
-
       full_path.write_text(clean_file_content(final_content), encoding='utf-8')
       ui.success(f'Updated {matched_path}')
       ui.print_diff(test_source_code, final_content, matched_path)

--- a/wptgen/phases/utils.py
+++ b/wptgen/phases/utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import asyncio
-import re
 
 import typer
 
@@ -23,39 +22,6 @@ from wptgen.ui import UIProvider
 
 # Global semaphore to limit parallel LLM requests
 _llm_semaphore: asyncio.Semaphore | None = None
-
-
-def validate_requirements_preserved(original_code: str, new_code: str) -> bool:
-  """
-  Validates that requirement comments in the original code are preserved exactly in the new code.
-  Requirements are typically contained in block comments (/* ... */) or HTML comments (<!-- ... -->).
-  """
-
-  def extract_comments(code: str) -> list[str]:
-    comments = []
-    for match in re.finditer(r'/\*[\s\S]*?\*/|<!--[\s\S]*?-->', code):
-      normalized = re.sub(r'\s+', ' ', match.group(0)).strip()
-      if len(normalized) > 20:
-        comments.append(normalized)
-    return comments
-
-  original_comments = extract_comments(original_code)
-  new_code_normalized = re.sub(r'\s+', ' ', new_code)
-
-  for comment in original_comments:
-    if comment not in new_code_normalized:
-      return False
-
-  for line in original_code.split('\n'):
-    line = line.strip()
-    if line.startswith('// '):
-      cleaned = re.sub(r'^//\s*', '', line).strip()
-      if len(cleaned) > 20:
-        req_normalized = re.sub(r'\s+', ' ', cleaned)
-        if req_normalized not in new_code_normalized:
-          return False
-
-  return True
 
 
 def get_semaphore(config: Config) -> asyncio.Semaphore:


### PR DESCRIPTION
## Background
When the `generate` workflow evaluates and corrects test changes, it previously enforced a strict validation check (`validate_requirements_preserved`). This strict check compared the original file's comments to the new output and discarded the AI's changes if any requirement comment was altered, relaxed, or removed.

## Changes
This PR removes the strict `validate_requirements_preserved` check from the test evaluation and execution phases (`wptgen/phases/evaluation.py` and `wptgen/phases/execution.py`).
The `validate_requirements_preserved` function itself was also removed from `wptgen/phases/utils.py`.

The LLM system prompts still instruct the model to preserve the requirement comments, so the AI will continue to attempt to preserve them, but the hard mechanical check that was discarding valid test edits has been eliminated.