### PR TITLE
feat: Add explicit directory creation and deletion tools for test agent

### DIFF
--- a/tests/agents/test_adk_tools.py
+++ b/tests/agents/test_adk_tools.py
@@ -269,3 +269,31 @@ def test_file_tools_search_file_contents(tmp_path: Path) -> None:
   result_invalid = search_contents_tool.func(str(wpt_root), '[invalid')
   assert result_invalid['status'] == 'error'
   assert 'Invalid regular expression' in result_invalid['error']
+
+
+def test_file_tools_create_directory(tmp_path: Path) -> None:
+  wpt_root = tmp_path / 'wpt'
+  wpt_root.mkdir()
+  test_dir = wpt_root / 'new_test_dir'
+
+  tools = create_agent_tools(wpt_root)
+  create_dir_tool = next(t for t in tools if t.name == 'create_directory')
+
+  result = create_dir_tool.func(str(test_dir))
+  assert result['status'] == 'success'
+  assert test_dir.is_dir()
+
+
+def test_file_tools_delete_directory(tmp_path: Path) -> None:
+  wpt_root = tmp_path / 'wpt'
+  wpt_root.mkdir()
+  test_dir = wpt_root / 'dir_to_delete'
+  test_dir.mkdir()
+  (test_dir / 'file.txt').touch()
+
+  tools = create_agent_tools(wpt_root)
+  delete_dir_tool = next(t for t in tools if t.name == 'delete_directory')
+
+  result = delete_dir_tool.func(str(test_dir))
+  assert result['status'] == 'success'
+  assert not test_dir.exists()

--- a/wptgen/agents/tools.py
+++ b/wptgen/agents/tools.py
@@ -248,6 +248,42 @@ def create_agent_tools(wpt_path: Path) -> list[FunctionTool]:
     except (OSError, ValueError) as e:
       return {'status': 'error', 'error': str(e)}
 
+  def create_directory(directory_path: str) -> dict[str, Any]:
+    """Creates a directory within the WPT repository, including any necessary parent directories.
+
+    Args:
+        directory_path: The relative or absolute path of the directory to create.
+
+    Returns:
+        A dictionary containing the 'status'.
+    """
+    try:
+      target = _validate_safe_path(Path(directory_path), wpt_path)
+      target.mkdir(parents=True, exist_ok=True)
+      return {'status': 'success'}
+    except (OSError, ValueError) as e:
+      return {'status': 'error', 'error': str(e)}
+
+  def delete_directory(directory_path: str) -> dict[str, Any]:
+    """Deletes a directory and all its contents within the WPT repository.
+
+    Args:
+        directory_path: The path to the directory to delete.
+
+    Returns:
+        A dictionary containing the 'status'.
+    """
+    try:
+      target = _validate_safe_path(Path(directory_path), wpt_path)
+      if not target.is_dir():
+        return {'status': 'error', 'error': f'Directory not found: {directory_path}'}
+      import shutil
+
+      shutil.rmtree(target)
+      return {'status': 'success'}
+    except (OSError, ValueError) as e:
+      return {'status': 'error', 'error': str(e)}
+
   def delete_file(file_path: str) -> dict[str, Any]:
     """Deletes a specific file within the WPT repository.
 
@@ -525,6 +561,8 @@ def create_agent_tools(wpt_path: Path) -> list[FunctionTool]:
     FunctionTool(func=write_file),
     FunctionTool(func=search_files),
     FunctionTool(func=list_directory),
+    FunctionTool(func=create_directory),
+    FunctionTool(func=delete_directory),
     FunctionTool(func=delete_file),
     FunctionTool(func=run_wpt_lint),
     FunctionTool(func=run_wpt_test),


### PR DESCRIPTION
Resolves #318

## Overview
Adds explicit tools (`create_directory` and `delete_directory`) to scaffold and manage file structures within the WPT repository boundary.

## Root Cause / Motivation
Currently, the test generation agent relies on implicit directory creation when saving files. To give the agent granular control over test suite structures (such as creating empty directories or cleaning up test environments), explicit `create_directory` and `delete_directory` tools have been added to the agent's available functions.

## Detailed Changelog
* **`wptgen/agents/tools.py`**: Added `create_directory` to safely create directories within bounds. Added `delete_directory` to safely remove directories using `shutil.rmtree`. Both tools have been wrapped in `FunctionTool` and included in `create_agent_tools()`.
* **`tests/agents/test_adk_tools.py`**: Added test cases `test_file_tools_create_directory` and `test_file_tools_delete_directory` to verify the functionality of the new tools.
