### PR TITLE
feat: add ChromeStatus command and explainer support in context assembly

### DIFF
--- a/tests/test_chromestatus.py
+++ b/tests/test_chromestatus.py
@@ -46,6 +46,27 @@ def test_fetch_chromestatus_metadata_success(mocker: MockerFixture) -> None:
   assert metadata.wpt_descr == 'Existing tests: https://wpt.fyi/results/css/css-grid'
 
 
+def test_fetch_chromestatus_metadata_with_prefix(mocker: MockerFixture) -> None:
+  """Tests that the JSON vulnerability prefix is correctly stripped."""
+  mock_data = {
+    'name': 'Prefixed Feature',
+    'summary': 'This feature has a prefix.',
+  }
+  # Simulate the prefix found in the real ChromeStatus API
+  prefix_content = ")]}'\n" + json.dumps(mock_data)
+
+  mock_response = mocker.MagicMock()
+  mock_response.read.return_value = prefix_content.encode('utf-8')
+  mock_response.__enter__.return_value = mock_response
+  mocker.patch('urllib.request.urlopen', return_value=mock_response)
+
+  metadata = fetch_chromestatus_metadata('1238765')
+
+  assert metadata is not None
+  assert metadata.name == 'Prefixed Feature'
+  assert metadata.description == 'This feature has a prefix.'
+
+
 def test_fetch_chromestatus_metadata_not_found(mocker: MockerFixture) -> None:
   mocker.patch(
     'urllib.request.urlopen',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -420,6 +420,38 @@ def test_init_command_with_wpt_path_flag() -> None:
     assert str(Path('/flag/wpt').resolve()) == config_data['wpt_path']
 
 
+@pytest.mark.parametrize('suggestions_only', [True, False])
+def test_chromestatus_command(
+  mock_config: Config,
+  mock_load_config: Any,
+  mock_engine_instance: Any,
+  suggestions_only: bool,
+) -> None:
+  """Test the chromestatus command with and without --suggestions-only."""
+  # Mock load_config and the Engine so they don't actually execute
+  mock_config.chromestatus = True
+
+  # Simulate running `wpt-gen chromestatus 12345`
+  args = ['chromestatus', '12345']
+  if suggestions_only:
+    args.append('--suggestions-only')
+
+  result = runner.invoke(app, args)
+
+  # Check standard output and exit code
+  assert result.exit_code == 0
+  assert 'Target ChromeStatus Feature' in result.stdout
+
+  # Verify our logic called the underlying functions with the correct CLI arguments
+  mock_load_config.assert_called_once()
+  kwargs = mock_load_config.call_args.kwargs
+  assert kwargs['suggestions_only'] is suggestions_only
+  assert kwargs['chromestatus_override'] is True
+
+  # Ensure the engine workflow was triggered with the correct feature ID
+  mock_engine_instance.run_workflow.assert_called_once_with('12345')
+
+
 def test_audit_success(mock_load_config: Any, mock_engine_instance: Any) -> None:
   """Test the happy path execution of the audit command."""
   result = runner.invoke(app, ['audit', 'grid', '--provider', 'gemini'])

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -129,7 +129,7 @@ async def test_run_context_assembly_with_mdn(
   assert context is not None
   assert isinstance(context.mdn_contents, list)
   assert len(context.mdn_contents) == 2
-  mock_ui.report_context_summary.assert_called_once()
+  mock_ui.report_context_summary.assert_called_once_with(len('Spec Content'), 0, 2, 0, 0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -95,6 +95,13 @@ def test_report_metadata(ui: RichUIProvider, mock_console: MagicMock) -> None:
   assert panel.title == '[bold]Feature Metadata[/bold]'
 
 
+def test_report_metadata_with_explainers(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test report_metadata semantic method with explainers."""
+  metadata = FeatureMetadata('Feat', 'Desc', ['http://spec'], explainer_links=['http://explainer'])
+  ui.report_metadata(metadata)
+  mock_console.print.assert_called_once()
+
+
 def test_report_token_usage(ui: RichUIProvider, mock_console: MagicMock) -> None:
   """Test report_token_usage semantic method."""
   ui.report_token_usage('Phase', 'Model', [(100, False, 'Task')], 100)
@@ -230,7 +237,7 @@ def test_on_phase_complete(ui: RichUIProvider, mock_console: MagicMock) -> None:
 
 
 def test_report_context_summary(ui: RichUIProvider, mock_console: MagicMock) -> None:
-  ui.report_context_summary(1, 2, 3, 4)
+  ui.report_context_summary(1, 2, 3, 4, 5)
   mock_console.print.assert_called_once()
 
 

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -98,6 +98,12 @@ def fetch_chromestatus_metadata(feature_id: str) -> FeatureMetadata | None:
     req = urllib.request.Request(url, headers={'User-Agent': 'WPT-Gen/1.0'})
     with urllib.request.urlopen(req) as response:
       content = response.read().decode('utf-8')
+      # ChromeStatus API often prefixes JSON with a vulnerability protection string.
+      if content.startswith(")]}'\n"):
+        content = content[5:]
+      elif content.startswith(")]}'"):
+        content = content[4:]
+
       data = json.loads(content)
 
       # Map ChromeStatus fields to FeatureMetadata

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -512,6 +512,229 @@ def generate(
     )
 
 
+@app.command(name='chromestatus')
+def chromestatus_command(
+  feature_id: Annotated[
+    str,
+    typer.Argument(help='The ChromeStatus feature ID (e.g., "12345").'),
+  ],
+  provider: Annotated[
+    str | None,
+    typer.Option(
+      '--provider',
+      '-p',
+      help="Override the default LLM provider (e.g., 'gemini', 'openai', 'anthropic').",
+    ),
+  ] = None,
+  wpt_dir: Annotated[
+    Path | None,
+    typer.Option(
+      '--wpt-dir',
+      '-w',
+      help='Path to the local web-platform-tests repository.',
+      exists=True,
+      dir_okay=True,
+      resolve_path=True,
+    ),
+  ] = None,
+  output_dir: Annotated[
+    Path | None,
+    typer.Option(
+      '--output-dir',
+      '-o',
+      help='Directory where generated tests will be saved.',
+      dir_okay=True,
+    ),
+  ] = None,
+  config_path: Annotated[
+    str, typer.Option('--config', '-c', help='Path to a custom wpt-gen.yml file.')
+  ] = DEFAULT_CONFIG_PATH,
+  show_responses: Annotated[
+    bool,
+    typer.Option(
+      '--show-responses', '-s', help='Display every LLM-generated response to the user.'
+    ),
+  ] = False,
+  yes_tokens: Annotated[
+    bool,
+    typer.Option('--yes-tokens', help='Automatically confirm all token count prompts.'),
+  ] = False,
+  yes_cache: Annotated[
+    bool,
+    typer.Option(
+      '--yes-cache',
+      help='Automatically use the cache if it exists without prompting.',
+    ),
+  ] = False,
+  no_cache: Annotated[
+    bool,
+    typer.Option(
+      '--no-cache',
+      help='Automatically ignore and overwrite the cache if it exists without prompting.',
+    ),
+  ] = False,
+  resume: Annotated[
+    bool,
+    typer.Option(
+      '--resume',
+      help='Resume the workflow from the last successful phase.',
+    ),
+  ] = False,
+  max_retries: Annotated[
+    int,
+    typer.Option(
+      '--max-retries',
+      help='Maximum number of retries for LLM calls.',
+    ),
+  ] = 3,
+  timeout: Annotated[
+    int,
+    typer.Option(
+      '--timeout',
+      help='Timeout for LLM requests in seconds.',
+    ),
+  ] = DEFAULT_LLM_TIMEOUT,
+  include_thoughts: Annotated[
+    bool,
+    typer.Option(
+      '--include-thoughts',
+      help='Stream the underlying ADK model thoughts to stdout.',
+    ),
+  ] = False,
+  use_lightweight: Annotated[
+    bool,
+    typer.Option('--use-lightweight', help='Use the lightweight model for all LLM requests.'),
+  ] = False,
+  use_reasoning: Annotated[
+    bool,
+    typer.Option('--use-reasoning', help='Use the reasoning model for all LLM requests.'),
+  ] = False,
+  save_traces: Annotated[
+    bool,
+    typer.Option(
+      '--save-traces',
+      help='Save LLM interaction traces to the .wptgen/traces/ directory.',
+    ),
+  ] = False,
+  suggestions_only: Annotated[
+    bool,
+    typer.Option(
+      '--suggestions-only',
+      help='Only generate the coverage audit report, skip test generation.',
+    ),
+  ] = False,
+) -> None:
+  """
+  Perform a coverage audit and generate a report for a ChromeStatus feature.
+  """
+  banner = Panel(
+    Align.center(
+      Text.from_markup(
+        '[bold blue]WPT[/bold blue][bold white]-[/bold white][bold green]Gen[/bold green]\n'
+        '[italic white]AI-Powered Web Platform Test Generation[/italic white]'
+      )
+    ),
+    border_style='bright_blue',
+  )
+  console.print(banner)
+  console.print(f'\n[bold]Target ChromeStatus Feature:[/bold] [cyan]{feature_id}[/cyan]\n')
+
+  if use_lightweight and use_reasoning:
+    ui.error('Cannot use both --use-lightweight and --use-reasoning.')
+    raise typer.Exit(code=1)
+
+  try:
+    # 1. Load configuration (merging YAML, env vars, and CLI overrides)
+    wpt_dir_str = str(wpt_dir) if wpt_dir else None
+    output_dir_str = str(output_dir) if output_dir else None
+
+    config = load_config(
+      config_path=config_path,
+      provider_override=provider,
+      wpt_dir_override=wpt_dir_str,
+      output_dir_override=output_dir_str,
+      show_responses=show_responses,
+      yes_tokens_override=yes_tokens,
+      yes_tests_override=False,
+      yes_cache_override=yes_cache,
+      no_cache_override=no_cache,
+      suggestions_only=suggestions_only,
+      brief_suggestions=False,
+      resume_override=resume,
+      resume_from_override=None,
+      state_dir_override=None,
+      max_retries_override=max_retries,
+      timeout_override=timeout,
+      spec_urls_override=None,
+      feature_description_override=None,
+      detailed_requirements_override=False,
+      include_mdn_docs_override=False,
+      draft_override=False,
+      chromestatus_override=True,
+      single_prompt_requirements_override=False,
+      use_lightweight_override=use_lightweight,
+      use_reasoning_override=use_reasoning,
+      include_thoughts_override=include_thoughts,
+      tentative_override=False,
+      save_traces_override=save_traces,
+      max_parallel_requests_override=None,
+      run_on_browser_override=None,
+      run_on_channel_override=None,
+      temperature_override=None,
+    )
+
+    config_info = Text.assemble(
+      ('Provider: ', 'bold'),
+      (f'{config.provider}\n', 'green'),
+      ('Model:    ', 'bold'),
+      (f'{config.default_model}', 'green'),
+    )
+    console.print(
+      Panel(
+        config_info,
+        title='[bold]Configuration[/bold]',
+        title_align='left',
+        expand=False,
+        border_style='bright_black',
+      )
+    )
+
+    # 2. Instantiate the core engine
+    engine = WPTGenEngine(config=config, ui=ui)
+
+    # 3. Execute the workflow
+    engine.run_workflow(feature_id)
+
+    console.print()
+    console.print(
+      Panel(
+        '[bold green]✔ ChromeStatus Audit completed successfully![/bold green]',
+        border_style='green',
+        expand=False,
+      )
+    )
+
+  except LLMTimeoutError as e:
+    console.print(f'[bold red]LLM Request Timeout:[/bold red] {str(e)}')
+    raise typer.Exit(code=1) from e
+  except ValueError as e:
+    console.print(f'[bold red]Configuration Error:[/bold red] {str(e)}')
+    raise typer.Exit(code=1) from e
+  except WorkflowError:
+    console.print()
+    console.print(
+      Panel(
+        '[bold red]✘ Workflow completed with errors.[/bold red]',
+        border_style='red',
+        expand=False,
+      )
+    )
+    raise typer.Exit(code=1) from None
+  except Exception as e:
+    console.print(f'[bold red]Unexpected Error:[/bold red] {str(e)}')
+    raise typer.Exit(code=1) from e
+
+
 @app.command(name='doctor')
 def doctor_command(
   config_path: Annotated[

--- a/wptgen/phases/context_assembly.py
+++ b/wptgen/phases/context_assembly.py
@@ -83,6 +83,17 @@ async def run_context_assembly(
     ui.error('Failed to extract spec content.')
     return None
 
+  explainer_contents: dict[str, str] | None = None
+  if metadata.explainer_links:
+    ui.print('Fetching explainer content...')
+    with ui.status(f'Fetching {len(metadata.explainer_links)} explainers...'):
+      results = await asyncio.gather(
+        *[asyncio.to_thread(fetch_and_extract_text, url) for url in metadata.explainer_links]
+      )
+      explainer_contents = {
+        url: res for url, res in zip(metadata.explainer_links, results, strict=True) if res
+      }
+
   ui.print('Scanning local WPT repository for existing tests and dependencies...')
   test_paths = find_feature_tests(config.wpt_path, web_feature_id)
   extracted_wpt_urls: list[str] | None = None
@@ -107,7 +118,7 @@ async def run_context_assembly(
   wpt_context = gather_local_test_context(test_paths, config.wpt_path)
 
   mdn_contents: list[str] | None = None
-  if config.include_mdn_docs:
+  if config.include_mdn_docs and not config.chromestatus:
     ui.print('Fetching MDN documentation...')
     mdn_urls = fetch_mdn_urls(web_feature_id)
     if mdn_urls:
@@ -121,11 +132,14 @@ async def run_context_assembly(
           for url, res in zip(mdn_urls, results, strict=True)
           if res
         ]
+  elif config.chromestatus:
+    ui.print('Skipping MDN documentation fetch for ChromeStatus feature.')
   else:
     ui.print('Skipping MDN documentation fetch (not requested).')
 
   ui.report_context_summary(
     sum(len(content) for content in spec_contents.values()),
+    len(explainer_contents) if explainer_contents else 0,
     len(mdn_contents) if mdn_contents else 0,
     len(wpt_context.test_contents),
     len(wpt_context.dependency_contents),
@@ -135,7 +149,7 @@ async def run_context_assembly(
     feature_id=web_feature_id,
     metadata=metadata,
     spec_contents=spec_contents,
-    explainer_contents=None,
+    explainer_contents=explainer_contents,
     mdn_contents=mdn_contents,
     wpt_context=wpt_context,
     wpt_urls=extracted_wpt_urls,

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -68,7 +68,12 @@ class UIProvider(Protocol):
   # Domain-specific reporting
   def report_metadata(self, metadata: FeatureMetadata) -> None: ...
   def report_context_summary(
-    self, spec_len: int, mdn_count: int, test_count: int, dep_count: int
+    self,
+    spec_len: int,
+    explainer_count: int,
+    mdn_count: int,
+    test_count: int,
+    dep_count: int,
   ) -> None: ...
   def report_token_usage(
     self,
@@ -176,6 +181,12 @@ class RichUIProvider:
     metadata_table.add_row('[bold]Description:[/bold]', metadata.description)
     metadata_table.add_row('[bold]Spec URL:[/bold]', f'[blue]{metadata.specs[0]}[/blue]')
 
+    if metadata.explainer_links:
+      metadata_table.add_row(
+        '[bold]Explainers:[/bold]',
+        '\n'.join(f'[blue]{url}[/blue]' for url in metadata.explainer_links),
+      )
+
     self.console.print(
       Panel(
         metadata_table,
@@ -186,10 +197,17 @@ class RichUIProvider:
     )
 
   def report_context_summary(
-    self, spec_len: int, mdn_count: int, test_count: int, dep_count: int
+    self,
+    spec_len: int,
+    explainer_count: int,
+    mdn_count: int,
+    test_count: int,
+    dep_count: int,
   ) -> None:
+    explainer_info = f'{explainer_count} explainers, ' if explainer_count > 0 else ''
     self.success(
       f'Context gathered: {spec_len} chars of spec, '
+      f'{explainer_info}'
       f'{mdn_count} MDN pages, '
       f'{test_count} tests, '
       f'{dep_count} dependency files.'


### PR DESCRIPTION
## Summary
This PR introduces two significant enhancements to the `wpt-gen` tool:
1.  **`chromestatus` command**: A new CLI command that allows users to perform a coverage audit and generate tests for a specific ChromeStatus feature using its ID (e.g., `wpt-gen chromestatus 12345`). It also includes support for bypassing JSON vulnerability prefixes in the ChromeStatus API.
2.  **Explainer support in context assembly**: When a feature's metadata includes explainer links, the tool now fetches and extracts content from those explainers to provide richer context for test generation. This also includes UI updates to display the number of explainers gathered.

## Changes
-   Added `chromestatus_command` to `wptgen/main.py` with full configuration support.
-   Enhanced `fetch_chromestatus_metadata` in `wptgen/context.py` to handle JSON vulnerability prefixes.
-   Updated `run_context_assembly` in `wptgen/phases/context_assembly.py` to fetch and extracted content from explainer links.
-   Extended `UIProvider` and `RichUIProvider` to support reporting explainer metadata and counts.
-   Added/updated unit tests in `tests/test_main.py`, `tests/test_chromestatus.py`, `tests/test_phases.py`, and `tests/test_ui.py`.

## Verification
-   Ran `make presubmit` which passed all lint, type checks, and tests.
-   All 350 tests passed successfully.

Resolves #62