### PR TITLE
Fix orphaned browser processes on execution timeout

### DIFF
--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import asyncio
 import json
+import signal
 import typing
 from pathlib import Path
 from typing import Any
@@ -206,17 +207,22 @@ async def test_run_test_execution_timeout(
   context = WorkflowContext(feature_id='feat')
 
   mock_process = AsyncMock()
-  mock_process.kill = MagicMock()
+  mock_process.pid = 9999
   mock_process.communicate = AsyncMock()
 
   with patch('asyncio.create_subprocess_exec', return_value=mock_process):
     with patch('asyncio.wait_for', side_effect=asyncio.TimeoutError):
-      await run_test_execution(
-        context, mock_config, mock_llm, mock_ui, mock_jinja_env, generated_tests
-      )
+      with patch('sys.platform', 'linux'):
+        with patch('os.getpgid', return_value=12345, create=True) as mock_getpgid:
+          with patch('os.killpg', create=True) as mock_killpg:
+            await run_test_execution(
+              context, mock_config, mock_llm, mock_ui, mock_jinja_env, generated_tests
+            )
 
-      mock_process.kill.assert_called_once()
-      mock_ui.error.assert_called_with('Test execution timed out after 30s.')
+            mock_getpgid.assert_called_once_with(9999)
+            sig = getattr(signal, 'SIGKILL', 9)
+            mock_killpg.assert_called_once_with(12345, sig)
+            mock_ui.error.assert_called_with('Test execution timed out after 30s.')
 
 
 @pytest.mark.asyncio
@@ -433,7 +439,7 @@ async def test_execute_wpt_run_timeout(
   wpt_executable = wpt_root / 'wpt'
 
   mock_process = AsyncMock()
-  mock_process.kill = MagicMock()
+  mock_process.pid = 8888
 
   async def slow_wait() -> int:
     await asyncio.sleep(0.02)
@@ -443,7 +449,45 @@ async def test_execute_wpt_run_timeout(
   mock_process.stdout = _mock_stream(b'')
   mock_process.stderr = _mock_stream(b'')
   with patch('asyncio.create_subprocess_exec', return_value=mock_process):
-    returncode, output = await _execute_wpt_run(
-      wpt_executable, wpt_root, ['test1.html'], '/tmp/log.json', mock_config, mock_ui, 0.01
-    )
-    assert returncode == -1
+    with patch('sys.platform', 'linux'):
+      with patch('os.getpgid', return_value=54321, create=True) as mock_getpgid:
+        with patch('os.killpg', create=True) as mock_killpg:
+          returncode, output = await _execute_wpt_run(
+            wpt_executable, wpt_root, ['test1.html'], '/tmp/log.json', mock_config, mock_ui, 0.01
+          )
+          assert returncode == -1
+          mock_getpgid.assert_called_once_with(8888)
+          sig = getattr(signal, 'SIGKILL', 9)
+          mock_killpg.assert_called_once_with(54321, sig)
+
+
+@pytest.mark.asyncio
+async def test_execute_wpt_run_timeout_windows(
+  mock_config: Config, mock_ui: MagicMock, tmp_path: Path
+) -> None:
+  wpt_root = tmp_path / 'wpt'
+  wpt_root.mkdir()
+  wpt_executable = wpt_root / 'wpt'
+
+  mock_process = AsyncMock()
+  mock_process.pid = 8888
+
+  async def slow_wait() -> int:
+    await asyncio.sleep(0.02)
+    return 0
+
+  mock_process.wait = slow_wait
+  mock_process.stdout = _mock_stream(b'')
+  mock_process.stderr = _mock_stream(b'')
+  with patch('asyncio.create_subprocess_exec', return_value=mock_process):
+    with patch('sys.platform', 'win32'):
+      with patch('subprocess.run') as mock_run:
+        returncode, output = await _execute_wpt_run(
+          wpt_executable, wpt_root, ['test1.html'], '/tmp/log.json', mock_config, mock_ui, 0.01
+        )
+        assert returncode == -1
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert 'taskkill' in args
+        assert '/T' in args
+        assert '8888' in args

--- a/wptgen/phases/execution.py
+++ b/wptgen/phases/execution.py
@@ -15,8 +15,12 @@
 import asyncio
 import json
 import os
+import signal
+import subprocess
+import sys
 import tempfile
 from pathlib import Path
+from typing import Any
 
 from jinja2 import Environment, Template
 
@@ -92,9 +96,15 @@ async def _execute_wpt_run(
     cmd.extend(['--binary', config.wpt_binary])
   cmd.extend([config.wpt_browser] + valid_rel_paths)
 
-  process = await asyncio.create_subprocess_exec(
-    *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=str(wpt_root)
-  )
+  kwargs: dict[str, Any] = {
+    'stdout': asyncio.subprocess.PIPE,
+    'stderr': asyncio.subprocess.PIPE,
+    'cwd': str(wpt_root),
+  }
+  if sys.platform != 'win32':
+    kwargs['start_new_session'] = True
+
+  process = await asyncio.create_subprocess_exec(*cmd, **kwargs)
 
   stdout_chunks: list[str] = []
   stderr_chunks: list[str] = []
@@ -119,7 +129,24 @@ async def _execute_wpt_run(
   try:
     await asyncio.wait_for(communicate_and_stream(), timeout=execution_timeout)
   except asyncio.TimeoutError:
-    process.kill()
+    if sys.platform == 'win32':
+      try:
+        subprocess.run(
+          ['taskkill', '/F', '/T', '/PID', str(process.pid)],
+          stdout=subprocess.DEVNULL,
+          stderr=subprocess.DEVNULL,
+          check=False,
+        )
+      except Exception:
+        process.kill()  # Safe final fallback if taskkill fails
+    else:
+      try:
+        # signal.SIGKILL is not available on Windows, so we use getattr to avoid AttributeError
+        # even though this branch is never executed on Windows.
+        sig = getattr(signal, 'SIGKILL', 9)
+        os.killpg(os.getpgid(process.pid), sig)
+      except ProcessLookupError:
+        pass  # Process may have already exited
     await process.wait()
     ui.error(f'Test execution timed out after {execution_timeout}s.')
     return -1, ''


### PR DESCRIPTION
Resolves #246

## Background & Motivation
When the `wpt run` subprocess hits the global `execution_timeout` in `_execute_wpt_run`, the previous logic sent a kill signal only to the Python wrapper. This left orphaned browser processes (like Chrome and ChromeDriver instances) running in the background, consuming memory and potentially interfering with subsequent test runs.

## Proposed Changes
- Modified the `asyncio.create_subprocess_exec` call in `_execute_wpt_run` to launch the subprocess in its own process group using `start_new_session=True`.
- Updated the error handling on timeout to send a `SIGKILL` to the entire process group (`os.killpg`). This ensures that the `wpt run` script and all of its spawned descendant processes are forcefully terminated.
- Added comprehensive mocking for `os.getpgid` and `os.killpg` in `tests/test_execution.py` to prevent unintended process killing during test execution.

## Acceptance Criteria
- [x] The `wpt run` subprocess is executed in a new process group.
- [x] On timeout, the entire process group is killed to terminate all descendant processes.
- [x] Verify that no orphaned browser or driver processes are left behind after an execution timeout.
