### PR TITLE
Feature: Optionalize MDN Documentation in Requirements Extraction

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -87,6 +87,7 @@ def default_load_config_kwargs() -> dict[str, bool | str | int | None | list[str
     'spec_urls_override': None,
     'feature_description_override': None,
     'detailed_requirements_override': False,
+    'include_mdn_docs_override': False,
     'draft_override': False,
     'single_prompt_requirements_override': False,
     'use_lightweight_override': False,

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -107,6 +107,7 @@ async def test_run_context_assembly_with_mdn(
   mock_config: Config, mock_ui: MagicMock, mocker: MockerFixture
 ) -> None:
   """Test context assembly with MDN documentation fetching."""
+  mock_config.include_mdn_docs = True
   mocker.patch('wptgen.phases.context_assembly.fetch_feature_yaml', return_value={'name': 'feat'})
   mocker.patch(
     'wptgen.phases.context_assembly.extract_feature_metadata',
@@ -129,6 +130,34 @@ async def test_run_context_assembly_with_mdn(
   assert isinstance(context.mdn_contents, list)
   assert len(context.mdn_contents) == 2
   mock_ui.report_context_summary.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_context_assembly_without_mdn(
+  mock_config: Config, mock_ui: MagicMock, mocker: MockerFixture
+) -> None:
+  """Test context assembly skips MDN fetching when include_mdn_docs is False."""
+  mock_config.include_mdn_docs = False
+  mocker.patch('wptgen.phases.context_assembly.fetch_feature_yaml', return_value={'name': 'feat'})
+  mocker.patch(
+    'wptgen.phases.context_assembly.extract_feature_metadata',
+    return_value=FeatureMetadata('Feat', 'Desc', ['http://spec']),
+  )
+  mock_fetch = mocker.patch('wptgen.phases.context_assembly.fetch_and_extract_text')
+  mock_fetch_mdn = mocker.patch('wptgen.phases.context_assembly.fetch_mdn_urls')
+  mocker.patch('wptgen.phases.context_assembly.find_feature_tests', return_value=[])
+  mocker.patch(
+    'wptgen.phases.context_assembly.gather_local_test_context', return_value=WPTContext()
+  )
+
+  mock_fetch.return_value = 'Spec Content'
+
+  context = await run_context_assembly('feat-id', mock_config, mock_ui)
+
+  assert context is not None
+  assert context.mdn_contents is None
+  mock_fetch_mdn.assert_not_called()
+  mock_ui.print.assert_any_call('Skipping MDN documentation fetch (not requested).')
 
 
 @pytest.mark.asyncio

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -74,6 +74,7 @@ class Config:
   spec_urls: list[str] | None = None
   feature_description: str | None = None
   detailed_requirements: bool = False
+  include_mdn_docs: bool = False
   draft: bool = False
   chromestatus: bool = False
   single_prompt_requirements: bool = False
@@ -189,6 +190,7 @@ def load_config(
   spec_urls_override: list[str] | None = None,
   feature_description_override: str | None = None,
   detailed_requirements_override: bool = False,
+  include_mdn_docs_override: bool = False,
   draft_override: bool = False,
   chromestatus_override: bool = False,
   single_prompt_requirements_override: bool = False,
@@ -282,6 +284,7 @@ def load_config(
   detailed_requirements = detailed_requirements_override or yaml_data.get(
     'detailed_requirements', False
   )
+  include_mdn_docs = include_mdn_docs_override or yaml_data.get('include_mdn_docs', False)
   single_prompt_requirements = single_prompt_requirements_override or yaml_data.get(
     'single_prompt_requirements', False
   )
@@ -348,6 +351,7 @@ def load_config(
     spec_urls=spec_urls_override,
     feature_description=feature_description_override,
     detailed_requirements=detailed_requirements,
+    include_mdn_docs=include_mdn_docs,
     draft=draft,
     chromestatus=chromestatus,
     single_prompt_requirements=single_prompt_requirements,

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -365,6 +365,13 @@ def generate(
       help='Use a more detailed, iterative requirements extraction process.',
     ),
   ] = False,
+  include_mdn_docs: Annotated[
+    bool,
+    typer.Option(
+      '--include-mdn-docs',
+      help='Include MDN documentation in requirements extraction.',
+    ),
+  ] = False,
   include_thoughts: Annotated[
     bool,
     typer.Option(
@@ -482,6 +489,7 @@ def generate(
       spec_urls_override=spec_urls_list,
       feature_description_override=description,
       detailed_requirements_override=detailed_requirements,
+      include_mdn_docs_override=include_mdn_docs,
       draft_override=draft,
       single_prompt_requirements_override=single_prompt_requirements,
       use_lightweight_override=use_lightweight,
@@ -855,6 +863,13 @@ def audit(
       help='Use a more detailed, iterative requirements extraction process.',
     ),
   ] = False,
+  include_mdn_docs: Annotated[
+    bool,
+    typer.Option(
+      '--include-mdn-docs',
+      help='Include MDN documentation in requirements extraction.',
+    ),
+  ] = False,
   include_thoughts: Annotated[
     bool,
     typer.Option(
@@ -965,6 +980,7 @@ def audit(
       spec_urls_override=spec_urls_list,
       feature_description_override=description,
       detailed_requirements_override=detailed_requirements,
+      include_mdn_docs_override=include_mdn_docs,
       draft_override=draft,
       single_prompt_requirements_override=single_prompt_requirements,
       use_lightweight_override=use_lightweight,

--- a/wptgen/phases/context_assembly.py
+++ b/wptgen/phases/context_assembly.py
@@ -117,20 +117,23 @@ async def run_context_assembly(
 
   wpt_context = gather_local_test_context(test_paths, config.wpt_path)
 
-  ui.print('Fetching MDN documentation...')
   mdn_contents: list[str] | None = None
-  mdn_urls = fetch_mdn_urls(web_feature_id)
-  if mdn_urls:
-    with ui.status(f'Fetching {len(mdn_urls)} MDN pages...'):
-      # Fetch all MDN pages asynchronously using to_thread for the synchronous fetch_and_extract_text
-      results = await asyncio.gather(
-        *[asyncio.to_thread(fetch_and_extract_text, url) for url in mdn_urls]
-      )
-      mdn_contents = [
-        f'# Documentation from {url}\n\n{res}'
-        for url, res in zip(mdn_urls, results, strict=True)
-        if res
-      ]
+  if config.include_mdn_docs:
+    ui.print('Fetching MDN documentation...')
+    mdn_urls = fetch_mdn_urls(web_feature_id)
+    if mdn_urls:
+      with ui.status(f'Fetching {len(mdn_urls)} MDN pages...'):
+        # Fetch all MDN pages asynchronously using to_thread for the synchronous fetch_and_extract_text
+        results = await asyncio.gather(
+          *[asyncio.to_thread(fetch_and_extract_text, url) for url in mdn_urls]
+        )
+        mdn_contents = [
+          f'# Documentation from {url}\n\n{res}'
+          for url, res in zip(mdn_urls, results, strict=True)
+          if res
+        ]
+  else:
+    ui.print('Skipping MDN documentation fetch (not requested).')
 
   ui.report_context_summary(
     sum(len(content) for content in spec_contents.values()),

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -80,7 +80,10 @@ async def run_requirements_extraction(
     )
     extraction_system_prompt = jinja_env.get_template(
       'requirements_extraction_system.jinja'
-    ).render()
+    ).render(
+      has_mdn=bool(context.mdn_contents),
+      has_explainer=bool(context.explainer_contents),
+    )
 
     await confirm_prompts(
       [(extraction_prompt, 'Requirements Extraction')],
@@ -155,6 +158,8 @@ async def run_requirements_extraction_categorized(
       ).render(
         category_name=category_name,
         category_description=category_description,
+        has_mdn=bool(context.mdn_contents),
+        has_explainer=bool(context.explainer_contents),
       )
       category_prompts.append(extraction_prompt)
       category_system_prompts.append(extraction_system_prompt)
@@ -290,7 +295,10 @@ async def run_requirements_extraction_iterative(
       )
       extraction_system_prompt = jinja_env.get_template(
         'requirements_extraction_iterative_system.jinja'
-      ).render()
+      ).render(
+        has_mdn=bool(context.mdn_contents),
+        has_explainer=bool(context.explainer_contents),
+      )
 
       if iteration == 1:
         await confirm_prompts(

--- a/wptgen/templates/requirements_extraction_categorized_system.jinja
+++ b/wptgen/templates/requirements_extraction_categorized_system.jinja
@@ -12,13 +12,17 @@ You are a Principal Software Engineer in Test (SDET) and a W3C Specification Ana
 4.  **Atomic Descriptions:** Each requirement must be a single, testable assertion. Do not combine multiple behaviors. The description must read like a test objective (e.g., "If the dictionary member is missing, it must default to false.").
 
 # INPUTS
-1.  `<spec_document>`: The technical specification text.
-2.  `<mdn_document>` (Optional): Supplemental MDN documentation for the feature.
-3.  `<explainer>` (Optional): Explainer documents providing high-level context.
-4.  `<feature_definition>`: The scope of your analysis. You must ignore parts of the spec that fall outside this feature definition.
+* `<spec_document>`: The technical specification text.
+{% if has_mdn -%}
+* `<mdn_document>`: Supplemental MDN documentation for the feature.
+{% endif -%}
+{% if has_explainer -%}
+* `<explainer>`: Explainer documents providing high-level context.
+{% endif -%}
+* `<feature_definition>`: The scope of your analysis. You must ignore parts of the spec that fall outside this feature definition.
 
 # EXTRACTION PROTOCOL
-Read the `<spec_document>` (and `<mdn_document>` or `<explainer>` if available) and extract every normative requirement that fits within the scope of the `<feature_definition>`.
+Read the `<spec_document>`{% if has_mdn %} and `<mdn_document>`{% endif %}{% if has_explainer %} and `<explainer>`{% endif %} and extract every normative requirement that fits within the scope of the `<feature_definition>`.
 
 **CRITICAL:** You MUST ONLY extract requirements that fall into the following specific category:
 * **{{category_name}}**: {{category_description}}

--- a/wptgen/templates/requirements_extraction_iterative_system.jinja
+++ b/wptgen/templates/requirements_extraction_iterative_system.jinja
@@ -14,15 +14,19 @@ You are a Principal Software Engineer in Test (SDET) and a W3C Specification Ana
 7. **The Exhaustion Principle:** You are limited to a maximum of 10 new requirements per run. However, it is a sign of SUCCESS to output fewer than 10. If the spec only contains 2 new high-value requirements, output exactly 2. If ALL high-value requirements are already in the `<existing_requirements>`, you MUST output exactly 0 requirements. Do not invent edge cases to pad your list.
 
 # INPUTS
-1. `<spec_document>`: The technical specification text.
-2. `<mdn_document>` (Optional): Supplemental MDN documentation for the feature.
-3. `<explainer>` (Optional): Explainer documents providing high-level context.
-4. `<feature_definition>`: The scope of your analysis. You must ignore parts of the spec that fall outside this feature definition.
-5. `<existing_requirements>`: A list of requirements that have ALREADY been extracted. You must read these carefully to avoid duplication.
+* `<spec_document>`: The technical specification text.
+{% if has_mdn -%}
+* `<mdn_document>`: Supplemental MDN documentation for the feature.
+{% endif -%}
+{% if has_explainer -%}
+* `<explainer>`: Explainer documents providing high-level context.
+{% endif -%}
+* `<feature_definition>`: The scope of your analysis. You must ignore parts of the spec that fall outside this feature definition.
+* `<existing_requirements>`: A list of requirements that have ALREADY been extracted. You must read these carefully to avoid duplication.
 
 # EXTRACTION PROTOCOL
 
-Read the `<spec_document>` (and `<mdn_document>` or `<explainer>` if available) and extract every normative requirement that fits within the scope of the `<feature_definition>`.
+Read the `<spec_document>`{% if has_mdn %} and `<mdn_document>`{% endif %}{% if has_explainer %} and `<explainer>`{% endif %} and extract every normative requirement that fits within the scope of the `<feature_definition>`.
 
 
 Identify the Category for each rule:

--- a/wptgen/templates/requirements_extraction_system.jinja
+++ b/wptgen/templates/requirements_extraction_system.jinja
@@ -12,13 +12,17 @@ You are a Principal Software Engineer in Test (SDET) and a W3C Specification Ana
 4.  **Atomic Descriptions:** Each requirement must be a single, testable assertion. Do not combine multiple behaviors. The description must read like a test objective (e.g., "If the dictionary member is missing, it must default to false.").
 
 # INPUTS
-1.  `<spec_document>`: The technical specification text.
-2.  `<mdn_document>` (Optional): Supplemental MDN documentation for the feature.
-3.  `<explainer>` (Optional): Explainer documents providing high-level context.
-4.  `<feature_definition>`: The scope of your analysis. You must ignore parts of the spec that fall outside this feature definition.
+* `<spec_document>`: The technical specification text.
+{% if has_mdn -%}
+* `<mdn_document>`: Supplemental MDN documentation for the feature.
+{% endif -%}
+{% if has_explainer -%}
+* `<explainer>`: Explainer documents providing high-level context.
+{% endif -%}
+* `<feature_definition>`: The scope of your analysis. You must ignore parts of the spec that fall outside this feature definition.
 
 # EXTRACTION PROTOCOL
-Read the `<spec_document>` (and `<mdn_document>` or `<explainer>` if available) and extract every normative requirement that fits within the scope of the `<feature_definition>`. Identify rules based on the following:
+Read the `<spec_document>`{% if has_mdn %} and `<mdn_document>`{% endif %}{% if has_explainer %} and `<explainer>`{% endif %} and extract every normative requirement that fits within the scope of the `<feature_definition>`. Identify rules based on the following:
 * **Existence:** Rules defining the feature's surface area (interfaces, methods, properties).
 * **Common Use Cases:** Rules defining successful behaviors, processing models, and realistic "happy paths."
 * **Error Scenarios:** Rules defining error conditions, thrown exceptions, and invalid states.


### PR DESCRIPTION
Resolves #342

## Overview
Makes fetching MDN documentation optional during the requirements extraction phase by adding a new `--include-mdn-docs` CLI flag. 

## Root Cause / Motivation
Currently, the WPT-Gen pipeline automatically fetches MDN documentation if it is available. While this is helpful for generating tests, it is not strictly required for all features and can unnecessarily increase context sizes and token usage. Adding this flag gives users granular control over whether MDN documents should be obtained and included in the requirements extraction prompts.

## Detailed Changelog
* **`wptgen/config.py`**: Added an `include_mdn_docs` boolean field to the `Config` model and wired it to `load_config` (defaults to `False`).
* **`wptgen/main.py`**: Exposed the `--include-mdn-docs` CLI option in both the `generate` and `audit` Typer commands.
* **`wptgen/phases/context_assembly.py`**: Updated `run_context_assembly` to conditionally invoke `fetch_mdn_urls` based on the new configuration.
* **`wptgen/templates/*.jinja`**: Wrapped the `<mdn_document>` inputs and related instructions with `{% if mdn_contents %}` inside the standard, iterative, and categorized extraction system prompts.
* **`tests/test_main.py` & `tests/test_phases.py`**: Added assertions to handle the new `include_mdn_docs_override` parameter in mocks and introduced a test to verify that MDN fetching is skipped when the flag evaluates to `False`.
