### PR TITLE
use ChromeStatusMetadata for ChromeStatus metadata extraction

### DIFF
--- a/tests/test_chromestatus.py
+++ b/tests/test_chromestatus.py
@@ -74,6 +74,7 @@ def test_extract_chromestatus_metadata_basic() -> None:
   assert metadata.name == 'Feature Name'
   assert metadata.description == 'Feature Summary'
   assert metadata.specs == ['https://example.com/spec']
+  assert metadata.explainer == []
 
 
 def test_extract_chromestatus_metadata_with_explainers() -> None:
@@ -89,9 +90,9 @@ def test_extract_chromestatus_metadata_with_explainers() -> None:
   assert metadata.name == 'Feature Name'
   assert 'Explainers:' in metadata.description
   assert 'https://example.com/explainer' in metadata.description
-  # specs should include both std spec and explainer
-  assert 'https://example.com/std_spec' in metadata.specs
-  assert 'https://example.com/explainer' in metadata.specs
+  # specs should be mapped to spec_url and explainer
+  assert metadata.specs == ['https://example.com/std_spec']
+  assert metadata.explainer == ['https://example.com/explainer']
 
 
 def test_extract_wpt_paths_from_descr_urls() -> None:

--- a/tests/test_chromestatus.py
+++ b/tests/test_chromestatus.py
@@ -88,10 +88,9 @@ def test_extract_chromestatus_metadata_with_explainers() -> None:
   metadata = extract_chromestatus_metadata(data)
 
   assert metadata.name == 'Feature Name'
-  assert 'Explainers:' in metadata.description
-  assert 'https://example.com/explainer' in metadata.description
+  assert metadata.description == 'Summary'
   # specs should be mapped to spec_url and explainer
-  assert metadata.specs == ['https://example.com/std_spec']
+  assert metadata.specs == []
   assert metadata.explainer == ['https://example.com/explainer']
 
 

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -24,10 +24,11 @@ import markdownify
 import yaml
 from bs4 import BeautifulSoup
 
-from wptgen.models import WebFeatureMetadata, WPTContext
+from wptgen.models import ChromeStatusMetadata, WebFeatureMetadata, WPTContext
 
 __all__ = [
   'WebFeatureMetadata',
+  'ChromeStatusMetadata',
   'WPTContext',
   'fetch_chromestatus_feature',
   'extract_chromestatus_metadata',
@@ -152,12 +153,12 @@ def extract_feature_metadata(feature_data: dict[str, Any]) -> WebFeatureMetadata
   )
 
 
-def extract_chromestatus_metadata(feature_data: dict[str, Any]) -> WebFeatureMetadata:
+def extract_chromestatus_metadata(feature_data: dict[str, Any]) -> ChromeStatusMetadata:
   """
   Extracts the high-level metadata (name and description) from ChromeStatus feature data.
 
   Returns:
-    WebFeatureMetadata object containing important feature metadata.
+    ChromeStatusMetadata object containing important feature metadata.
   """
   name = str(feature_data.get('name', 'Unknown Feature'))
   summary = str(feature_data.get('summary', ''))
@@ -166,34 +167,15 @@ def extract_chromestatus_metadata(feature_data: dict[str, Any]) -> WebFeatureMet
   if not isinstance(explainers, list):
     explainers = []
 
-  explainer_str = ''
-  if explainers:
-    explainer_str = '\n\nExplainers:\n' + '\n'.join(explainers)
+  # Extract the spec_link
+  spec_url = feature_data.get('spec_link') or ''
 
