### PR TITLE
Fix #282: Prompt Gemini CLI to inform user to exit when finished in interactive mode

### DIFF
--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -511,6 +511,12 @@ async def test_run_test_generation_agentic(
   mock_ui.print.assert_any_call('[cyan]│[/cyan] stdout line')
   mock_ui.print.assert_any_call('[cyan]│[/cyan] [white]stderr error[/white]')
   mock_ui.success.assert_any_call('Agentic generation for suggestion #1 completed successfully.')
+  from unittest.mock import ANY
+
+  jinja_env.get_template.return_value.render.assert_called_with(
+    test_suggestion_xml_block=ANY,
+    is_interactive=False,
+  )
 
 
 @pytest.mark.asyncio
@@ -722,3 +728,10 @@ async def test_run_test_generation_agentic_interactive(
   else:
     assert kwargs['stdout'] is None
     assert kwargs['stderr'] is None
+
+  from unittest.mock import ANY
+
+  jinja_env.get_template.return_value.render.assert_called_with(
+    test_suggestion_xml_block=ANY,
+    is_interactive=True,
+  )

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -47,3 +47,20 @@ def test_chromestatus_coverage_audit_system_template_brief() -> None:
   assert '<pre_conditions>' in rendered_full
   assert '<steps>' in rendered_full
   assert '<expected_result>' in rendered_full
+
+
+def test_agentic_test_generation_template_interactive() -> None:
+  env = Environment(loader=FileSystemLoader('wptgen/templates'))
+  template = env.get_template('agentic_test_generation.jinja')
+
+  # Test with is_interactive=True
+  rendered_interactive = template.render(
+    is_interactive=True, test_suggestion_xml_block='<test></test>'
+  )
+  assert 'safely close the Gemini CLI now' in rendered_interactive
+
+  # Test with is_interactive=False
+  rendered_non_interactive = template.render(
+    is_interactive=False, test_suggestion_xml_block='<test></test>'
+  )
+  assert 'safely close the Gemini CLI now' not in rendered_non_interactive

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -220,7 +220,10 @@ async def _generate_agentic_loop(
       suggestion_xml, context.feature_id, spec_urls, sanitize=True
     )
 
-    prompt = agentic_template.render(test_suggestion_xml_block=modified_xml)
+    prompt = agentic_template.render(
+      test_suggestion_xml_block=modified_xml,
+      is_interactive=not config.agentic_yolo,
+    )
 
     if config.agentic_yolo:
       # Use bash -ic to force an interactive shell so it loads aliases/nvm.

--- a/wptgen/templates/agentic_test_generation.jinja
+++ b/wptgen/templates/agentic_test_generation.jinja
@@ -1,3 +1,7 @@
 Use the wpt-generator skill to generate the following test. Rigorously follow all instructions in the skill.
 
 {{ test_suggestion_xml_block }}
+{% if is_interactive %}
+
+When you have finished generating the test and completing your tasks, explicitly tell the user that they can safely close the Gemini CLI now to continue the WPT-Gen process.
+{%- endif %}


### PR DESCRIPTION
Resolves #282

## Overview
This PR updates the agentic generation process to instruct the Gemini CLI to explicitly prompt the user to safely exit when running in interactive mode.

## Root Cause / Motivation
When `wpt-gen` runs with the `--agentic-generation` flag without `--agentic-yolo`, it launches the Gemini CLI interactively. Because it runs interactively, the process halts and waits for the user to manually exit, which stalls the workflow if the user does not realize they need to close the CLI. Adding an explicit system instruction ensures the user is informed about the next steps and can seamlessly continue the WPT-Gen process.

## Detailed Changelog
* **`wptgen/phases/generation.py`**: Updated `_generate_agentic_loop` to pass the `is_interactive` boolean (derived from `not config.agentic_yolo`) into the template renderer.
* **`wptgen/templates/agentic_test_generation.jinja`**: Modified the template to conditionally append a sign-off instruction when `is_interactive` is true.
* **`tests/test_phases.py`**: Updated `test_run_test_generation_agentic` and `test_run_test_generation_agentic_interactive` to assert the correct `is_interactive` arguments are used during template rendering.
* **`tests/test_templates.py`**: Added a new unit test `test_agentic_test_generation_template_interactive` to explicitly cover the new Jinja template rendering logic.
