### PR TITLE
feat: Add Google ADK dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
     # Core LLM Integration
+    "google-adk>=1.27.2",
     "google-genai>=1.62.0",
     "openai>=2.20.0",
     "anthropic>=0.84.0",


### PR DESCRIPTION
Resolves #294

## Overview
Adds the official `google-adk` package (version `>=1.27.2`) to the project dependencies.

## Root Cause / Motivation
This establishes the underlying infrastructure required for Epic #293 (Utilize Agent Development Kit for Test Generation Process). By adding this dependency, we can begin building `Agent` instances and workflow tools in subsequent tasks without risking conflicts with existing tools.

## Detailed Changelog
* **`pyproject.toml`**: Appended `"google-adk>=1.27.2"` to the core dependencies block to enable ADK integrations within the virtual environment.
