### PR TITLE
fix: halt workflow after coverage audit for --brief-suggestions

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -437,3 +437,22 @@ async def test_engine_resume_from_generation(
   mock_gen.assert_called_once()
   mock_eval.assert_called_once()
   mock_exec.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_async_workflow_brief_suggestions(
+  engine: WPTGenEngine, mocker: MockerFixture
+) -> None:
+  engine.config.brief_suggestions = True
+  context = WorkflowContext(feature_id='test-feat', audit_response='audit')
+
+  mocker.patch('wptgen.engine.run_context_assembly', return_value=context)
+  mocker.patch('wptgen.engine.run_requirements_extraction_categorized', return_value='reqs')
+  mocker.patch('wptgen.engine.run_coverage_audit', return_value='audit')
+  mock_provide = mocker.patch('wptgen.engine.provide_coverage_report', return_value=None)
+  mock_gen = mocker.patch('wptgen.engine.run_test_generation', return_value=[])
+
+  await engine._run_async_workflow(web_feature_id='test-feat')
+
+  mock_provide.assert_called_once_with(context, engine.config, engine.ui)
+  mock_gen.assert_not_called()

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -245,12 +245,13 @@ class WPTGenEngine:
       self._save_phase_artifacts(context, WorkflowPhase.COVERAGE_AUDIT)
 
     # Skip Phase 4 if the user only wants the coverage audit report.
-    if self.config.suggestions_only:
+    if self.config.suggestions_only or self.config.brief_suggestions:
       await provide_coverage_report(context, self.config, self.ui)
       # Cleanup resume file if it exists, as this is a terminal state for suggestions-only
       resume_file = self._get_resume_file_path(web_feature_id)
       if resume_file.exists():
         resume_file.unlink()
+
       return context
 
     # Phase 4: User Selection & Generation


### PR DESCRIPTION
Resolves #262

## Overview
Ensures the `--brief-suggestions` flag halts the WPT-Gen workflow after the Coverage Audit phase and prompts the user to save the report, mirroring the behavior of `--suggestions-only`.

## Root Cause / Motivation
The initial implementation of the `--brief-suggestions` flag conditionally adjusted the generated Jinja templates but failed to update the early-exit logic within the main engine. As a result, the workflow would continue to Phase 4 (Test Generation) instead of stopping after the audit report was compiled.

## Detailed Changelog
* **`wptgen/engine.py`**: Added `self.config.brief_suggestions` to the early-exit condition at the end of `_run_async_workflow`'s Coverage Audit phase handling.
* **`tests/test_engine.py`**: Added `test_run_async_workflow_brief_suggestions` to verify that the generation phase is skipped and the coverage report is provided when the flag is active.