### PR TITLE
Fix #277: Minimize and standardize <test_suggestion> blocks

### DIFF
--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -7,13 +7,13 @@ def test_coverage_audit_system_template_brief() -> None:
 
   # Test with brief_suggestions=True
   rendered_brief = template.render(brief_suggestions=True, spec_urls=['https://example.com/spec'])
-  assert '<title>' in rendered_brief
+  assert '<title>' not in rendered_brief
   assert '<description>' in rendered_brief
   assert '<test_type>' not in rendered_brief
   assert '<pre_conditions>' not in rendered_brief
   assert '<steps>' not in rendered_brief
   assert '<expected_result>' not in rendered_brief
-  assert '<spec_url>https://example.com/spec</spec_url>' in rendered_brief
+  assert '<spec_url>https://example.com/spec</spec_url>' not in rendered_brief
 
   # Test with brief_suggestions=False
   rendered_full = template.render(brief_suggestions=False)
@@ -31,13 +31,13 @@ def test_chromestatus_coverage_audit_system_template_brief() -> None:
 
   # Test with brief_suggestions=True
   rendered_brief = template.render(brief_suggestions=True, spec_urls=['https://example.com/spec'])
-  assert '<title>' in rendered_brief
+  assert '<title>' not in rendered_brief
   assert '<description>' in rendered_brief
   assert '<test_type>' not in rendered_brief
   assert '<pre_conditions>' not in rendered_brief
   assert '<steps>' not in rendered_brief
   assert '<expected_result>' not in rendered_brief
