### PR TITLE
feat: Add `--force` flag to `clear-cache` command for CI/CD automation

### DIFF
--- a/tests/test_clear_cache.py
+++ b/tests/test_clear_cache.py
@@ -84,6 +84,28 @@ def test_clear_cache_success(
   assert cache_dir.exists()  # The directory itself should remain, but empty
 
 
+def test_clear_cache_force(
+  mock_config: Config, mock_load_config: MagicMock, mock_ui: MagicMock
+) -> None:
+  """Test successful cache clearing when using the --force flag (bypasses confirmation)."""
+  assert mock_config.cache_path is not None
+  cache_dir = Path(mock_config.cache_path)
+
+  # Populate cache
+  (cache_dir / 'file1.txt').write_text('content1')
+  (cache_dir / 'subdir').mkdir()
+  (cache_dir / 'subdir' / 'file2.txt').write_text('content2')
+
+  result = runner.invoke(app, ['clear-cache', '--force'])
+
+  assert result.exit_code == 0
+  mock_ui.confirm.assert_not_called()
+  assert 'Cache cleared successfully' in normalize_ws(result.stdout)
+  assert not (cache_dir / 'file1.txt').exists()
+  assert not (cache_dir / 'subdir').exists()
+  assert cache_dir.exists()
+
+
 def test_clear_cache_aborted(
   mock_config: Config, mock_load_config: MagicMock, mock_ui: MagicMock
 ) -> None:

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -1236,6 +1236,7 @@ def clear_cache(
   config_path: Annotated[
     str, typer.Option('--config', '-c', help='Path to a custom wpt-gen.yml file.')
   ] = DEFAULT_CONFIG_PATH,
+  force: Annotated[bool, typer.Option('--force', '-f', help='Bypass confirmation prompt.')] = False,
 ) -> None:
   """
   Clear the existing cached data for wpt-gen.
@@ -1257,7 +1258,9 @@ def clear_cache(
       console.print(f'Cache directory [cyan]{cache_dir}[/cyan] is already empty.')
       return
 
-    if ui.confirm(f'Are you sure you want to clear the cache at [cyan]{cache_dir}[/cyan]?'):
+    if force or ui.confirm(
+      f'Are you sure you want to clear the cache at [cyan]{cache_dir}[/cyan]?'
+    ):
       for item in files:
         if item.is_file():
           item.unlink()


### PR DESCRIPTION
## Description
Fixes #334

Added the `--force` (`-f`) flag to the `clear-cache` command to bypass the confirmation prompt, allowing the command to be used in automated workflows, scripts, or CI/CD pipelines where no interactive TTY is available. 

## Changes Made
- Added `--force` / `-f` flag to `wptgen/main.py` -> `clear_cache`.
- Bypassed the `ui.confirm` prompt if the `force` flag is `True`.
- Added a corresponding test `test_clear_cache_force` to `tests/test_clear_cache.py`.
- Ran `make check` successfully.