### PR TITLE
Fix: Ensure Coverage Audit Uses Brief Suggestions Rendering in Agentic Generation Mode

### DIFF
--- a/tests/test_coverage_audit.py
+++ b/tests/test_coverage_audit.py
@@ -199,3 +199,48 @@ async def test_provide_coverage_report_save_success(
   await provide_coverage_report(context, mock_config, mock_ui)
 
   mock_ui.success.assert_called_with(f'Saved: {(tmp_path / "test_coverage_audit.md").absolute()}')
+
+
+@pytest.mark.asyncio
+async def test_run_coverage_audit_agentic_generation_brief_suggestions(
+  mocker: MagicMock, mock_config: Config, mock_ui: MagicMock
+) -> None:
+  wpt_context = WPTContext()
+  context = WorkflowContext(
+    feature_id='test',
+    requirements_xml='<requirements><requirement id="R1">Test</requirement></requirements>',
+    wpt_context=wpt_context,
+  )
+
+  mock_config.agentic_generation = True
+  mock_config.brief_suggestions = False
+
+  mock_llm = MagicMock()
+  mock_llm.prompt_exceeds_input_token_limit.return_value = False
+
+  jinja_env = MagicMock(spec=Environment)
+
+  audit_template_mock = MagicMock()
+  audit_template_mock.render.return_value = 'Audit Prompt'
+
+  system_template_mock = MagicMock()
+  system_template_mock.render.return_value = 'System Prompt'
+
+  def mock_get_template(name: str) -> MagicMock:
+    if name == 'coverage_audit.jinja':
+      return audit_template_mock
+    elif name == 'coverage_audit_system.jinja':
+      return system_template_mock
+    return MagicMock()
+
+  jinja_env.get_template.side_effect = mock_get_template
+
+  mocker.patch('wptgen.phases.coverage_audit.confirm_prompts')
+  mocker.patch(
+    'wptgen.phases.coverage_audit.generate_safe',
+    return_value='<status>SATISFIED</status>\n<audit_worksheet>W1</audit_worksheet>',
+  )
+
+  await run_coverage_audit(context, mock_config, mock_llm, mock_ui, jinja_env)
+
+  system_template_mock.render.assert_called_once_with(brief_suggestions=True, spec_urls=[])

--- a/wptgen/phases/coverage_audit.py
+++ b/wptgen/phases/coverage_audit.py
@@ -115,7 +115,7 @@ async def run_coverage_audit(
   spec_urls = context.metadata.specs if context.metadata and context.metadata.specs else []
 
   audit_system_prompt = jinja_env.get_template('coverage_audit_system.jinja').render(
-    brief_suggestions=config.brief_suggestions, spec_urls=spec_urls
+    brief_suggestions=(config.brief_suggestions or config.agentic_generation), spec_urls=spec_urls
   )
 
   await confirm_prompts(


### PR DESCRIPTION
Resolves #285

## Overview
This PR ensures that the test generation process leverages the brief version of the coverage audit response when the `--agentic-generation` or `--agentic-yolo` flags are active.

## Root Cause / Motivation
Currently, in `wptgen/engine.py`, the `brief_suggestions` flag is used as a terminal condition to skip Phase 4 (Test Generation) entirely. We cannot simply set the `--brief-suggestions` flag programmatically when agentic mode is active because it would skip test generation. This PR ensures that the `coverage_audit_system.jinja` template explicitly renders brief suggestions during the agentic process without tripping the skip condition in the engine workflow.

## Detailed Changelog
* **`wptgen/phases/coverage_audit.py`**: Updated the `run_coverage_audit` function to pass `brief_suggestions=(config.brief_suggestions or config.agentic_generation)` into the `coverage_audit_system.jinja` template.
* **`tests/test_coverage_audit.py`**: Added `test_run_coverage_audit_agentic_generation_brief_suggestions` to verify that the brief version of the system prompt is used when `agentic_generation` is True.
