### PR TITLE
feat: Add `move_file` tool to adk agent

### DIFF
--- a/tests/agents/test_adk_tools.py
+++ b/tests/agents/test_adk_tools.py
@@ -183,6 +183,23 @@ def test_file_tools_delete_file(tmp_path: Path) -> None:
   assert not test_file.exists()
 
 
+def test_file_tools_move_file(tmp_path: Path) -> None:
+  wpt_root = tmp_path / 'wpt'
+  wpt_root.mkdir()
+  source_file = wpt_root / 'to_move.txt'
+  source_file.write_text('content')
+  dest_file = wpt_root / 'moved.txt'
+
+  tools = create_agent_tools(wpt_root, MagicMock(spec=UIProvider), 'chrome', 'canary')
+  move_file_tool = next(t for t in tools if t.name == 'move_file')
+
+  result = move_file_tool.func(str(source_file), str(dest_file))
+  assert result['status'] == 'success'
+  assert not source_file.exists()
+  assert dest_file.exists()
+  assert dest_file.read_text() == 'content'
+
+
 def test_file_tools_security_rejection(tmp_path: Path) -> None:
   wpt_root = tmp_path / 'wpt'
   wpt_root.mkdir()
@@ -194,6 +211,14 @@ def test_file_tools_security_rejection(tmp_path: Path) -> None:
   read_file_tool = next(t for t in tools if t.name == 'read_file')
 
   result = read_file_tool.func(str(outside_file))
+  assert result['status'] == 'error'
+  assert 'outside the designated WPT repository root' in result['error']
+
+  # Test moving a file outside the repository
+  inside_file = wpt_root / 'inside.txt'
+  inside_file.write_text('inside')
+  move_file_tool = next(t for t in tools if t.name == 'move_file')
+  result = move_file_tool.func(str(inside_file), str(outside_file))
   assert result['status'] == 'error'
   assert 'outside the designated WPT repository root' in result['error']
 

--- a/wptgen/agents/tools.py
+++ b/wptgen/agents/tools.py
@@ -308,6 +308,31 @@ def create_agent_tools(
     except (OSError, ValueError) as e:
       return {'status': 'error', 'error': str(e)}
 
+  def move_file(source_path: str, destination_path: str) -> dict[str, Any]:
+    """Moves or renames a file within the WPT repository.
+
+    Args:
+        source_path: The path to the file to move or rename.
+        destination_path: The new path for the file.
+
+    Returns:
+        A dictionary containing the 'status'.
+    """
+    try:
+      source = _validate_safe_path(Path(source_path), wpt_path)
+      if not source.is_file():
+        return {'status': 'error', 'error': f'Source file not found: {source_path}'}
+
+      destination = _validate_safe_path(Path(destination_path), wpt_path)
+      destination.parent.mkdir(parents=True, exist_ok=True)
+
+      import shutil
+
+      shutil.move(source, destination)
+      return {'status': 'success'}
+    except (OSError, ValueError) as e:
+      return {'status': 'error', 'error': str(e)}
+
   def run_wpt_lint(file_path: str) -> dict[str, Any]:
     """Runs the WPT linter on a specific file and returns any syntax or style errors.
 
@@ -380,7 +405,7 @@ def create_agent_tools(
           '--channel',
           channel,
           '--headless',
-          '--log-mach',
+          '--log-raw',
           log_path,
           browser,
           rel_path,
@@ -600,6 +625,7 @@ def create_agent_tools(
     FunctionTool(func=create_directory),
     FunctionTool(func=delete_directory),
     FunctionTool(func=delete_file),
+    FunctionTool(func=move_file),
     FunctionTool(func=run_wpt_lint),
     FunctionTool(func=run_wpt_test),
     FunctionTool(func=search_feature_tests),


### PR DESCRIPTION
This PR adds the `move_file` tool to the ADK agent, allowing the test generator agent to move or rename files securely within the WPT repository. Included are tests to ensure proper functionality and security boundary checks.