### PR TITLE
Formatting: Parse XML tags in --brief-suggestions console output

### DIFF
--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -210,8 +210,12 @@ async def test_run_test_execution_timeout(
   mock_process.pid = 9999
   mock_process.communicate = AsyncMock()
 
+  async def mock_wait_for(coro: Any, timeout: float) -> Any:
+    coro.close()
+    raise asyncio.TimeoutError()
+
   with patch('asyncio.create_subprocess_exec', return_value=mock_process):
-    with patch('asyncio.wait_for', side_effect=asyncio.TimeoutError):
+    with patch('asyncio.wait_for', side_effect=mock_wait_for):
       with patch('sys.platform', 'linux'):
         with patch('os.getpgid', return_value=12345, create=True) as mock_getpgid:
           with patch('os.killpg', create=True) as mock_killpg:

--- a/wptgen/phases/coverage_audit.py
+++ b/wptgen/phases/coverage_audit.py
@@ -175,7 +175,25 @@ async def run_coverage_audit(
 async def provide_coverage_report(context: WorkflowContext, config: Config, ui: UIProvider) -> None:
   """Prints the coverage audit report and optionally saves it to a file."""
   assert context.audit_response is not None
-  ui.report_coverage_audit(context.audit_response)
+
+  audit_worksheet = extract_xml_tag(context.audit_response, 'audit_worksheet')
+  test_suggestions_block = extract_xml_tag(context.audit_response, 'test_suggestions')
+
+  if audit_worksheet and test_suggestions_block:
+    ui.report_coverage_audit()
+    ui.report_audit_worksheet(audit_worksheet)
+
+    if '<status>SATISFIED</status>' in test_suggestions_block:
+      ui.success('All requirements are SATISFIED. No new tests suggested.')
+    else:
+      suggestions = parse_suggestions(test_suggestions_block)
+      for idx, suggestion in enumerate(suggestions, 1):
+        title = extract_xml_tag(suggestion, 'title') or 'Untitled'
+        description = extract_xml_tag(suggestion, 'description') or 'No description provided'
+        test_type = extract_xml_tag(suggestion, 'test_type')
+        ui.report_test_suggestion(idx, title, description, test_type)
+  else:
+    ui.report_coverage_audit(context.audit_response)
 
   if ui.confirm('\nSave report to a file?'):
     # Create a sanitized filename from the feature ID

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -70,7 +70,7 @@ async def run_test_generation(
   for i, suggestion in enumerate(suggestions):
     title = extract_xml_tag(suggestion, 'title') or f'Suggestion #{i + 1}'
     description = extract_xml_tag(suggestion, 'description') or 'No description provided.'
-    test_type = extract_xml_tag(suggestion, 'test_type') or 'Unknown'
+    test_type = extract_xml_tag(suggestion, 'test_type')
 
     ui.report_test_suggestion(i + 1, title, description, test_type)
     if config.yes_tests or ui.confirm('Generate this test?'):

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -78,10 +78,10 @@ class UIProvider(Protocol):
     auto_confirmed: bool = False,
   ) -> None: ...
   def report_llm_response(self, response: str, task_name: str) -> None: ...
-  def report_coverage_audit(self, audit_response: str) -> None: ...
+  def report_coverage_audit(self, audit_response: str | None = None) -> None: ...
   def report_audit_worksheet(self, worksheet_text: str) -> None: ...
   def report_test_suggestion(
-    self, suggestion_index: int, title: str, description: str, test_type: str
+    self, suggestion_index: int, title: str, description: str, test_type: str | None = None
   ) -> None: ...
   def report_generation_start(self, count: int) -> None: ...
   def report_test_generated(
@@ -253,12 +253,13 @@ class RichUIProvider:
       )
     )
 
-  def report_coverage_audit(self, audit_response: str) -> None:
+  def report_coverage_audit(self, audit_response: str | None = None) -> None:
     self.console.print()
     self.console.rule('[bold cyan]Coverage Audit Report')
     self.console.print()
-    self.console.print(Markdown(audit_response))
-    self.console.print()
+    if audit_response:
+      self.console.print(Markdown(audit_response))
+      self.console.print()
 
   def report_audit_worksheet(self, worksheet_text: str) -> None:
     table = Table(title='Coverage Audit Worksheet', show_header=True, header_style='bold cyan')
@@ -288,12 +289,15 @@ class RichUIProvider:
     self.console.print()
 
   def report_test_suggestion(
-    self, suggestion_index: int, title: str, description: str, test_type: str
+    self, suggestion_index: int, title: str, description: str, test_type: str | None = None
   ) -> None:
+    content = f'[bold cyan]Description:[/bold cyan] {description}'
+    if test_type:
+      content += f'\n[bold cyan]Test Type:[/bold cyan] {test_type}'
+
     self.console.print(
       Panel(
-        f'[bold cyan]Description:[/bold cyan] {description}\n'
-        f'[bold cyan]Test Type:[/bold cyan] {test_type}',
+        content,
         title=f'[bold cyan] Test Suggestion #{suggestion_index}:[/bold cyan] [white]{title}[/white]',
         border_style='blue',
         expand=False,


### PR DESCRIPTION
Resolves #266

## Overview
This PR improves the readability of the coverage audit report when running the `generate` workflow with `--brief-suggestions`. Instead of printing raw LLM XML tags directly to the console, the output is now cleanly parsed and rendered using existing `RichUIProvider` formatting methods. Additionally, it resolves a test suite warning by properly closing an unawaited coroutine.

## Root Cause / Motivation
Previously, `provide_coverage_report` dumped the raw `audit_response` directly to the `UIProvider`. This bypassed rich formatting for the `<audit_worksheet>` and `<test_suggestions>` blocks, resulting in hard-to-read, unstructured XML output for the user. Furthermore, an unawaited coroutine in `_execute_wpt_run` was causing a `RuntimeWarning` when testing timeouts because `asyncio.wait_for` was simply mocked without closing the underlying coroutine properly.

## Detailed Changelog
* **`wptgen/phases/coverage_audit.py`**: Refactored `provide_coverage_report` to extract and parse the `audit_worksheet` and `test_suggestions` blocks. It now invokes `ui.report_audit_worksheet` and iterates over parsed suggestions to invoke `ui.report_test_suggestion`.
* **`wptgen/ui.py`**: Updated `UIProvider` protocol and `RichUIProvider` class to handle optional parameters (`test_type` and `audit_response`), and adjusted their display logic for cases where they're not provided.
* **`wptgen/phases/generation.py`**: Removed the default "Unknown" fallback when extracting the `test_type` since `ui.report_test_suggestion` now supports it natively.
* **`tests/test_execution.py`**: Updated the mock for `asyncio.wait_for` in `test_run_test_execution_timeout` to `.close()` the coroutine before throwing a `TimeoutError`, cleanly resolving an unawaited coroutine `RuntimeWarning` during garbage collection.
