### PR TITLE
docs(wpt-generator): update reference files based on test generation feedback

### DIFF
--- a/.agents/skills/wpt-generator/SKILL.md
+++ b/.agents/skills/wpt-generator/SKILL.md
@@ -44,6 +44,8 @@ Before creating a new file, rigorously check if the test logic belongs in existi
 4. **Create New Only When Necessary:** Only if no logical match is found (even after considering splitting and manual consolidation), plan to create a new file. **Consult `references/wpt_style_guide.md` to determine the correct filename extension and suffixes** (e.g., `.html`, `.window.js`, `.any.js`) based on your chosen test type. Name the file logically based on the `<web_feature_id>`.
 5. **File Existence Check:** Before using `write_file` to create a new test file, you MUST verify that the proposed filename does not already exist in the target directory (e.g., by using the `list_directory` tool).
 6. **Naming Conflicts:** If a file with the proposed name already exists, you MUST either append the new test logic to the existing file (if logically appropriate) or generate a new unique filename by incrementing a numerical suffix (e.g., changing `-001.html` to `-002.html`) to prevent overwriting existing work.
+7. **Existing Test Expansion:** If you detect that the core assertion of the WPT blueprint is already present in an existing test (i.e. a test perfectly matching the blueprint exists), you MUST ensure all specification edge cases, permutations, or multi-level DOM configurations are thoroughly exercised, and expand the existing test file as necessary instead of creating a redundant new test.
+   - **Handling `.tentative` files:** If an existing `.tentative` file matches your blueprint, append your new test cases directly to it. **Do NOT remove the `.tentative` suffix or rename the file** to "upgrade" it unless explicitly instructed to do so by the user.
 
 ### 5. Load References & Generate the Test
 **Before writing any code**, you MUST read the appropriate style guides to ensure correct formatting and syntax:
@@ -51,7 +53,7 @@ Before creating a new file, rigorously check if the test logic belongs in existi
 - If Testharness: See [testharness_style_guide.md](references/testharness_style_guide.md)
 - If Reftest: See [reftest_style_guide.md](references/reftest_style_guide.md)
 - If Crashtest: See [crashtest_style_guide.md](references/crashtest_style_guide.md)
-- If the test requires simulated user interaction (clicks, typing, gestures): See [automation_guide.md](references/automation_guide.md)
+- If the test requires simulated user interaction (clicks, typing, gestures) or tests hardware/device APIs (like Web MIDI, Web Bluetooth): See [automation_guide.md](references/automation_guide.md)
 - If the test is a wdspec test (testing the WebDriver protocol itself): See [wdspec_guide.md](references/wdspec_guide.md)
 - If the test strictly requires a human operator and cannot be automated: See [manual_test_style_guide.md](references/manual_test_style_guide.md)
 - If the test involves Web IDL interfaces (e.g., testing `[Exposed]` attributes, method existence, or interface exposure): See [idlharness_guide.md](references/idlharness_guide.md)
@@ -64,8 +66,10 @@ Write the appropriate WPT test to strictly satisfy the `<description>` using the
 - **CRITICAL RULE: Minimize Specification Boilerplate:** Only use the APIs strictly required to trigger the behavior described in the `<description>`. Do not include optional features or initialization boilerplate from the spec unless explicitly required by the core assertion.
 - **CRITICAL RULE: Domain Helpers > Golden Examples:** Check if a built-in helper exists in the local `resources/` directory to avoid repetitive boilerplate. Even if your "Golden Example" writes out boilerplate logic manually (e.g., manually polling, fetching, resolving a sequence of events, or establishing positive controls), you MUST aggressively replace that boilerplate if a higher-level abstraction exists in a local helper file. **When you identify a helper file, you MUST perform an exhaustive audit of its entire exported API (e.g., reading the whole `helper.js` file using `read_file`) to discover all available utilities (like `wait()`, `delay()`, or custom assertions). Do not restrict your usage only to the specific functions the Golden Example used.**
    - If testing CSS property parsing, descriptor parsing (e.g., `@font-face` descriptors), at-rules, inheritance, computed values, or shorthands: See [css_testcommon.md](references/domain_helpers/css_testcommon.md)
