### PR TITLE
fix: explicitly isolate and reset ADK context windows across tests

### DIFF
--- a/tests/agents/test_adk_test_generator.py
+++ b/tests/agents/test_adk_test_generator.py
@@ -39,6 +39,7 @@ async def test_generate_test_with_adk(tmp_path: Path, mocker: MagicMock) -> None
   # Mock the ADK Runner to simulate the agent calling the completion tool
   mock_runner_cls = mocker.patch('wptgen.agents.adk_test_generator.Runner')
   mock_runner_instance = mock_runner_cls.return_value
+  mock_runner_instance.close = mocker.AsyncMock()
 
   async def mock_run_async(*args: Any, **kwargs: Any) -> Any:
     # In actual ADK, the tools are attached to the agent which is passed to Runner

--- a/wptgen/agents/adk_test_generator.py
+++ b/wptgen/agents/adk_test_generator.py
@@ -94,8 +94,10 @@ async def generate_test_with_adk(
     if var_name.isidentifier():
       adk_state[var_name] = match.group(0)
 
+  # Ensure the agent name is a valid Python identifier to avoid validation errors.
+  safe_root_name = root_name.replace('-', '_').replace('.', '_')
   agent_kwargs: dict[str, Any] = {
-    'name': 'wpt_generator',
+    'name': f'wpt_generator_{safe_root_name}',
     'model': model_string,
     'instruction': instruction,
     'tools': list(tools),
@@ -137,25 +139,32 @@ async def generate_test_with_adk(
   )
   content = types.Content(role='user', parts=[types.Part(text=prompt)])
 
-  events = runner.run_async(session_id=session.id, user_id='cli_user', new_message=content)
+  try:
+    events = runner.run_async(session_id=session.id, user_id='cli_user', new_message=content)
 
-  # We just consume the stream to let the agent run.
-  with ADKStreamManager(ui) as stream_manager:
-    async for event in events:
-      stream_manager.process_event(event)
+    # We just consume the stream to let the agent run.
+    with ADKStreamManager(ui) as stream_manager:
+      async for event in events:
+        stream_manager.process_event(event)
 
-  results = []
-  # If the agent correctly called the completion tool, we read those files back
-  for path_str in generated_paths:
-    try:
-      target_path = Path(path_str)
-      # Ensure it is absolutely relative to wpt_root
-      target_path = _validate_safe_path(target_path, wpt_root)
+    results = []
+    # If the agent correctly called the completion tool, we read those files back
+    for path_str in generated_paths:
+      try:
+        target_path = Path(path_str)
+        # Ensure it is absolutely relative to wpt_root
+        target_path = _validate_safe_path(target_path, wpt_root)
 
-      if target_path.is_file():
-        file_content = target_path.read_text(encoding='utf-8')
-        results.append((target_path, file_content, suggestion_xml))
-    except (ValueError, OSError) as e:
-      ui.error(f"Failed to read securely generated file '{path_str}': {e}")
+        if target_path.is_file():
+          file_content = target_path.read_text(encoding='utf-8')
+          results.append((target_path, file_content, suggestion_xml))
+      except (ValueError, OSError) as e:
+        ui.error(f"Failed to read securely generated file '{path_str}': {e}")
 
-  return results
+    return results
+
+  finally:
+    await runner.close()  # type: ignore[no-untyped-call]
+    await session_service.delete_session(
+      app_name='wpt-gen', user_id='cli_user', session_id=session.id
+    )


### PR DESCRIPTION
## Description
This pull request ensures that the context window is not maintained from one test generation to another when running `--generator adk`.

By default, an Agent Development Kit (ADK) `Agent` and `Runner` are designed to be long-lived, stateless engines where conversation history is exclusively tied to the `Session`. 

However, because the ADK `report_generation_complete` tool currently relies on a local Python closure variable (`generated_paths`) to capture the generated files, reusing a single `Agent` and `Runner` across multiple tests would reuse that single tool instance. This risks either accumulating files from previous tests or creating race conditions if tests were ever generated concurrently.

**The Pragmatic Solution**
To provide bulletproof state isolation without rewriting how the ADK tool returns data or inspecting the event stream manually, this PR implements the following safety measures:
1. **Unique Agent Names:** ADK agents use Pydantic models. To prevent ADK from incorrectly caching or tracking an agent by name internally, the current test's `root_name` is appended to the agent's name (and normalized to pass Pydantic's identifier validation).
2. **Explicit Session Deletion:** Although `InMemorySessionService` is instantiated freshly per test, explicitly calling `await session_service.delete_session(...)` inside a `finally` block ensures that any internally tracked state for the session is wiped out immediately.
3. **Closing the Runner:** Added `await runner.close()` to the `finally` block to ensure all Toolsets, plugins, background queues, and any LLM connections tied to that test's Runner are properly terminated.

This ensures 100% isolation for both the LLM's context window and local Python state.

## Stacked PR
This branch is based on the `feat/adk-streaming-and-ux` branch as requested.
