### PR TITLE
feat: Remove legacy Gemini CLI subprocess logic and configuration flags

### DIFF
--- a/tests/test_coverage_audit.py
+++ b/tests/test_coverage_audit.py
@@ -202,7 +202,7 @@ async def test_provide_coverage_report_save_success(
 
 
 @pytest.mark.asyncio
-async def test_run_coverage_audit_agentic_generation_brief_suggestions(
+async def test_run_coverage_audit_always_brief_suggestions(
   mocker: MagicMock, mock_config: Config, mock_ui: MagicMock
 ) -> None:
   wpt_context = WPTContext()
@@ -212,8 +212,7 @@ async def test_run_coverage_audit_agentic_generation_brief_suggestions(
     wpt_context=wpt_context,
   )
 
-  mock_config.agentic_generation = True
-  mock_config.brief_suggestions = False
+  mock_config.brief_suggestions = True
 
   mock_llm = MagicMock()
   mock_llm.prompt_exceeds_input_token_limit.return_value = False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -105,8 +105,6 @@ def test_generate_success(mocker: MockerFixture, mock_config: Config) -> None:
     single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
-    agentic_generation_override=False,
-    agentic_yolo_override=False,
     tentative_override=False,
     save_traces_override=False,
     max_parallel_requests_override=None,
@@ -152,8 +150,6 @@ def test_generate_show_responses(mocker: MockerFixture, mock_config: Config) -> 
     single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
-    agentic_generation_override=False,
-    agentic_yolo_override=False,
     tentative_override=False,
     save_traces_override=False,
     max_parallel_requests_override=None,
@@ -195,8 +191,6 @@ def test_generate_yes_tokens(mocker: MockerFixture, mock_config: Config) -> None
     single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
-    agentic_generation_override=False,
-    agentic_yolo_override=False,
     tentative_override=False,
     save_traces_override=False,
     max_parallel_requests_override=None,
@@ -238,8 +232,6 @@ def test_generate_suggestions_only(mocker: MockerFixture, mock_config: Config) -
     single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
-    agentic_generation_override=False,
-    agentic_yolo_override=False,
     tentative_override=False,
     save_traces_override=False,
     max_parallel_requests_override=None,
@@ -281,8 +273,6 @@ def test_generate_max_retries(mocker: MockerFixture, mock_config: Config) -> Non
     single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
-    agentic_generation_override=False,
-    agentic_yolo_override=False,
     tentative_override=False,
     save_traces_override=False,
     max_parallel_requests_override=None,
@@ -324,8 +314,6 @@ def test_generate_detailed_requirements(mocker: MockerFixture, mock_config: Conf
     single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
-    agentic_generation_override=False,
-    agentic_yolo_override=False,
     tentative_override=False,
     save_traces_override=False,
     max_parallel_requests_override=None,
@@ -398,8 +386,6 @@ def test_generate_spec_urls(mocker: MockerFixture, mock_config: Config) -> None:
     single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
-    agentic_generation_override=False,
-    agentic_yolo_override=False,
     tentative_override=False,
     save_traces_override=False,
     max_parallel_requests_override=None,
@@ -441,8 +427,6 @@ def test_generate_description(mocker: MockerFixture, mock_config: Config) -> Non
     single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
-    agentic_generation_override=False,
-    agentic_yolo_override=False,
     tentative_override=False,
     save_traces_override=False,
     max_parallel_requests_override=None,
@@ -484,8 +468,6 @@ def test_generate_resume(mocker: MockerFixture, mock_config: Config) -> None:
     single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
-    agentic_generation_override=False,
-    agentic_yolo_override=False,
     tentative_override=False,
     save_traces_override=False,
     max_parallel_requests_override=None,
@@ -527,8 +509,6 @@ def test_generate_use_lightweight(mocker: MockerFixture, mock_config: Config) ->
     single_prompt_requirements_override=False,
     use_lightweight_override=True,
     use_reasoning_override=False,
-    agentic_generation_override=False,
-    agentic_yolo_override=False,
     tentative_override=False,
     save_traces_override=False,
     max_parallel_requests_override=None,
@@ -570,8 +550,6 @@ def test_generate_use_reasoning(mocker: MockerFixture, mock_config: Config) -> N
     single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=True,
-    agentic_generation_override=False,
-    agentic_yolo_override=False,
     tentative_override=False,
     save_traces_override=False,
     max_parallel_requests_override=None,
@@ -613,8 +591,6 @@ def test_generate_single_prompt_requirements(mocker: MockerFixture, mock_config:
     single_prompt_requirements_override=True,
     use_lightweight_override=False,
     use_reasoning_override=False,
-    agentic_generation_override=False,
-    agentic_yolo_override=False,
     tentative_override=False,
     save_traces_override=False,
     max_parallel_requests_override=None,
@@ -656,8 +632,6 @@ def test_generate_max_parallel_requests(mocker: MockerFixture, mock_config: Conf
     single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
-    agentic_generation_override=False,
-    agentic_yolo_override=False,
     tentative_override=False,
     save_traces_override=False,
     max_parallel_requests_override=5,
@@ -969,8 +943,6 @@ def test_generate_draft(mocker: MockerFixture, mock_config: Config) -> None:
     single_prompt_requirements_override=False,
     use_lightweight_override=False,
     use_reasoning_override=False,
-    agentic_generation_override=False,
-    agentic_yolo_override=False,
     tentative_override=False,
     save_traces_override=False,
     max_parallel_requests_override=None,
@@ -1061,90 +1033,6 @@ def test_config_set_command_types(mocker: MockerFixture) -> None:
     assert data['timeout'] == 120
     assert data['show_responses'] is True
     assert data['temperature'] == 0.5
-
-
-def test_generate_agentic_generation(mocker: MockerFixture, mock_config: Config) -> None:
-  """Test that the --agentic-generation flag is correctly passed to load_config."""
-  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
-  mocker.patch('wptgen.main.WPTGenEngine')
-
-  # Run with --agentic-generation
-  result = runner.invoke(app, ['generate', 'grid', '--agentic-generation'])
-  assert result.exit_code == 0
-  mock_load_config.assert_called_with(
-    config_path=DEFAULT_CONFIG_PATH,
-    provider_override=None,
-    wpt_dir_override=None,
-    output_dir_override=None,
-    show_responses=False,
-    yes_tokens_override=False,
-    yes_tests_override=False,
-    yes_cache_override=False,
-    no_cache_override=False,
-    suggestions_only=False,
-    brief_suggestions=False,
-    resume_override=False,
-    resume_from_override=None,
-    state_dir_override=None,
-    max_retries_override=3,
-    timeout_override=600,
-    spec_urls_override=None,
-    feature_description_override=None,
-    detailed_requirements_override=False,
-    draft_override=False,
-    single_prompt_requirements_override=False,
-    use_lightweight_override=False,
-    use_reasoning_override=False,
-    agentic_generation_override=True,
-    agentic_yolo_override=False,
-    tentative_override=False,
-    save_traces_override=False,
-    max_parallel_requests_override=None,
-    temperature_override=None,
-    include_thoughts_override=False,
-  )
-
-
-def test_generate_agentic_yolo(mocker: MockerFixture, mock_config: Config) -> None:
-  """Test that the --agentic-yolo flag is correctly passed to load_config."""
-  mock_load_config = mocker.patch('wptgen.main.load_config', return_value=mock_config)
-  mocker.patch('wptgen.main.WPTGenEngine')
-
-  # Run with --agentic-yolo
-  result = runner.invoke(app, ['generate', 'grid', '--agentic-yolo'])
-  assert result.exit_code == 0
-  mock_load_config.assert_called_with(
-    config_path=DEFAULT_CONFIG_PATH,
-    provider_override=None,
-    wpt_dir_override=None,
-    output_dir_override=None,
-    show_responses=False,
-    yes_tokens_override=False,
-    yes_tests_override=False,
-    yes_cache_override=False,
-    no_cache_override=False,
-    suggestions_only=False,
-    brief_suggestions=False,
-    resume_override=False,
-    resume_from_override=None,
-    state_dir_override=None,
-    max_retries_override=3,
-    timeout_override=600,
-    spec_urls_override=None,
-    feature_description_override=None,
-    detailed_requirements_override=False,
-    draft_override=False,
-    single_prompt_requirements_override=False,
-    use_lightweight_override=False,
-    use_reasoning_override=False,
-    agentic_generation_override=False,
-    agentic_yolo_override=True,
-    tentative_override=False,
-    save_traces_override=False,
-    max_parallel_requests_override=None,
-    temperature_override=None,
-    include_thoughts_override=False,
-  )
 
 
 def test_generate_brief_suggestions(mocker: MockerFixture, mock_config: Config) -> None:

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import re
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -536,73 +535,6 @@ async def test_run_test_generation_none_selected(
   mock_ui.warning.assert_any_call('No tests selected. Exiting.')
 
 
-@pytest.mark.asyncio
-async def test_run_test_generation_agentic(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock
-) -> None:
-  """Test that agentic generation uses subprocess to call gemini."""
-  mock_config.agentic_generation = True
-  mock_config.agentic_yolo = True
-  mock_config.wpt_path = '/mock/wpt'
-  suggestion_xml = (
-    '<test_suggestion><title>T1</title><description>D1</description></test_suggestion>'
-  )
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=FeatureMetadata('Feat', 'Desc', ['http://spec']),
-    audit_response=suggestion_xml,
-  )
-  jinja_env = MagicMock()
-  jinja_env.get_template.return_value.render.return_value = 'Use the wpt-generator skill to generate the following test\n<web_feature_id>feat</web_feature_id>'
-
-  mock_ui.confirm.return_value = True
-
-  mock_process = AsyncMock()
-
-  # Set up streaming output mocks
-  stdout_mock = AsyncMock()
-  stdout_mock.readline = AsyncMock(side_effect=[b'stdout line\n', b''])
-  mock_process.stdout = stdout_mock
-
-  stderr_mock = AsyncMock()
-  stderr_mock.readline = AsyncMock(side_effect=[b'stderr error\n', b''])
-  mock_process.stderr = stderr_mock
-
-  mock_process.returncode = 0
-  mock_process.wait = AsyncMock()
-
-  with patch('asyncio.create_subprocess_exec', return_value=mock_process) as mock_exec:
-    res = await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
-
-  assert res == []
-  mock_exec.assert_called_once()
-
-  args, kwargs = mock_exec.call_args
-  assert args[0] == 'bash'
-  assert args[1] == '-ic'
-  assert 'gemini --yolo --model' in args[2]
-  assert '-p "$0"' in args[2]
-  assert 'Use the wpt-generator skill to generate the following test' in args[3]
-  assert '<web_feature_id>feat</web_feature_id>' in args[3]
-  assert kwargs['cwd'] == '/mock/wpt'
-  if mock_config.agentic_yolo:
-    assert kwargs['stdout'] == asyncio.subprocess.PIPE
-    assert kwargs['stderr'] == asyncio.subprocess.PIPE
-  else:
-    assert kwargs['stdout'] is None
-    assert kwargs['stderr'] is None
-
-  mock_ui.print.assert_any_call('[cyan]│[/cyan] stdout line')
-  mock_ui.print.assert_any_call('[cyan]│[/cyan] [white]stderr error[/white]')
-  mock_ui.success.assert_any_call('Agentic generation for suggestion #1 completed successfully.')
-  from unittest.mock import ANY
-
-  jinja_env.get_template.return_value.render.assert_called_with(
-    test_suggestion_xml_block=ANY,
-    is_interactive=False,
-  )
-
-
 def test_partition_requirements_xml() -> None:
   # Empty or no tags
   assert partition_requirements_xml('') == []
@@ -667,72 +599,6 @@ R3: COVERED
 
 
 @pytest.mark.asyncio
-async def test_run_test_generation_agentic_interactive(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock
-) -> None:
-  """Test that agentic generation uses subprocess to call gemini in interactive mode."""
-  mock_config.agentic_generation = True
-  mock_config.agentic_yolo = False
-  mock_config.wpt_path = '/mock/wpt'
-  suggestion_xml = (
-    '<test_suggestion><title>T1</title><description>D1</description></test_suggestion>'
-  )
-  context = WorkflowContext(
-    feature_id='feat',
-    metadata=FeatureMetadata('Feat', 'Desc', ['http://spec']),
-    audit_response=suggestion_xml,
-  )
-  jinja_env = MagicMock()
-  jinja_env.get_template.return_value.render.return_value = 'Use the wpt-generator skill to generate the following test\n<web_feature_id>feat</web_feature_id>'
-
-  mock_ui.confirm.return_value = True
-
-  mock_process = AsyncMock()
-
-  # Set up streaming output mocks
-  stdout_mock = AsyncMock()
-  stdout_mock.readline = AsyncMock(side_effect=[b'stdout line\n', b''])
-  mock_process.stdout = stdout_mock
-
-  stderr_mock = AsyncMock()
-  stderr_mock.readline = AsyncMock(side_effect=[b'stderr error\n', b''])
-  mock_process.stderr = stderr_mock
-
-  mock_process.returncode = 0
-  mock_process.wait = AsyncMock()
-
-  with patch('asyncio.create_subprocess_exec', return_value=mock_process) as mock_exec:
-    res = await run_test_generation(context, mock_config, mock_llm, mock_ui, jinja_env)
-
-  assert res == []
-  mock_exec.assert_called_once()
-
-  args, kwargs = mock_exec.call_args
-  assert args[0] == 'bash'
-  assert args[1] == '-ic'
-  assert 'gemini --model' in args[2]
-  assert '--yolo' not in args[2]
-  assert '"$0"' in args[2]
-  assert '-p' not in args[2]
-  assert 'Use the wpt-generator skill to generate the following test' in args[3]
-  assert '<web_feature_id>feat</web_feature_id>' in args[3]
-  assert kwargs['cwd'] == '/mock/wpt'
-  if mock_config.agentic_yolo:
-    assert kwargs['stdout'] == asyncio.subprocess.PIPE
-    assert kwargs['stderr'] == asyncio.subprocess.PIPE
-  else:
-    assert kwargs['stdout'] is None
-    assert kwargs['stderr'] is None
-
-  from unittest.mock import ANY
-
-  jinja_env.get_template.return_value.render.assert_called_with(
-    test_suggestion_xml_block=ANY,
-    is_interactive=True,
-  )
-
-
-@pytest.mark.asyncio
 async def test_run_test_generation_adk(
   mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock
 ) -> None:
@@ -777,8 +643,6 @@ async def test_generate_adk_loop(mock_config: Config, mock_ui: MagicMock) -> Non
     feature_id='feat',
     metadata=FeatureMetadata('Feat', 'D', ['url']),
   )
-
-  from unittest.mock import AsyncMock
 
   with patch(
     'wptgen.agents.adk_test_generator.generate_test_with_adk',

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -23,20 +23,3 @@ def test_coverage_audit_system_template_brief() -> None:
   assert '<pre_conditions>' in rendered_full
   assert '<steps>' in rendered_full
   assert '<expected_result>' in rendered_full
-
-
-def test_agentic_test_generation_template_interactive() -> None:
-  env = Environment(loader=FileSystemLoader('wptgen/templates'))
-  template = env.get_template('agentic_test_generation.jinja')
-
-  # Test with is_interactive=True
-  rendered_interactive = template.render(
-    is_interactive=True, test_suggestion_xml_block='<test></test>'
-  )
-  assert 'safely close the Gemini CLI now' in rendered_interactive
-
-  # Test with is_interactive=False
-  rendered_non_interactive = template.render(
-    is_interactive=False, test_suggestion_xml_block='<test></test>'
-  )
-  assert 'safely close the Gemini CLI now' not in rendered_non_interactive

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -78,8 +78,6 @@ class Config:
   use_lightweight: bool = False
   use_reasoning: bool = False
   include_thoughts: bool = False
-  agentic_generation: bool = False
-  agentic_yolo: bool = False
   tentative: bool = False
   save_traces: bool = False
   resume_from: WorkflowPhase | None = None
@@ -194,8 +192,6 @@ def load_config(
   single_prompt_requirements_override: bool = False,
   use_lightweight_override: bool = False,
   use_reasoning_override: bool = False,
-  agentic_generation_override: bool = False,
-  agentic_yolo_override: bool = False,
   include_thoughts_override: bool = False,
   tentative_override: bool = False,
   save_traces_override: bool = False,
@@ -299,11 +295,7 @@ def load_config(
     timeout = MIN_LLM_TIMEOUT
 
   cache_path = yaml_data.get('cache_path') or _get_default_cache_path()
-  agentic_generation = agentic_generation_override or yaml_data.get('agentic_generation', False)
-  agentic_yolo = agentic_yolo_override or yaml_data.get('agentic_yolo', False)
   include_thoughts = include_thoughts_override or yaml_data.get('include_thoughts', False)
-  if agentic_yolo:
-    agentic_generation = True
   tentative = tentative_override or yaml_data.get('tentative', False)
   save_traces = save_traces_override or yaml_data.get('save_traces', False)
 
@@ -352,8 +344,6 @@ def load_config(
     use_lightweight=use_lightweight_override,
     use_reasoning=use_reasoning_override,
     include_thoughts=include_thoughts,
-    agentic_generation=agentic_generation,
-    agentic_yolo=agentic_yolo,
     tentative=tentative,
     save_traces=save_traces,
     resume_from=resume_from,

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -266,20 +266,6 @@ def generate(
     bool,
     typer.Option('--use-reasoning', help='Use the reasoning model for all LLM requests.'),
   ] = False,
-  agentic_generation: Annotated[
-    bool,
-    typer.Option(
-      '--agentic-generation',
-      help='Enable agentic generation pipeline orchestration.',
-    ),
-  ] = False,
-  agentic_yolo: Annotated[
-    bool,
-    typer.Option(
-      '--agentic-yolo',
-      help='Enable agentic generation in YOLO mode.',
-    ),
-  ] = False,
   tentative: Annotated[
     bool,
     typer.Option(
@@ -376,8 +362,6 @@ def generate(
       single_prompt_requirements_override=single_prompt_requirements,
       use_lightweight_override=use_lightweight,
       use_reasoning_override=use_reasoning,
-      agentic_generation_override=agentic_generation,
-      agentic_yolo_override=agentic_yolo,
       tentative_override=tentative,
       save_traces_override=save_traces,
       max_parallel_requests_override=max_parallel_requests,

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 from pathlib import Path
 
 from jinja2 import Environment
@@ -20,7 +19,7 @@ from rich.rule import Rule
 
 from wptgen.config import Config
 from wptgen.llm import LLMClient
-from wptgen.models import STYLE_GUIDE_MAP, TestType, WorkflowContext, WorkflowPhase
+from wptgen.models import STYLE_GUIDE_MAP, TestType, WorkflowContext
 from wptgen.ui import UIProvider
 from wptgen.utils import (
   extract_xml_tag,
@@ -75,9 +74,6 @@ async def run_test_generation(
     ui.warning('No tests selected. Exiting.')
     return []
 
-  if config.agentic_generation:
-    return await _generate_agentic_loop(approved_suggestions_xml, context, config, ui, jinja_env)
-
   return await _generate_adk_loop(approved_suggestions_xml, context, config, ui, jinja_env)
 
 
@@ -101,86 +97,6 @@ def _format_test_suggestion(
     lines.append(f'  <web_feature_id>{feature_id}</web_feature_id>')
     additions = '\n'.join(lines)
     return suggestion_xml.replace('</test_suggestion>', f'{additions}\n</test_suggestion>')
-
-
-async def _generate_agentic_loop(
-  approved_suggestions_xml: list[str],
-  context: WorkflowContext,
-  config: Config,
-  ui: UIProvider,
-  jinja_env: Environment,
-) -> list[tuple[Path, str, str]]:
-  """Runs the gemini CLI as a subprocess to handle test generation natively."""
-  ui.report_generation_start(len(approved_suggestions_xml))
-
-  model = config.get_model_for_phase(WorkflowPhase.GENERATION) or config.default_model
-  agentic_template = jinja_env.get_template('agentic_test_generation.jinja')
-
-  spec_urls = context.metadata.specs if context.metadata and context.metadata.specs else []
-
-  for i, suggestion_xml in enumerate(approved_suggestions_xml):
-    # Sanitize and strictly enforce the <test_suggestion> block structure
-    modified_xml = _format_test_suggestion(
-      suggestion_xml, context.feature_id, spec_urls, sanitize=True
-    )
-
-    prompt = agentic_template.render(
-      test_suggestion_xml_block=modified_xml,
-      is_interactive=not config.agentic_yolo,
-    )
-
-    if config.agentic_yolo:
-      # Use bash -ic to force an interactive shell so it loads aliases/nvm.
-      # -p ensures the CLI exits automatically after completion.
-      cmd = ['bash', '-ic', f'gemini --yolo --model {model} -p "$0"', prompt]
-    else:
-      cmd = ['bash', '-ic', f'gemini --model {model} "$0"', prompt]
-
-    ui.print(
-      f'\n[bold blue]Starting Agentic Generation #{i + 1} for: {context.feature_id}[/bold blue]'
-    )
-    ui.print(Rule('[bold cyan]🤖 Gemini CLI[/bold cyan]', style='cyan', align='left'))
-
-    process = await asyncio.create_subprocess_exec(
-      *cmd,
-      cwd=config.wpt_path,
-      stdout=asyncio.subprocess.PIPE if config.agentic_yolo else None,
-      stderr=asyncio.subprocess.PIPE if config.agentic_yolo else None,
-    )
-
-    if config.agentic_yolo:
-
-      async def _stream_output(
-        stream: asyncio.StreamReader | None, is_stderr: bool = False
-      ) -> None:
-        if not stream:
-          return
-        while True:
-          line = await stream.readline()
-          if not line:
-            break
-          text = line.decode('utf-8').rstrip()
-          if is_stderr:
-            ui.print(f'[cyan]│[/cyan] [white]{text}[/white]')
-          else:
-            ui.print(f'[cyan]│[/cyan] {text}')
-
-      await asyncio.gather(
-        _stream_output(process.stdout), _stream_output(process.stderr, is_stderr=True)
-      )
-
-    await process.wait()
-    ui.print(Rule(style='cyan'))
-
-    if process.returncode != 0:
-      ui.error(
-        f'Agentic generation for suggestion #{i + 1} failed with exit code {process.returncode}'
-      )
-    else:
-      ui.success(f'Agentic generation for suggestion #{i + 1} completed successfully.')
-
-  # Agentic generation handles saving natively, so we return an empty memory state.
-  return []
 
 
 async def _generate_adk_loop(

--- a/wptgen/templates/agentic_test_generation.jinja
+++ b/wptgen/templates/agentic_test_generation.jinja
@@ -1,7 +1,0 @@
-Use the wpt-generator skill to generate the following test. Rigorously follow all instructions in the skill.
-
-{{ test_suggestion_xml_block }}
-{% if is_interactive %}
-
-When you have finished generating the test and completing your tasks, explicitly tell the user that they can safely close the Gemini CLI now to continue the WPT-Gen process.
-{%- endif %}


### PR DESCRIPTION
Resolves #324

## Overview
This pull request removes the legacy `gemini` CLI subprocess integration, fully committing to the ADK workflow as the single test generation approach.

## Root Cause / Motivation
Now that the ADK-based agent has been robustly integrated into WPT-Gen (with streaming logs and native tool support), the old test generation logic that shelled out to the `gemini` CLI is completely deprecated. Removing this unused logic simplifies the codebase, avoids redundant maintenance, and prevents user confusion.

## Detailed Changelog
* **`wptgen/phases/generation.py`**: Removed `_generate_agentic_loop` and associated shell out logic entirely.
* **`wptgen/config.py`**: Cleaned up the `agentic_generation` and `agentic_yolo` configuration booleans.
* **`wptgen/main.py`**: Stripped out `--agentic-generation` and `--agentic-yolo` Typer arguments.
* **`wptgen/phases/coverage_audit.py`**: Simplified `brief_suggestions` override that originally depended on `agentic_generation`.
* **`wptgen/templates/agentic_test_generation.jinja`**: Removed this legacy template file.