-  description = f'{summary}{explainer_str}'.strip()
-
-  specs = []
-  # Check spec_link first
-  spec_link = feature_data.get('spec_link')
-  if spec_link:
-    specs.append(spec_link)
-
-  # Check standards.spec
-  standards = feature_data.get('standards', {})
-  if isinstance(standards, dict):
-    std_spec = standards.get('spec')
-    if std_spec and std_spec not in specs:
-      specs.append(std_spec)
-
-  # Include explainers as "specs" so they get fetched for context
-  for ex in explainers:
-    if ex and ex not in specs:
-      specs.append(ex)
-
-  return WebFeatureMetadata(
+  return ChromeStatusMetadata(
     name=name,
-    description=description,
-    specs=specs,
+    description=summary,
+    specs=[spec_url] if spec_url else [],
+    explainer=explainers,
+    wpt_tests=wpt_tests,
   )
 
 

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -170,6 +170,10 @@ def extract_chromestatus_metadata(feature_data: dict[str, Any]) -> ChromeStatusM
   # Extract the spec_link
   spec_url = feature_data.get('spec_link') or ''
 
+  # Extract WPT paths
+  wpt_descr = feature_data.get('wpt_descr', '')
+  wpt_tests = extract_wpt_paths_from_descr(wpt_descr)
+
   return ChromeStatusMetadata(
     name=name,
     description=summary,

--- a/wptgen/models.py
+++ b/wptgen/models.py
@@ -70,6 +70,23 @@ class WebFeatureMetadata:
 
 
 @dataclass
+class ChromeStatusMetadata:
+  is_chromestatus: bool = True
+  name: str
+  description: str
+  specs: list[str]
+  explainer: list[str]
+  wpt_tests: list[str]
+
+  def to_dict(self) -> dict[str, Any]:
+    return asdict(self)
+
+  @classmethod
+  def from_dict(cls, data: dict[str, Any]) -> 'ChromeStatusMetadata':
+    return cls(**data)
+
+
+@dataclass
 class WPTContext:
   """Holds the results of a local WPT content and dependency fetch operation."""
 
@@ -96,8 +113,9 @@ class WorkflowContext:
   """Maintains the state of the WPT generation workflow."""
 
   feature_id: str
-  metadata: WebFeatureMetadata | None = None
+  metadata: WebFeatureMetadata | ChromeStatusMetadata | None = None
   spec_contents: dict[str, str] | None = None
+  explainer_contents: dict[str, str] | None = None
   wpt_context: WPTContext | None = None
   requirements_xml: str | None = None
   audit_response: str | None = None
@@ -111,6 +129,7 @@ class WorkflowContext:
       'feature_id': self.feature_id,
       'metadata': self.metadata.to_dict() if self.metadata else None,
       'spec_contents': self.spec_contents,
+      'explainer_contents': self.explainer_contents,
       'wpt_context': self.wpt_context.to_dict() if self.wpt_context else None,
       'requirements_xml': self.requirements_xml,
       'audit_response': self.audit_response,
@@ -125,7 +144,14 @@ class WorkflowContext:
 
   @classmethod
   def from_dict(cls, data: dict[str, Any]) -> 'WorkflowContext':
-    metadata = WebFeatureMetadata.from_dict(data['metadata']) if data.get('metadata') else None
+    metadata_data = data.get('metadata')
+    metadata: WebFeatureMetadata | ChromeStatusMetadata | None = None
+    if metadata_data:
+      if 'is_chromestatus' in metadata_data:
+        metadata = ChromeStatusMetadata.from_dict(metadata_data)
+      else:
+        metadata = WebFeatureMetadata.from_dict(metadata_data)
+
     wpt_context = WPTContext.from_dict(data['wpt_context']) if data.get('wpt_context') else None
     generated_tests = None
     if data.get('generated_tests'):

--- a/wptgen/models.py
+++ b/wptgen/models.py
@@ -71,12 +71,12 @@ class WebFeatureMetadata:
 
 @dataclass
 class ChromeStatusMetadata:
-  is_chromestatus: bool = True
   name: str
   description: str
   specs: list[str]
   explainer: list[str]
   wpt_tests: list[str]
+  is_chromestatus: bool = True
 
   def to_dict(self) -> dict[str, Any]:
     return asdict(self)
@@ -167,6 +167,7 @@ class WorkflowContext:
       feature_id=data['feature_id'],
       metadata=metadata,
       spec_contents=spec_contents,
+      explainer_contents=data.get('explainer_contents'),
       wpt_context=wpt_context,
       requirements_xml=data.get('requirements_xml'),
       audit_response=data.get('audit_response'),

--- a/wptgen/phases/context_assembly.py
+++ b/wptgen/phases/context_assembly.py
@@ -126,16 +126,16 @@ async def run_chromestatus_context_assembly(
   # Override with CLI options if provided
   # TODO: consider chromestatus only using one spec url
   if config.spec_urls:
-    metadata.spec_url = config.spec_urls[0]
+    metadata.specs = [config.spec_urls[0]]
   if config.feature_description:
     metadata.description = config.feature_description
 
-  if not metadata.spec_url:
+  if not metadata.specs or not metadata.specs[0]:
     ui.error('No specification URL found in ChromeStatus data.')
     return None
 
   # Detailed resource discovery logging
-  found_specs = {metadata.spec_url} if metadata.spec_url else set()
+  found_specs = {metadata.specs[0]} if metadata.specs else set()
 
   explainers = metadata.explainer
   raw_test_paths = metadata.wpt_tests
@@ -148,12 +148,26 @@ async def run_chromestatus_context_assembly(
 
   ui.report_metadata(metadata)
 
-  ui.print('\nFetching spec content...')
+  ui.print('\nFetching spec and explainer content...')
+
+  spec_url = metadata.specs[0] if metadata.specs else None
+  all_urls = [spec_url] if spec_url else []
+  all_urls.extend(explainers)
+  all_urls = [url for url in all_urls if url]  # Ensure no empty strings
+
   with ui.status('Fetching and extracting text...'):
     results = await asyncio.gather(
-      *[asyncio.to_thread(fetch_and_extract_text, url) for url in metadata.specs]
+      *[asyncio.to_thread(fetch_and_extract_text, url) for url in all_urls]
     )
-    spec_contents = {url: res for url, res in zip(metadata.specs, results, strict=True) if res}
+
+  spec_contents = {}
+  explainer_contents = {}
+  for url, res in zip(all_urls, results, strict=True):
+    if res:
+      if url == spec_url:
+        spec_contents[url] = res
+      elif url in explainers:
+        explainer_contents[url] = res
 
   if not spec_contents:
     ui.error('Failed to extract spec content.')
@@ -196,5 +210,5 @@ async def run_chromestatus_context_assembly(
     spec_contents=spec_contents,
     mdn_contents=None,  # MDN docs are not used in ChromeStatus workflow
     wpt_context=wpt_context,
-    explainer_contents=explainers
+    explainer_contents=explainer_contents,
   )

--- a/wptgen/phases/context_assembly.py
+++ b/wptgen/phases/context_assembly.py
@@ -20,7 +20,6 @@ from wptgen.context import (
   WebFeatureMetadata,
   extract_chromestatus_metadata,
   extract_feature_metadata,
-  extract_wpt_paths_from_descr,
   fetch_and_extract_text,
   fetch_chromestatus_feature,
   fetch_feature_yaml,
@@ -125,30 +124,21 @@ async def run_chromestatus_context_assembly(
   metadata = extract_chromestatus_metadata(feature_data)
 
   # Override with CLI options if provided
+  # TODO: consider chromestatus only using one spec url
   if config.spec_urls:
-    metadata.specs = config.spec_urls
+    metadata.spec_url = config.spec_urls[0]
   if config.feature_description:
     metadata.description = config.feature_description
 
-  if not metadata.specs:
+  if not metadata.spec_url:
     ui.error('No specification URL found in ChromeStatus data.')
     return None
 
   # Detailed resource discovery logging
-  spec_link = feature_data.get('spec_link')
-  standards_spec = (
-    feature_data.get('standards', {}).get('spec')
-    if isinstance(feature_data.get('standards'), dict)
-    else None
-  )
-  found_specs = {s for s in [spec_link, standards_spec] if s}
+  found_specs = {metadata.spec_url} if metadata.spec_url else set()
 
-  explainers = feature_data.get('explainer_links', [])
-  if not isinstance(explainers, list):
-    explainers = []
-
-  wpt_descr = feature_data.get('wpt_descr', '')
-  raw_test_paths = extract_wpt_paths_from_descr(wpt_descr)
+  explainers = metadata.explainer
+  raw_test_paths = metadata.wpt_tests
 
   ui.print(
     f'Found [cyan]{len(found_specs)}[/cyan] spec links, '
@@ -169,24 +159,21 @@ async def run_chromestatus_context_assembly(
     ui.error('Failed to extract spec content.')
     return None
 
-  # Use wpt_descr to find existing tests
-  wpt_descr = feature_data.get('wpt_descr', '')
+  # Use wpt_tests to find existing tests
   test_paths = []
-  if wpt_descr:
+  if raw_test_paths:
     ui.print("Extracting existing test paths from 'wpt_descr'...")
-    raw_paths = extract_wpt_paths_from_descr(wpt_descr)
-    if raw_paths:
-      ui.print(f"Found {len(raw_paths)} test references in 'wpt_descr'.")
-      for rp in raw_paths:
-        local_path = Path(config.wpt_path) / rp.lstrip('/')
-        if local_path.exists():
-          if local_path.is_file():
-            test_paths.append(str(local_path))
-          elif local_path.is_dir():
-            # If it's a directory, include all files inside
-            test_paths.extend([str(f) for f in local_path.rglob('*') if f.is_file()])
-    else:
-      ui.print("No test references found in 'wpt_descr'.")
+    ui.print(f"Found {len(raw_test_paths)} test references in 'wpt_descr'.")
+    for rp in raw_test_paths:
+      local_path = Path(config.wpt_path) / rp.lstrip('/')
+      if local_path.exists():
+        if local_path.is_file():
+          test_paths.append(str(local_path))
+        elif local_path.is_dir():
+          # If it's a directory, include all files inside
+          test_paths.extend([str(f) for f in local_path.rglob('*') if f.is_file()])
+  else:
+    ui.print("No test references found in 'wpt_descr'.")
 
   if test_paths:
     ui.print(f'Gathering context for {len(test_paths)} local WPT test files...')
@@ -209,4 +196,5 @@ async def run_chromestatus_context_assembly(
     spec_contents=spec_contents,
     mdn_contents=None,  # MDN docs are not used in ChromeStatus workflow
     wpt_context=wpt_context,
+    explainer_contents=explainers
   )

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -179,6 +179,10 @@ class RichUIProvider:
     metadata_table.add_row('[bold]Description:[/bold]', metadata.description)
     metadata_table.add_row('[bold]Spec URL:[/bold]', f'[blue]{metadata.specs[0]}[/blue]')
 
+    if hasattr(metadata, 'explainer') and metadata.explainer:
+      explainer_links = '\n'.join([f'[blue]{link}[/blue]' for link in metadata.explainer])
+      metadata_table.add_row('[bold]Explainers:[/bold]', explainer_links)
+
     self.console.print(
       Panel(
         metadata_table,

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -32,7 +32,7 @@ from rich.table import Table
 from wptgen.utils import parse_multi_file_response
 
 if TYPE_CHECKING:
-  from wptgen.models import WebFeatureMetadata
+  from wptgen.models import ChromeStatusMetadata, WebFeatureMetadata
 
 
 class ProgressIndicator(Protocol):
@@ -65,7 +65,7 @@ class UIProvider(Protocol):
   def on_phase_complete(self, phase_name: str) -> None: ...
 
   # Domain-specific reporting
-  def report_metadata(self, metadata: WebFeatureMetadata) -> None: ...
+  def report_metadata(self, metadata: WebFeatureMetadata | ChromeStatusMetadata) -> None: ...
   def report_context_summary(
     self, spec_len: int, mdn_count: int, test_count: int, dep_count: int
   ) -> None: ...
@@ -173,7 +173,7 @@ class RichUIProvider:
   def on_phase_complete(self, phase_name: str) -> None:
     self.success(f'{phase_name} complete.')
 
-  def report_metadata(self, metadata: WebFeatureMetadata) -> None:
+  def report_metadata(self, metadata: WebFeatureMetadata | ChromeStatusMetadata) -> None:
     metadata_table = Table(show_header=False, box=None, padding=(0, 2))
     metadata_table.add_row('[bold]Web Feature Name:[/bold]', f'[cyan]{metadata.name}[/cyan]')
     metadata_table.add_row('[bold]Description:[/bold]', metadata.description)


### PR DESCRIPTION
New Data Model: Added ChromeStatusMetadata in [wptgen/models.py](https://github.com/GoogleChromeLabs/wpt-gen/pull/284/changes#diff-24dde47de6f91d18c7c924493d14f9436f2c124ba0f59efd3992ebac9ac0749b) to explicitly track explainer links and wpt_tests paths.

Improved Extraction: Updated extract_chromestatus_metadata in [wptgen/context.py](https://github.com/GoogleChromeLabs/wpt-gen/pull/284/changes#diff-d5c63f3b837bf411d7027516ce28f0d8ade3a0d0a2c64b408926c56d1f7b9400) to map ChromeStatus-specific fields (like spec_link and wpt_descr) directly to the new model.

Context Assembly: Refactored [wptgen/phases/context_assembly.py](https://github.com/GoogleChromeLabs/wpt-gen/pull/284/changes#diff-52f928adc9a02e5000f187b7f9b787d46224c5a81442675f0efd733116b09428) to fetch content for both specifications and explainers concurrently, ensuring more comprehensive context for WPT generation.

Testing: Updated [tests/test_chromestatus.py](https://github.com/GoogleChromeLabs/wpt-gen/pull/284/changes#diff-6c11e18951e84dc758e33b2f94dc2a73670eb05facfe6d4e84f1400518519862) to verify that explainers and spec URLs are correctly isolated and stored.