+   - If testing CSS Fonts, typography, or synthetic glyph metrics: See [css_fonts.md](references/domain_helpers/css_fonts.md)
    - If testing CSS property animatability, interpolation, or discrete flips: See [css_animations.md](references/domain_helpers/css_animations.md)
    - If testing cross-origin network or fetch behaviors via Javascript: See [get_host_info.md](references/domain_helpers/get_host_info.md)
+   - If testing features controlled by Permissions Policy (formerly Feature Policy): See [permissions_policy.md](references/domain_helpers/permissions_policy.md)
 - **Implementation:** Write the test logic, setup, and assertions autonomously. When generating tests for multiple permutations or variations of an API, you should consider writing a data-driven test using arrays and loops, as described in `testharness_style_guide.md`. However, do not over-engineer simple, isolated features. *Note: If the target directory lacks examples of your chosen Test Type, rely entirely on the style guides.*
 
 ### 6. Validation & Self-Correction (CRITICAL)

--- a/.agents/skills/wpt-generator/references/automation_guide.md
+++ b/.agents/skills/wpt-generator/references/automation_guide.md
@@ -114,3 +114,41 @@ test_driver.set_test_context(window.opener);
 await test_driver.click(document.getElementById("btn"));
 test_driver.message_test("action complete");
 ```
+
+## 5. Hardware & Device APIs (Web MIDI, WebUSB, Web Bluetooth, Gamepads)
+
+Testing hardware-oriented specifications often requires special handling because standard headless runners lack physical devices or OS-level drivers.
+
+### Granting Permissions
+Most device-level APIs require explicit permissions. You MUST use `testdriver.js` to grant these permissions before interacting with the API to prevent automatic rejections.
+```javascript
+promise_test(async t => {
+  // Example for Web MIDI
+  await test_driver.set_permission({name: 'midi', sysex: true}, 'granted');
+  const access = await navigator.requestMIDIAccess({sysex: true});
+  assert_true(access instanceof MIDIAccess);
+}, "MIDI access granted via testdriver");
+```
+
+### Handling Missing Hardware (Best Effort Testing)
+When true end-to-end testing requires physical hardware (or virtual loopback interfaces) that do not exist in the standard WPT environment, you should write "best effort" tests.
+- **Structural Validity:** Assert that the API methods and attributes exist and have the correct IDL types.
+- **Method Acceptance (No-Throw):** Assert that methods can be called with valid arguments without throwing exceptions (if permitted by the spec when disconnected).
+- **Graceful Degradation:** If an API throws an initialization error (e.g., `NotSupportedError`, `NotFoundError`, or `InvalidStateError`) purely due to the runner lacking OS-level driver configurations or physical devices, your test MUST catch and handle this gracefully rather than failing the test suite completely (e.g., by skipping the test or asserting the specific expected `DOMException` for a disconnected state).
+
+```javascript
+promise_test(async t => {
+  await test_driver.set_permission({name: 'bluetooth'}, 'granted');
+  try {
+    const device = await navigator.bluetooth.requestDevice({acceptAllDevices: true});
+    // If a mock device is present, assert on it
+    assert_true(device !== null);
+  } catch (e) {
+    // Gracefully handle environments without physical bluetooth radios or mock drivers
+    assert_equals(e.name, 'NotFoundError');
+  }
+}, "requestDevice handles missing hardware gracefully");
+```
+
+### When to use Manual Tests (`-manual`)
+If the blueprint specifically requires simulating OS-level hardware interventions (e.g., physically unplugging a USB device, locking a device, or simulating a hardware fault) AND you have verified that no `testdriver.js` extension or `wdspec` backend exists to mock this specific state, you MUST default to a `-manual` test. Do not attempt to automate physical hardware manipulations if the testing infrastructure lacks a mock interface for it.

--- a/.agents/skills/wpt-generator/references/domain_helpers/css_fonts.md
+++ b/.agents/skills/wpt-generator/references/domain_helpers/css_fonts.md
@@ -1,0 +1,42 @@
+# CSS Fonts Testing (`css/css-fonts/*`)
+
+Testing typography and fonts in WPT requires a solid understanding of how browsers asynchronously load resources, how standard WPT fonts behave, and when to use Reftests versus `testharness.js`.
+
+## 1. Standard WPT Fonts
+
+WPT provides a suite of reliable, deterministic fonts for testing in `fonts/` (or `support/fonts/` depending on the directory). You MUST use these instead of system fonts to ensure cross-platform consistency.
+
+*   **`Ahem.ttf`:** The canonical testing font. Every character renders as a solid square block matching its em-size.
+    *   **Predictable Metrics:** `1ex = 0.8em`, `1ch = 1em`.
+    *   **Linter Warning (`AHEM SYSTEM FONT`):** The WPT linter strictly forbids the word "Ahem" from appearing in CSS to prevent accidentally falling back to the system's Ahem font instead of the web font. If you get an `AHEM SYSTEM FONT` lint error when writing an `@font-face` rule, **do NOT try to obfuscate the font name in the code.** You MUST append the file path to the repository's `lint.ignore` file exactly as instructed by the WPT runner output.
+*   **`pass.woff` / `fail.woff`:** Incredibly powerful tools for CSS font rendering/matching testing. These fonts use ligature replacement to visually render the strings "PASS" or "FAIL" when a specific single letter (like `P` or `F`) is typed in the HTML. Use these in Reftests instead of relying solely on Ahem blocks for complex matching algorithms.
+*   **`FontWithFancyFeatures.otf`:** Use this when you specifically need to trigger OpenType features (like `sups` and `subs` for superscript/subscript) or synthesis fallbacks. Ahem inherently lacks these features.
+
+## 2. Asynchronous Font Loading (`testharness.js`)
+
+If you are writing a `testharness.js` test that relies on the dimensions of a loaded font, you **MUST NOT** synchronously measure DOM elements (e.g., using `getBoundingClientRect()`) immediately after appending them.
+
+`document.fonts.ready` only resolves for *requested* fonts. You must explicitly ensure the font is loaded before measuring:
+
+```javascript
+promise_test(async t => {
+  const div = document.createElement('div');
+  div.style.fontFamily = 'Ahem';
+  div.textContent = 'X';
+  document.body.appendChild(div);
+
+  // CRITICAL: Await the explicit load of the font metrics before measuring
+  await document.fonts.load('10px Ahem');
+  
+  const rect = div.getBoundingClientRect();
+  assert_equals(rect.width, 10);
+}, "Font metrics are measured after explicit load");
+```
+
+## 3. Synthetic Glyphs (Mandatory Reftests)
+
+If you are testing properties that affect synthetic glyph geometries or metrics overrides (such as `font-variant-position` synthesizing superscript/subscript, or `@font-face` descriptor adjustments like `size-adjust` or `ascent-override`), you generally **MUST use Reftests**.
+
+**Why?** Standard line-box heights and `.getBoundingClientRect()` often remain unaffected by synthetic glyph alterations. The inline bounding box does not accurately map the ink bounds of the synthesized glyph, making `testharness.js` measurements unreliable.
+
+Compare the visual layout output to a hardcoded text reference, often utilizing `Ahem` and absolute CSS positioning equivalents (e.g., `position: relative; top: -0.5em`) to verify the exact mathematical shift of the glyph.

--- a/.agents/skills/wpt-generator/references/domain_helpers/css_testcommon.md
+++ b/.agents/skills/wpt-generator/references/domain_helpers/css_testcommon.md
@@ -45,7 +45,7 @@ Use these to test whether a browser correctly parses (or rejects) a specified CS
 
 **Example:**
 ```javascript
-// CRITICAL: Always use data-driven arrays/loops for multiple values!
+// Consider using data-driven arrays/loops for multiple values.
 const valid_values = [
   { specified: 'center' },
   { specified: 'flex-start', expected: 'start' }
@@ -60,13 +60,19 @@ for (const value of invalid_values) {
 }
 ```
 
+**Validation Reassurance (Unimplemented Grammar):**
+When writing tests for newly specified grammar (e.g., a new 2-value syntax for a property), it is common for the test runner to report a failure because the browser engine hasn't implemented the new spec syntax yet. **Do not endlessly attempt to "fix" your code if it correctly matches the specification.** Write tests strictly to the spec. If the browser rejects valid grammar because it is unimplemented, accept the failure and finalize the test.
+
 ## Computed Style (`computed-testcommon.js`)
 Use these to test how a specified CSS value resolves in `getComputedStyle`.
 *   `test_computed_value(property, specified, computed)`: Tests that setting the property to `specified` results in a `getComputedStyle` value of `computed`. If `computed` is omitted, it defaults to `specified`.
 
+**CRITICAL WARNING: CSS Counters**
+Do NOT use `getComputedStyle` (or `test_computed_value`) to verify the mathematical evaluation or output of CSS counters (e.g., `counter-set`, `counter-increment`). The `getComputedStyle(element, '::before').content` API is unreliable for this purpose; many browser engines will return the raw functional value (e.g., `"counter(c)"`) instead of the computed integer string (e.g., `"1"`). **You MUST use Reftests to verify CSS counter outputs.** See `reftest_style_guide.md`.
+
 **Example:**
 ```javascript
-// CRITICAL: Always use data-driven arrays/loops for multiple values!
+// Consider using data-driven arrays/loops for multiple values.
 const computed_values = [
   { specified: 'auto' },
   { specified: '100px' },

--- a/.agents/skills/wpt-generator/references/domain_helpers/permissions_policy.md
+++ b/.agents/skills/wpt-generator/references/domain_helpers/permissions_policy.md
@@ -1,0 +1,72 @@
+# Permissions Policy Testing (`permissions-policy.js`)
+
+When testing features controlled by the Permissions Policy (formerly Feature Policy), you MUST use the established testing framework located in `/permissions-policy/resources/permissions-policy.js`.
+
+## 1. Setup
+
+Include the helper script in your HTML test file:
+```html
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+```
+
+## 2. Testing Feature Availability
+
+The primary utility is `test_feature_availability(test_promise_or_func, description, expected_availability, iframe_src, [feature_name])`.
+
+This helper creates an iframe (using the provided `iframe_src`), applies the permissions policy, and verifies if the feature is available or blocked.
+
+### Handling Asynchronous APIs
+If the API being tested is asynchronous (returns a Promise), you must ensure your helper iframe correctly awaits the result and posts the success or failure back via `postMessage`.
+
+## 3. Helper Iframes (`permissions-policy-*.html`)
+
+You will typically need to create or use an existing cross-origin helper iframe HTML file. This file attempts to use the feature and reports back to the parent using `window.parent.postMessage`.
+
+**Example Helper (`permissions-policy-midi.html`):**
+```html
+<!DOCTYPE html>
+<script>
+  Promise.resolve().then(async () => {
+    try {
+      await navigator.requestMIDIAccess();
+      window.parent.postMessage({ type: 'availability', enabled: true }, '*');
+    } catch (e) {
+      if (e.name === 'NotAllowedError' || e.name === 'SecurityError') {
+        window.parent.postMessage({ type: 'availability', enabled: false }, '*');
+      } else {
+        // Unexpected error
+        window.parent.postMessage({ type: 'availability', enabled: false, error: e.name }, '*');
+      }
+    }
+  });
+</script>
+```
+*CRITICAL RULE:* Do not update core exception types in canonical helper resources unless the test suite expects immediate failure on older engines.
+
+## 4. Policy Denial vs. User Permission Denial
+
+When testing Permissions Policy, it is critical to isolate the policy block from a standard user permission denial.
+
+*   **User Permission Denial:** Simulating a user clicking "Block" on a permission prompt. Done via `test_driver.set_permission({ name: 'feature' }, 'denied')`.
+*   **Policy Block Denial:** The feature is disabled by the `Permissions-Policy` HTTP header or the `allow=""` attribute on an iframe (e.g., `<iframe allow="midi 'none'">`).
+
+Both scenarios often result in the exact same exception (e.g., `NotAllowedError` or `SecurityError`).
+
+**CRITICAL RULE:** To accurately test that a feature is blocked *by the Permissions Policy*, you MUST first grant the user permission using `testdriver.js` before running the policy test. Otherwise, you cannot be sure which mechanism blocked the feature.
+
+```javascript
+promise_test(async t => {
+  // 1. Grant user permission first to isolate the policy test
+  // Note: Permission descriptor can be a complex dictionary, e.g., {name: 'midi', sysex: false}
+  await test_driver.set_permission({name: 'midi', sysex: false}, 'granted');
+
+  // 2. Test the policy block
+  // test_feature_availability will create the iframe and manage the postMessage lifecycle
+  test_feature_availability(
+    null,
+    "MIDI is blocked by permissions policy",
+    false, // expected_availability
+    "resources/permissions-policy-midi.html"
+  );
+}, "Permissions Policy properly blocks Web MIDI");
+```

--- a/.agents/skills/wpt-generator/references/reftest_style_guide.md
+++ b/.agents/skills/wpt-generator/references/reftest_style_guide.md
@@ -2,6 +2,11 @@ Reftests (reference tests) are one of the primary tools in Web Platform Tests (W
 
 This guide provides a comprehensive overview of best practices for writing high-quality, maintainable, and robust reftests.
 
+### When to Use Reftests: The CSS Counter Exception
+While `testharness.js` is generally preferred for testing parsed or computed CSS values, **you MUST use Reftests when verifying the mathematical evaluation or visual output of CSS counters** (e.g., `counter-set`, `counter-increment`, `counter-reset`).
+*   **Why?** The JavaScript API `getComputedStyle(element, '::before').content` is unreliable for extracting the evaluated integer string of a counter across all major browser engines. Many engines will incorrectly return the raw functional value (e.g., `"counter(c)"`) instead of the computed number (e.g., `"1"`).
+*   **The Solution:** A Reftest avoids JavaScript entirely by comparing the visual output of the CSS counter against a reference file that uses hardcoded, statically defined text.
+
 ## 1. Anatomy of a Reftest
 
 A reftest requires at least two files: the test file and the reference file. 
@@ -58,6 +63,8 @@ Before creating a new reference file, **you MUST check if an existing reference 
 - Look in the current directory and any `reference/`, `references/`, or `support/` subdirectories.
 - Look for standard WPT shared references (e.g., `../reference/ref-filled-green-100px-square.xht`).
 - If an existing file produces the exact same visual rendering (e.g., a simple green square or a blank white page), link to it using `<link rel="match" href="...">` instead of creating a new `-ref.html` file.
+
+**The Cleanliness Boundary:** While reusing reference files is strongly encouraged, you must balance this against test cleanliness. If reusing an older, multi-element reference file requires you to write an overly "hacky", mangled, or excessively complex DOM in your test file just to perfectly align with its output, **do not reuse it**. A clean, readable, and focused test file takes priority over reference reuse. If the tradeoff is severe, simply spawn a new, slightly altered reference file to keep the individual tests clean.
 
 ### 3.1 Designing Tests for Reference Reuse
 

--- a/.agents/skills/wpt-generator/references/testharness_style_guide.md
+++ b/.agents/skills/wpt-generator/references/testharness_style_guide.md
@@ -90,8 +90,10 @@ Metadata and file names communicate critical information to the WPT server and r
 *   `-manual`: Indicates the test requires manual user interaction and should not be run in an automated runner without specific configuration. Must appear right before the extension.
 *   `.tentative`: Indicates the test is for a feature still under discussion or not yet standardized.
 
-### 3.2 `// META` Comments (for `.js` files)
+### 3.2 `// META` Comments and Spec Links (for `.js` files)
 *   `// META: title=Test Title`: Sets the document title.
+*   **Spec URLs:** To include a specification link in a `.js` test (like `.window.js` or `.any.js`), you MUST use a standard JavaScript comment, e.g., `// https://spec.url/path`.
+    *   **CRITICAL RULE:** Do NOT attempt to use `// META: help=...`. The `help` metadata tag is illegal and unsupported by `wptserve` for `.js` files, and it will trigger an `UNKNOWN-METADATA` linter error. Use `// https://...` instead.
 *   `// META: script=/common/utils.js`: Includes external scripts.
 *   `// META: global=window,worker`: Specifies which globals to run in (for `.any.js`).
 *   `// META: timeout=long`: Increases the test timeout (standard is 10s, long is 60s).


### PR DESCRIPTION
This PR updates the reference files for the `wpt-generator` skill based on feedback received during test generation.

Updates include:
- Adding a new domain helper guide for Permissions Policy (`permissions_policy.md`).
- Clarifying that CSS counters must be tested using Reftests due to `getComputedStyle` limitations.
- Adding comprehensive documentation on testing device and hardware APIs (like Web MIDI and Web Bluetooth) using `testdriver.js`.
- Specifying the exact syntax for formatting specification URLs in `.js` test files.
- Adding instructions to expand existing tests rather than creating redundant new ones when they perfectly match a blueprint.
- Requesting feedback on missing reference information rather than requesting new tools.