### PR TITLE
fix: Preserve internal spec links during HTML-to-Markdown conversion

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -194,6 +194,26 @@ def test_fetch_and_extract_text_extract_fails(mocker: MockerFixture) -> None:
   assert result is None
 
 
+def test_fetch_and_extract_text_preserves_internal_links(mocker: MockerFixture) -> None:
+  """Test that internal spec links are preserved while external links are stripped."""
+  mock_urlopen = mocker.patch('urllib.request.urlopen')
+  mock_response = mocker.MagicMock()
+  mock_response.read.return_value = (
+    b'<html><body><main><h1>Spec</h1>\n'
+    b'<p>Link to <a href="#section-1">Section 1</a>.</p>\n'
+    b'<p>Link to <a href="https://external.com/path">External</a>.</p>\n'
+    b'</main></body></html>'
+  )
+  mock_urlopen.return_value.__enter__.return_value = mock_response
+
+  result = fetch_and_extract_text('https://example.com')
+
+  assert result is not None
+  assert '[Section 1](#section-1)' in result
+  assert 'Link to External.' in result
+  assert 'https://external.com' not in result
+
+
 def test_resolve_patterns_basic_and_recursive(tmp_path: Path) -> None:
   """Test that _resolve_patterns correctly handles standard and recursive globs."""
   # Create a mock directory structure

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -157,11 +157,18 @@ def fetch_and_extract_text(url: str) -> str | None:
     logger.warning(f'Could not find main content block in {url}')
     return None
 
-  # Convert the HTML tree to markdown, omitting link URLs to save token space
+  # Pre-process <a> tags to preserve internal specification links (fragments)
+  # but strip external URLs to conserve token limits.
+  for a_tag in main_content.find_all('a'):
+    href = a_tag.get('href')
+    if not isinstance(href, str) or not href.startswith('#'):
+      a_tag.unwrap()
+
+  # Convert the HTML tree to markdown, omitting external link URLs to save token space
   content = markdownify.markdownify(
     str(main_content),
     heading_style='ATX',
-    strip=['a', 'img', 'picture', 'video', 'audio', 'iframe'],
+    strip=['img', 'picture', 'video', 'audio', 'iframe'],
   )
 
   content = content.strip()


### PR DESCRIPTION
## Background
Resolves #247
During the context assembly phase, HTML content conversion was stripping all `<a>` tags. This caused internal specification references (like `href="#section"`) to be lost, limiting cross-referencing capabilities during Requirements Extraction.

## Proposed Changes
- Added logic to pre-process HTML with `BeautifulSoup` to unwrap `<a>` tags containing external URLs.
- Modified `markdownify` configuration to no longer universally strip anchor tags, allowing internal fragment links to be preserved in Markdown.
- Added `test_fetch_and_extract_text_preserves_internal_links` to verify behavior.

## Verification
- Executed `make presubmit` successfully (all tests, type checks, and formatting passed).
- Satisfies all acceptance criteria outlined in #247.
