### PR TITLE
Enforce Strict WPT-Gen Agent Skills & ADK Architectures via Embedded Workflows

### DIFF
--- a/.agents/skills/wpt-gen-cli/SKILL.md
+++ b/.agents/skills/wpt-gen-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wpt-gen-cli
-description: Best practices for CLI infrastructure, outputs, and templating in WPT-Gen.
+description: Best practices for CLI infrastructure, outputs, subprocess management, and templating in WPT-Gen.
 ---
 
 # WPT-Gen CLI Skills
@@ -20,18 +20,27 @@ WPT-Gen uses [Typer](https://typer.tiangolo.com/) for building its command-line 
     - `--show-responses` (`-s`): Display raw LLM-generated responses.
     - `--use-lightweight` / `--use-reasoning`: Force a specific model category.
 
-## 2. Rich Console Output
+## 2. Rich Console Output & Abstraction
 
 For displaying information to the user, WPT-Gen utilizes [Rich](https://rich.readthedocs.io/en/stable/).
 
-- **Styling:** Use `rich.print` (often imported as `from rich import print`) for colored and formatted output.
-- **Panels & Tables:** Use `Panel` to encapsulate related information (like summarizing the generated test plan) and `Table` for structured data.
-- **Progress Bars:** When iterating over long-running LLM calls out, use `rich.progress` to provide visual feedback to the user so they know the command has not hung.
+- **Strict UIProvider Abstraction:** Never use the native `print()` function. You must route all outputs through the injected `UIProvider` dependency (e.g. `ui.print`, `ui.warning`, `ui.error`).
+- **Styling:** Use `rich.print` (via `UIProvider`) for colored and formatted output.
+- **Panels & Tables:** Use `rich.panel.Panel` to encapsulate related information (like summarizing test plans) and `rich.table.Table` for structured data, rather than dumping raw JSON or concatenated strings to the CLI.
+- **Progress Bars:** When iterating over long-running LLM calls, use `ui.status()` wrappers to provide visual `rich.progress` spinners to the user so they know the command has not hung.
 
-## 3. Templating with Jinja2
+## 3. Subprocess execution & Wrappers
+
+WPT-Gen heavily relies on executing native binaries (`wpt lint`, `grep`) to empower LLM agents. 
+
+- **Subprocess Stability (Hung Agents):** Autonomous agents will hang indefinitely if tools don't return. When using `subprocess.run()`, you must **always** provide explicit `timeout=...` constraints, otherwise a rogue blocking command will freeze the AI forever.
+- **Environment Context Leaking:** Subprocess calls must construct and pass explicit `env={**os.environ, "CUSTOM": "VAL"}` mappings, rather than lazily mutating the global `os.environ` which bleeds state across Python threads. Reviewers must actively catch environment leaking.
+- **Shell Injection & Compat:** When wrapping native CLI execution tools (e.g., `git grep` or `grep`), scrutinize custom arguments for shell injection vulnerabilities. Force the use of the `--` argument separator to securely separate binary options from user-generated patterns.
+
+## 4. Templating with Jinja2
 
 WPT-Gen uses Jinja2 to template both prompts to the LLM and the final generated output (HTML/JS files).
 
 - **Location:** Templates are typically stored in the `wptgen/templates/` directory.
 - **Variable Injection:** Use standard Jinja2 syntax (`{{ variable_name }}`) to inject context retrieved via `trafilatura` or derived from local scans.
-- **Control Structures:** Utilize standard `{% if %}` and `{% for %}` loops to dynamically construct test structures based on the suggested test footprint.
+- **Control Structures:** Utilize standard `{% if %}` and `{% for %}` loops to dynamically construct test structures based on the suggested test footprint. Ensure large, nullable dependencies are robustly guarded behind `{% if %}` conditions to avoid causing context bloat.

--- a/.agents/skills/wpt-gen-llm/SKILL.md
+++ b/.agents/skills/wpt-gen-llm/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: wpt-gen-llm
-description: Best practices for configuring LLM integrations, provider configuration, context scraping, and managing prompts in WPT-Gen.
+description: Best practices for configuring LLM integrations, concurrent networking, context scraping, and managing prompts in WPT-Gen.
 ---
 
 # WPT-Gen LLM Skills
 
-This document outlines the best practices for LLM integrations within the `wpt-gen` repository.
+This document outlines the best practices for LLM integrations, prompt pipeline safety, and context extraction within the `wpt-gen` repository.
 
 ## 1. Multi-Provider Support
 
@@ -26,16 +26,19 @@ The agentic workflow uses different model categories based on the complexity of 
     - **Test Generation**: Produces test code based on audit blueprints.
     - **Evaluation**: Performs self-correction and validation of generated code.
 
-## 3. Context Scraping
+## 3. Network Architecture (Context Extraction)
 
-Providing context is critical for minimizing hallucinations.
+Providing context is critical for minimizing hallucinations, but it involves extensive network I/O blockades.
 
-- **Trafilatura:** WPT-Gen uses `trafilatura` to extract text from W3C Specification URLs linked to web features.
+- **Concurrent I/O:** Always use `asyncio.gather` combined with `asyncio.to_thread` for concurrent network requests (e.g. fetching 5 MDN explainer URLs at once). Blocking sequential `for` loops across network dependencies creates catastrophic UI lag.
+- **Missing Failsafes:** Reviewers must actively flag blocking network requests that lack exponential retry logic/backoff for `HTTPError 429` (Too Many Requests). Do not depend on LLMs blindly surviving a dropped HTTP request.
+- **Trafilatura:** WPT-Gen uses `trafilatura` to extract dense text from W3C Specification URLs linked to web features.
 
-## 4. Prompt Management
+## 4. Prompt Management & Defensive Context
 
-Prompt structure determines the output quality.
+Prompt structure determines output quality, but unbounded inputs determine runtime OOM exceptions. 
 
+- **Defensive Paging (OOM/Token Limits):** Native memory limits and LLM token limits require defensive programming. If ingesting massive terminal runner logs into the context window, slice the array to only keep the *tail end* to remain token-efficient. If querying expansive file directory contents, return or exit early when numerical limits are hit rather than crashing. 
+- **Context Bloat:** Ensure large, optional prompt dependencies (like MDN explainers) are safely guarded behind Jinja `{% if %}` statements to avoid feeding the LLM empty strings when variables map to null.
 - **Clear Instructions:** Ensure system prompts clearly dictate the agent's persona (expert test engineer) and the expected format.
-- **Few-Shot Prompting:** When generating precise test structures (e.g., testharness.js output), provide examples of well-formed WPT tests within the prompt.
 - **XML Output:** When requesting structured data (like gap analysis or test blueprints), explicitly request XML format and provide the intended schema structure. This allows WPT-Gen to parse and programmatically act on the AI output.

--- a/.agents/skills/wpt-gen-maintenance/SKILL.md
+++ b/.agents/skills/wpt-gen-maintenance/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: wpt-gen-maintenance
-description: Instructions on managing dependencies, build tools, and integrating workflows via the Makefile in WPT-Gen.
+description: Instructions on managing dependencies, build tools, project architecture rules, and integrating workflows via the Makefile in WPT-Gen.
 ---
 
 # WPT-Gen Maintenance Skills
 
-This document outlines standard maintenance procedures and development workflow instructions for the `wpt-gen` repository.
+This document outlines standard maintenance procedures, core architectural constraints, and development workflow instructions for the `wpt-gen` repository.
 
 ## 1. Project Management
 
@@ -36,7 +36,16 @@ make presubmit
 
 This command runs `lint-fix`, `typecheck`, and `test`. If this pipeline fails, your code will fail Continuous Integration.
 
-## 3. License Compliance
+## 3. Core Architecture Rules
+
+When authoring or reviewing structural code for WPT-Gen, you MUST strictly adhere to these foundational constraints:
+
+- **Google Python Style Guide:** All code MUST adhere strictly to the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html), particularly concerning docstring formatting, naming conventions, and inline comments. Reviewers must reject patches that violate standard Python whitespace or Google documentation formatting.
+- **Strict Type Design (No Magic Strings):** Never use arbitrary "magic strings" (e.g., `'chrome'`, `'canary'`, `'gemini'`) for business logic routing or configurations. You must define explicit Python `Enum` classes. For grouping configurations, prefer the use of explicit `@dataclass` objects over sprawling dictionaries or tuples.
+- **Type Checking Escapes:** Bypassing strict types with `# type: ignore` comments is strictly banned without an accompanying inline comment providing technical justification for the upstream stub failure.
+- **Security & Pathing (Sandbox Escapes):** LLMs frequently hallucinate or generate unsafe relative file system paths. You must **always** anchor file access to a base boundary directory (e.g. `wpt_root` or `output_dir`). You must strictly validate paths before execution using `path.resolve().relative_to(wpt_root)` to prevent catastrophic `../` traversal sandbox escapes. Reviewers must actively search for `read_text` or `write_text` calls that lack preceding `.relative_to()` constraints.
+
+## 4. License Compliance
 
 Every file containing source code must include the standard Apache 2.0 copyright and license information header.
 
@@ -60,7 +69,7 @@ Every file containing source code must include the standard Apache 2.0 copyright
 
 Ensure this is present at the top of any newly created `.py`, `.js`, `.html`, or `.yml` files.
 
-## 4. Cleanup Operations
+## 5. Cleanup Operations
 
 To avoid stale cache issues (especially with `pytest` or `mypy`):
 

--- a/.agents/skills/wpt-gen-testing/SKILL.md
+++ b/.agents/skills/wpt-gen-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wpt-gen-testing
-description: Guidelines for Python testing using pytest, including async tests, mocking, type safety (mypy), and syntax/style linting (ruff) in WPT-Gen.
+description: Guidelines for Python testing using pytest, including coverage constraints, mock migrations, type safety (mypy), and style linting (ruff) in WPT-Gen.
 ---
 
 # WPT-Gen Testing Skills
@@ -13,10 +13,22 @@ WPT-Gen relies on [pytest](https://docs.pytest.org/) for its testing framework.
 
 - **Location:** All tests reside in the `tests/` directory.
 - **Async Tests:** Because LLM generation and scraping operations are asynchronous, use the `pytest.mark.asyncio` decorator (provided by `pytest-asyncio`) for any `async def test_...()` functions.
-- **Mocking:** Use the `mocker` fixture (provided by `pytest-mock`) to isolate units under test. Mock external LLM API calls, file system operations (`os`, `pathlib`), and network requests (`trafilatura`).
+- **Data-Driven Parameterization:** Use `pytest.mark.parametrize` to rigorously cover provider matrices (Gemini, OpenAI, Anthropic tests) cleanly within isolated scopes.
 - **Assertion Style:** Use standard `assert` statements. Avoid `unittest.TestCase` inheritance unless absolutely necessary for a legacy mock.
 
-## 2. Static Type Checking with Mypy
+## 2. Mocking Philosophy & Constraints
+
+- **pytest-mock Migration:** Use the `mocker` fixture (provided by `pytest-mock`) to isolate units under test. Completely reject and avoid legacy `unittest.mock` approaches (like `@patch` or `patch.object`) inside native pytest scopes.
+- **Broad Exception Catching:** Testing error boundaries is crucial. Avoid generic `except Exception:` blocks unless strictly re-raising. Actively catch explicit exceptions (`OSError`, `HTTPError`) to prove the error handlers function correctly. Reviewers must flag lazily wrapped `except Exception:` catch-alls.
+
+## 3. Coverage Analysis & Cheating Bans
+
+WPT-Gen actively pipelines against `--cov-fail-under` thresholds to monitor test stability. 
+
+- **Test Coverage Gamification:** Explicitly **BAN** the usage of `# pragma: no cover` for artificially bypassing untested error handlers or logical edge-cases in pursuit of arbitrary 100% metrics. 
+- **Reviewer Guideline:** If you see `# pragma: no cover` in a PR, instruct the developer to either write the corresponding test matrix, or lower the overall `--cov-fail-under` requirement (e.g., dial it back to 95%). Artificial masking creates a severe false sense of security over time.
+
+## 4. Static Type Checking with Mypy
 
 WPT-Gen enforces strict type checking using [mypy](https://mypy.readthedocs.io/).
 
@@ -24,7 +36,7 @@ WPT-Gen enforces strict type checking using [mypy](https://mypy.readthedocs.io/)
 - **Typing Every Signature:** Every function, method, and variable definition should have a type hint where it cannot be perfectly inferred.
 - **Handling `Any`:** Avoid using `Any` wherever possible. If integrating with untyped third-party libraries, use `# type: ignore` sparingly and document why it is necessary.
 
-## 3. Linting and Formatting with Ruff
+## 5. Linting and Formatting with Ruff
 
 WPT-Gen uses [Ruff](https://docs.astral.sh/ruff/) as a unified linter and formatter.
 

--- a/.agents/workflows/review_pr.md
+++ b/.agents/workflows/review_pr.md
@@ -1,0 +1,32 @@
+---
+description: An explicit step-by-step workflow for the AI to dynamically review and apply internal architectural constraints before conducting a Code Review on PRs.
+---
+
+# Code Review Protocol
+
+This workflow dictates the exact steps you MUST take before submitting or authoring a PR review for the WPT-Gen repository. Because WPT-Gen extensively leverages LLM/ADK architectures, its engineering standards are rigid.
+
+## Step 1: Ingest the Augmentations
+
+Before you look at a single line of patch code, you MUST use the `view_file` tool to secretly brush up on the 4 canonical architectural skills in the WPT-Gen codebase. These files dictate exactly what you are looking for.
+
+### Execute `view_file` on the following paths:
+1. `.agents/skills/wpt-gen-maintenance/SKILL.md` (Focus on finding missing Sandboxing, Type-checking cheats, and missing Enums).
+2. `.agents/skills/wpt-gen-testing/SKILL.md` (Focus on finding `# pragma: no cover` abuses and `unittest.mock` infractions).
+3. `.agents/skills/wpt-gen-cli/SKILL.md` (Focus on finding missing Subprocess timeouts, leaked Environment states, and raw `print()` statements).
+4. `.agents/skills/wpt-gen-llm/SKILL.md` (Focus on lack of `asyncio.gather` concurrency, missing network retries, and unbounded LLM context arrays).
+
+## Step 2: The Detective Mindset
+
+When analyzing the user's PR or `.patch` file, take a hostile but polite approach. Assume the author successfully generated working code, but critically failed edge-case constraints.
+
+- Did they add an HTTP request without a retry handler?
+- Did they add a `subprocess.run` without an explicit `timeout=...`?
+- Did they add file reading without `Path().relative_to(wpt_root)`?
+- Did they slap `# pragma: no cover` on a line rather than writing the test?
+
+If you find ANY violations of the rules established in step 1, you MUST firmly request changes in your review and cite the relevant architectural danger (e.g. "We don't use `# pragma: no cover` here because it creates a false sense of security.")
+
+## Step 3: Write the Review
+
+Format your review cleanly using GitHub-style Markdown. Always lead with praise before delivering the critique. Use `write_to_file` to save your review locally if requested, or present it dynamically.


### PR DESCRIPTION
This Pull Request codifies all architectural, security, and stability lessons learned across the first 29 codebase iterations into native **Gemini AI Skills**.

By natively integrating these skills, we guarantee that any future AI agent (or team member using Gemini) acting as an Author or a Reviewer strictly adheres to the established Python boundaries of this project without suffering context bloat or hallucinated security flaws.

Key Changes:

To prevent "Agent Confusion" caused by overlapping contexts, we have **augmented the 4 existing skills** rather than creating new ones:

1. **`wpt-gen-maintenance/SKILL.md` (Core Architecture):**
   - Enforces the Google Python Style Guide for docstrings and formatting.
   - Bans "magic strings" in favor of strict `Enum` and `@dataclass` routing.
   - **Crucial Security:** Mandates strict sandboxing of file paths via `Path.relative_to(wpt_root)` to prevent arbitrary file traversal escapes from LLM generations.

2. **`wpt-gen-testing/SKILL.md` (Testing & Mocks):**
   - Strictly bans the usage of `# pragma: no cover` for gamifying 100% metrics over legitimately verified error scopes.
   - Bans legacy `unittest.mock` configurations in favor of `pytest-mock` (`mocker`).

3. **`wpt-gen-cli/SKILL.md` (Execution & CLI Stability):**
   - Bans the native `print()` loop, mandating routing through the strict `UIProvider` using `rich.table.Table`.
   - **Crucial Stability:** Mandates explicit `timeout=...` constraints on all `subprocess.run()` tools to prevent the autonomous agent from hanging infinitely.
   - Guards against environmental state leaking.

4. **`wpt-gen-llm/SKILL.md` (LLM Context & Network I/O):**
   - Requires `asyncio.gather` for concurrent fetching, accompanied by mandatory HTTP `429` retry logic frameworks.
   - Enforces defensive memory paging (slicing arrays to only keep terminal tails) to prevent OOM errors and Token budget explosions.
   - Guards optional templating variables (like MDN docs) behind strict Jinja `{% if %}` gates.

ADK Workflow Integration (`review_pr.md`):

Because reviewing is a complex, generalized task, we added `.agents/workflows/review_pr.md`. This leverages the native routing of the AI agent running the repository. Any developer can invoke this workflow instruction, and the agent will natively ingest the 4 `SKILL.md` rulesets as system context and ruthlessly evaluate incoming `.patch` files against this exhaustive standard. This only works with [Antigravity](https://codelabs.developers.google.com/autonomous-ai-developer-pipelines-antigravity#1) I think though.