-  assert '<spec_url>https://example.com/spec</spec_url>' in rendered_brief
+  assert '<spec_url>https://example.com/spec</spec_url>' not in rendered_brief
 
   # Test with brief_suggestions=False
   rendered_full = template.render(brief_suggestions=False)

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -100,12 +100,10 @@ async def run_test_generation(
   output_dir = Path(config.output_dir or '.')
 
   for suggestion_xml in approved_suggestions_xml:
-    # Inject specification URLs if available
-    if spec_urls:
-      spec_url_tags = '\n'.join([f'  <spec_url>{url}</spec_url>' for url in spec_urls])
-      suggestion_xml = suggestion_xml.replace(
-        '</test_suggestion>', f'{spec_url_tags}\n</test_suggestion>'
-      )
+    # Inject specification URLs and feature ID, and sanitize if using brief suggestions
+    suggestion_xml = _format_test_suggestion(
+      suggestion_xml, context.feature_id, spec_urls, sanitize=config.brief_suggestions
+    )
 
     # Extract and normalize test type
     raw_test_type = extract_xml_tag(suggestion_xml, 'test_type') or 'JavaScript Test'
@@ -179,6 +177,28 @@ async def run_test_generation(
   return final_results
 
 
+def _format_test_suggestion(
+  suggestion_xml: str, feature_id: str, spec_urls: list[str], sanitize: bool = False
+) -> str:
+  if sanitize:
+    description = extract_xml_tag(suggestion_xml, 'description') or 'No description provided.'
+    lines = ['<test_suggestion>']
+    lines.append(f'  <description>{description}</description>')
+    for url in spec_urls:
+      lines.append(f'  <spec_url>{url}</spec_url>')
+    lines.append(f'  <web_feature_id>{feature_id}</web_feature_id>')
+    lines.append('</test_suggestion>')
+    return '\n'.join(lines)
+  else:
+    # Just inject spec_urls and web_feature_id into the existing XML
+    lines = []
+    for url in spec_urls:
+      lines.append(f'  <spec_url>{url}</spec_url>')
+    lines.append(f'  <web_feature_id>{feature_id}</web_feature_id>')
+    additions = '\n'.join(lines)
+    return suggestion_xml.replace('</test_suggestion>', f'{additions}\n</test_suggestion>')
+
+
 async def _generate_agentic_loop(
   approved_suggestions_xml: list[str],
   context: WorkflowContext,
@@ -192,11 +212,12 @@ async def _generate_agentic_loop(
   model = config.get_model_for_phase(WorkflowPhase.GENERATION) or config.default_model
   agentic_template = jinja_env.get_template('agentic_test_generation.jinja')
 
+  spec_urls = context.metadata.specs if context.metadata and context.metadata.specs else []
+
   for i, suggestion_xml in enumerate(approved_suggestions_xml):
-    # Inject <web_feature_id> before the closing tag so the agent knows the directory target
-    modified_xml = suggestion_xml.replace(
-      '</test_suggestion>',
-      f'  <web_feature_id>{context.feature_id}</web_feature_id>\n</test_suggestion>',
+    # Sanitize and strictly enforce the <test_suggestion> block structure
+    modified_xml = _format_test_suggestion(
+      suggestion_xml, context.feature_id, spec_urls, sanitize=True
     )
 
     prompt = agentic_template.render(test_suggestion_xml_block=modified_xml)

--- a/wptgen/templates/chromestatus_templates/coverage_audit_system.jinja
+++ b/wptgen/templates/chromestatus_templates/coverage_audit_system.jinja
@@ -53,7 +53,9 @@ R3: [Requirement Text] -> [COVERED by filename.html]
 
 <test_suggestions>
   <test_suggestion>
+    {%- if not brief_suggestions %}
     <title>[Short Descriptive Title]</title>
+    {%- endif %}
     <description>[The exact text taken from the requirement description]</description>
     {%- if not brief_suggestions %}
     <test_type>[Explicitly categorize the test. e.g. "JavaScript test", "Reftest", "Crashtest"]</test_type>
@@ -63,11 +65,6 @@ R3: [Requirement Text] -> [COVERED by filename.html]
       <step>2. [Second step...]</step>
     </steps>
     <expected_result>[Exact assertion needed. e.g., "Promise rejects with TypeError"]</expected_result>
-    {%- endif %}
-    {%- if brief_suggestions and spec_urls %}
-    {%- for url in spec_urls %}
-    <spec_url>{{ url }}</spec_url>
-    {%- endfor %}
     {%- endif %}
   </test_suggestion>
 </test_suggestions>

--- a/wptgen/templates/coverage_audit_system.jinja
+++ b/wptgen/templates/coverage_audit_system.jinja
@@ -51,7 +51,9 @@ R3: [Requirement Text] -> [COVERED by filename.html]
 
 <test_suggestions>
   <test_suggestion>
+    {%- if not brief_suggestions %}
     <title>[Short Descriptive Title]</title>
+    {%- endif %}
     <description>[The exact text taken from the requirement description]</description>
     {%- if not brief_suggestions %}
     <test_type>[Explicitly categorize the test. e.g. "JavaScript test", "Reftest", "Crashtest"]</test_type>
@@ -61,11 +63,6 @@ R3: [Requirement Text] -> [COVERED by filename.html]
       <step>2. [Second step...]</step>
     </steps>
     <expected_result>[Exact assertion needed. e.g., "Promise rejects with TypeError"]</expected_result>
-    {%- endif %}
-    {%- if brief_suggestions and spec_urls %}
-    {%- for url in spec_urls %}
-    <spec_url>{{ url }}</spec_url>
-    {%- endfor %}
     {%- endif %}
   </test_suggestion>
 </test_suggestions>


### PR DESCRIPTION
Resolves #277

## Overview
This pull request minimizes and standardizes the structure of `<test_suggestion>` blocks generated during the coverage audit phase. Extraneous tags like `<title>` have been removed, and `<spec_url>` injections are now handled centrally to ensure consistency across standard and agentic test generation workflows.

## Root Cause / Motivation
Previously, `<test_suggestion>` blocks contained varying extraneous XML tags depending on the flags used (e.g., `--brief-suggestions` or `--agentic-generation`), which needlessly consumed tokens and diluted the LLM's focus. We needed a unified and strictly minimal structure (containing only `<description>`, `<spec_url>`, and `<web_feature_id>`) injected programmatically rather than depending on the LLM to output the additional elements correctly.

## Detailed Changelog
* **`wptgen/templates/coverage_audit_system.jinja` & `wptgen/templates/chromestatus_templates/coverage_audit_system.jinja`**: Removed the `<title>` output requirement for brief suggestions and eliminated the prompt instruction for generating `<spec_url>` tags, deferring that logic to the generation phase.
* **`wptgen/phases/generation.py`**: Introduced a centralized `_format_test_suggestion` helper to stringently enforce the block structure when using strict sanitization. This is used in both the standard `run_test_generation` loop (when `--brief-suggestions` is active) and the `_generate_agentic_loop`.
* **`tests/test_templates.py`**: Updated test mock assertions to reflect the removal of the `<title>` tag and verify the updated template behaviors when `--brief-suggestions` is passed.
