### PR TITLE
fix(generation): support interactive prompt in agentic generation

### DIFF
--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import re
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -500,6 +501,12 @@ async def test_run_test_generation_agentic(
   assert 'Use the wpt-generator skill to generate the following test' in args[3]
   assert '<web_feature_id>feat</web_feature_id>' in args[3]
   assert kwargs['cwd'] == '/mock/wpt'
+  if mock_config.agentic_yolo:
+    assert kwargs['stdout'] == asyncio.subprocess.PIPE
+    assert kwargs['stderr'] == asyncio.subprocess.PIPE
+  else:
+    assert kwargs['stdout'] is None
+    assert kwargs['stderr'] is None
 
   mock_ui.print.assert_any_call('[cyan]│[/cyan] stdout line')
   mock_ui.print.assert_any_call('[cyan]│[/cyan] [white]stderr error[/white]')
@@ -709,3 +716,9 @@ async def test_run_test_generation_agentic_interactive(
   assert 'Use the wpt-generator skill to generate the following test' in args[3]
   assert '<web_feature_id>feat</web_feature_id>' in args[3]
   assert kwargs['cwd'] == '/mock/wpt'
+  if mock_config.agentic_yolo:
+    assert kwargs['stdout'] == asyncio.subprocess.PIPE
+    assert kwargs['stderr'] == asyncio.subprocess.PIPE
+  else:
+    assert kwargs['stdout'] is None
+    assert kwargs['stderr'] is None

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -237,26 +237,30 @@ async def _generate_agentic_loop(
     process = await asyncio.create_subprocess_exec(
       *cmd,
       cwd=config.wpt_path,
-      stdout=asyncio.subprocess.PIPE,
-      stderr=asyncio.subprocess.PIPE,
+      stdout=asyncio.subprocess.PIPE if config.agentic_yolo else None,
+      stderr=asyncio.subprocess.PIPE if config.agentic_yolo else None,
     )
 
-    async def _stream_output(stream: asyncio.StreamReader | None, is_stderr: bool = False) -> None:
-      if not stream:
-        return
-      while True:
-        line = await stream.readline()
-        if not line:
-          break
-        text = line.decode('utf-8').rstrip()
-        if is_stderr:
-          ui.print(f'[cyan]│[/cyan] [white]{text}[/white]')
-        else:
-          ui.print(f'[cyan]│[/cyan] {text}')
+    if config.agentic_yolo:
 
-    await asyncio.gather(
-      _stream_output(process.stdout), _stream_output(process.stderr, is_stderr=True)
-    )
+      async def _stream_output(
+        stream: asyncio.StreamReader | None, is_stderr: bool = False
+      ) -> None:
+        if not stream:
+          return
+        while True:
+          line = await stream.readline()
+          if not line:
+            break
+          text = line.decode('utf-8').rstrip()
+          if is_stderr:
+            ui.print(f'[cyan]│[/cyan] [white]{text}[/white]')
+          else:
+            ui.print(f'[cyan]│[/cyan] {text}')
+
+      await asyncio.gather(
+        _stream_output(process.stdout), _stream_output(process.stderr, is_stderr=True)
+      )
 
     await process.wait()
     ui.print(Rule(style='cyan'))


### PR DESCRIPTION
## Overview
This PR updates the agentic test generation pipeline to support fully interactive TTY sessions when the user is not running in YOLO mode.

## Root Cause / Motivation
Currently, when `gemini` is executed as a subprocess via `asyncio.create_subprocess_exec` during the generation phase, `stdout` and `stderr` are aggressively piped to `asyncio.subprocess.PIPE`. When Gemini CLI starts in interactive mode (no `-p` flag) but does not have access to a native TTY device, it assumes it is headless and automatically fails all `ask_user` policies, effectively becoming un-interactive.

By conditionally inheriting the terminal's standard streams (`stdout=None` and `stderr=None`) when `config.agentic_yolo` is `False`, the subprocess directly hooks into the parent TTY. This enables normal interactive prompt usage where users can manually approve tool calls and review generation steps.

## Detailed Changelog
* **`wptgen/phases/generation.py`**: Conditionally pipes `stdout`/`stderr` and streams the output *only* if `config.agentic_yolo` is enabled. Otherwise, `asyncio.create_subprocess_exec` defaults to inheriting the streams directly, allowing an interactive session.
* **`tests/test_phases.py`**: Updated `test_run_test_generation_agentic` and `test_run_test_generation_agentic_interactive` to assert the updated standard stream kwargs.
