### PR TITLE
feat(ui): improve ChromeStatus display, include explainers, and hide MDN pages

### DIFF
--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -81,11 +81,17 @@ async def test_run_context_assembly_success(
 ) -> None:
   """Test successful context assembly for a registered feature."""
   mocker.patch('wptgen.phases.context_assembly.fetch_feature_yaml', return_value={'name': 'feat'})
+  metadata = FeatureMetadata('Feat', 'Desc', ['http://spec'])
+  metadata.explainer_links = ['http://explainer']
   mocker.patch(
     'wptgen.phases.context_assembly.extract_feature_metadata',
-    return_value=FeatureMetadata('Feat', 'Desc', ['http://spec']),
+    return_value=metadata,
   )
   mocker.patch('wptgen.phases.context_assembly.fetch_and_extract_text', return_value='Spec Content')
+  mocker.patch(
+    'wptgen.phases.context_assembly.fetch_explainer_contents',
+    return_value={'http://explainer': 'Explainer Content'},
+  )
   mocker.patch('wptgen.phases.context_assembly.find_feature_tests', return_value=[])
   mocker.patch(
     'wptgen.phases.context_assembly.gather_local_test_context', return_value=WPTContext()
@@ -98,6 +104,7 @@ async def test_run_context_assembly_success(
   assert context.metadata is not None
   assert context.metadata.name == 'Feat'
   assert context.spec_contents == {'http://spec': 'Spec Content'}
+  assert context.explainer_contents == {'http://explainer': 'Explainer Content'}
   mock_ui.on_phase_start.assert_called_once_with(1, 'Context Assembly')
   mock_ui.report_metadata.assert_called_once()
 
@@ -158,6 +165,32 @@ async def test_run_context_assembly_without_mdn(
   assert context.mdn_contents is None
   mock_fetch_mdn.assert_not_called()
   mock_ui.print.assert_any_call('Skipping MDN documentation fetch (not requested).')
+
+
+@pytest.mark.asyncio
+async def test_run_context_assembly_chromestatus_skips_mdn(
+  mock_config: Config, mock_ui: MagicMock, mocker: MockerFixture
+) -> None:
+  """Test that context assembly skips MDN fetching for ChromeStatus features."""
+  mock_config.chromestatus = True
+  mock_config.include_mdn_docs = True
+  mocker.patch(
+    'wptgen.phases.context_assembly.fetch_chromestatus_metadata',
+    return_value=FeatureMetadata('Feat', 'Desc', ['http://spec']),
+  )
+  mocker.patch('wptgen.phases.context_assembly.fetch_and_extract_text', return_value='Spec Content')
+  mock_fetch_mdn = mocker.patch('wptgen.phases.context_assembly.fetch_mdn_urls')
+  mocker.patch('wptgen.phases.context_assembly.find_feature_tests', return_value=[])
+  mocker.patch(
+    'wptgen.phases.context_assembly.gather_local_test_context', return_value=WPTContext()
+  )
+
+  context = await run_context_assembly('feat-id', mock_config, mock_ui)
+
+  assert context is not None
+  assert context.mdn_contents is None
+  mock_fetch_mdn.assert_not_called()
+  mock_ui.print.assert_any_call('Skipping MDN documentation fetch for ChromeStatus feature.')
 
 
 @pytest.mark.asyncio
@@ -345,80 +378,54 @@ async def test_run_requirements_extraction_with_explainer(
 
 
 @pytest.mark.asyncio
-async def test_run_requirements_extraction_fetches_explainer(
+async def test_run_requirements_extraction_success(
   mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
 ) -> None:
-  """Test that requirements extraction fetches explainer content if missing from context."""
-  metadata = FeatureMetadata('Feat', 'Desc', ['http://spec'])
-  metadata.explainer_links = ['http://explainer1']
+  """Test successful requirements extraction with mocked LLM response."""
   context = WorkflowContext(
-    feature_id='feat-fetch-explainer',
-    metadata=metadata,
+    feature_id='feat',
+    metadata=FeatureMetadata('Feat', 'Desc', ['http://spec']),
     spec_contents={'http://spec': 'Spec Content'},
-    explainer_contents=None,  # Missing from context
   )
   jinja_env = MagicMock()
   template_mock = MagicMock()
   jinja_env.get_template.return_value = template_mock
 
   with patch(
-    'wptgen.phases.requirements_extraction.fetch_explainer_contents',
-    return_value={'http://explainer1': 'Fetched Explainer Content'},
-  ) as mock_fetch:
-    with patch(
-      'wptgen.phases.requirements_extraction.generate_safe',
-      return_value='<requirements_list><requirement id="R1"><category>Existence</category><description>D1</description></requirement></requirements_list>',
-    ):
-      await run_requirements_extraction(
-        context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
-      )
+    'wptgen.phases.requirements_extraction.generate_safe',
+    return_value='<requirements_list><requirement id="R1"><category>Existence</category><description>D1</description></requirement></requirements_list>',
+  ):
+    await run_requirements_extraction(context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path)
 
-    # Verify fetch_explainer_contents was called
-    mock_fetch.assert_called_once_with(['http://explainer1'])
-
-  # Verify explainer_contents was passed to render
-  template_mock.render.assert_any_call(
-    feature_name='Feat',
-    feature_description='Desc',
-    specs={'http://spec': 'Spec Content'},
-    mdn_contents=None,
-    explainer_contents={'http://explainer1': 'Fetched Explainer Content'},
-  )
-
-  # Verify it's stored in context
-  assert context.explainer_contents == {'http://explainer1': 'Fetched Explainer Content'}
+  mock_ui.on_phase_start.assert_called_once_with(2, 'Requirements Extraction')
+  mock_ui.success.assert_any_call('Extracted 1 test requirements.')
 
 
 @pytest.mark.asyncio
-async def test_run_requirements_extraction_explainer_fetch_warning(
-  mock_config: Config, mock_ui: MagicMock, mock_llm: MagicMock, tmp_path: Path
+async def test_run_context_assembly_explainer_fetch_warning(
+  mock_config: Config, mock_ui: MagicMock, mocker: MockerFixture
 ) -> None:
-  """Test that a warning is shown if an explainer fails to fetch."""
+  """Test that a warning is shown if an explainer fails to fetch during context assembly."""
+  mocker.patch('wptgen.phases.context_assembly.fetch_feature_yaml', return_value={'name': 'feat'})
   metadata = FeatureMetadata('Feat', 'Desc', ['http://spec'])
   metadata.explainer_links = ['http://explainer-fail']
-  context = WorkflowContext(
-    feature_id='feat-fail-explainer',
-    metadata=metadata,
-    spec_contents={'http://spec': 'Spec Content'},
-    explainer_contents=None,
+  mocker.patch(
+    'wptgen.phases.context_assembly.extract_feature_metadata',
+    return_value=metadata,
   )
-  jinja_env = MagicMock()
-  jinja_env.get_template.return_value = MagicMock()
+  mocker.patch('wptgen.phases.context_assembly.fetch_and_extract_text', return_value='Spec Content')
+  mocker.patch(
+    'wptgen.phases.context_assembly.fetch_explainer_contents',
+    return_value={},  # Fail
+  )
+  mocker.patch('wptgen.phases.context_assembly.find_feature_tests', return_value=[])
+  mocker.patch(
+    'wptgen.phases.context_assembly.gather_local_test_context', return_value=WPTContext()
+  )
 
-  with patch(
-    'wptgen.phases.requirements_extraction.fetch_explainer_contents',
-    return_value={},  # Failed to fetch
-  ):
-    with patch(
-      'wptgen.phases.requirements_extraction.generate_safe',
-      return_value='<requirements_list></requirements_list>',
-    ):
-      await run_requirements_extraction(
-        context, mock_config, mock_llm, mock_ui, jinja_env, tmp_path
-      )
+  await run_context_assembly('feat-id', mock_config, mock_ui)
 
-  # Verify warning was shown
-  mock_ui.warning.assert_called_with(
+  mock_ui.warning.assert_any_call(
     'Failed to fetch or extract content from explainer: http://explainer-fail'
   )
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -87,7 +87,7 @@ def test_on_phase_start(ui: RichUIProvider, mock_console: MagicMock) -> None:
 
 def test_report_metadata(ui: RichUIProvider, mock_console: MagicMock) -> None:
   """Test report_metadata semantic method."""
-  metadata = FeatureMetadata('Feat', 'Desc', ['http://spec'])
+  metadata = FeatureMetadata('Feat', 'Desc', ['http://spec'], explainer_links=['http://explainer'])
   ui.report_metadata(metadata)
   mock_console.print.assert_called_once()
   args, _ = mock_console.print.call_args
@@ -229,9 +229,20 @@ def test_on_phase_complete(ui: RichUIProvider, mock_console: MagicMock) -> None:
   mock_console.print.assert_called_once_with('[bold green]✔[/bold green] Phase 1 complete.')
 
 
-def test_report_context_summary(ui: RichUIProvider, mock_console: MagicMock) -> None:
-  ui.report_context_summary(1, 2, 3, 4)
-  mock_console.print.assert_called_once()
+def test_report_context_summary_chromestatus(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test report_context_summary with arguments for ChromeStatus."""
+  ui.report_context_summary(spec_len=1000, explainer_count=1, test_count=5)
+  mock_console.print.assert_called_once_with(
+    '[bold green]✔[/bold green] Context gathered: 1000 chars of spec, 1 explainers, 5 tests.'
+  )
+
+
+def test_report_context_summary_generate(ui: RichUIProvider, mock_console: MagicMock) -> None:
+  """Test report_context_summary with arguments for web feature command."""
+  ui.report_context_summary(spec_len=5000, mdn_count=2, test_count=10, dep_count=3)
+  mock_console.print.assert_called_once_with(
+    '[bold green]✔[/bold green] Context gathered: 5000 chars of spec, 2 MDN pages, 10 tests, 3 dependency files.'
+  )
 
 
 def test_report_token_usage_warnings(ui: RichUIProvider, mock_console: MagicMock) -> None:

--- a/wptgen/phases/context_assembly.py
+++ b/wptgen/phases/context_assembly.py
@@ -21,6 +21,7 @@ from wptgen.context import (
   extract_wpt_paths,
   fetch_and_extract_text,
   fetch_chromestatus_metadata,
+  fetch_explainer_contents,
   fetch_feature_yaml,
   fetch_mdn_urls,
   find_feature_tests,
@@ -83,6 +84,19 @@ async def run_context_assembly(
     ui.error('Failed to extract spec content.')
     return None
 
+  explainer_contents: dict[str, str] | None = None
+  if metadata.explainer_links:
+    ui.print('Fetching explainer content...')
+    with ui.status('Fetching and extracting text from explainers...'):
+      explainer_contents = await asyncio.to_thread(
+        fetch_explainer_contents, metadata.explainer_links
+      )
+
+      # Check for missing URLs to show warnings
+      for url in metadata.explainer_links:
+        if url not in explainer_contents:
+          ui.warning(f'Failed to fetch or extract content from explainer: {url}')
+
   ui.print('Scanning local WPT repository for existing tests and dependencies...')
   test_paths = find_feature_tests(config.wpt_path, web_feature_id)
   extracted_wpt_urls: list[str] | None = None
@@ -107,7 +121,7 @@ async def run_context_assembly(
   wpt_context = gather_local_test_context(test_paths, config.wpt_path)
 
   mdn_contents: list[str] | None = None
-  if config.include_mdn_docs:
+  if config.include_mdn_docs and not config.chromestatus:
     ui.print('Fetching MDN documentation...')
     mdn_urls = fetch_mdn_urls(web_feature_id)
     if mdn_urls:
@@ -121,21 +135,30 @@ async def run_context_assembly(
           for url, res in zip(mdn_urls, results, strict=True)
           if res
         ]
+  elif config.chromestatus and config.include_mdn_docs:
+    ui.print('Skipping MDN documentation fetch for ChromeStatus feature.')
   else:
     ui.print('Skipping MDN documentation fetch (not requested).')
 
-  ui.report_context_summary(
-    sum(len(content) for content in spec_contents.values()),
-    len(mdn_contents) if mdn_contents else 0,
-    len(wpt_context.test_contents),
-    len(wpt_context.dependency_contents),
-  )
+  if config.chromestatus:
+    ui.report_context_summary(
+      spec_len=sum(len(content) for content in spec_contents.values()),
+      explainer_count=len(explainer_contents) if explainer_contents else 0,
+      test_count=len(wpt_context.test_contents),
+    )
+  else:
+    ui.report_context_summary(
+      spec_len=sum(len(content) for content in spec_contents.values()),
+      mdn_count=len(mdn_contents) if mdn_contents else 0,
+      test_count=len(wpt_context.test_contents),
+      dep_count=len(wpt_context.dependency_contents),
+    )
 
   return WorkflowContext(
     feature_id=web_feature_id,
     metadata=metadata,
     spec_contents=spec_contents,
-    explainer_contents=None,
+    explainer_contents=explainer_contents,
     mdn_contents=mdn_contents,
     wpt_context=wpt_context,
     wpt_urls=extracted_wpt_urls,

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from jinja2 import Environment
 
 from wptgen.config import Config
-from wptgen.context import fetch_explainer_contents
 from wptgen.llm import LLMClient
 from wptgen.models import REQUIREMENT_CATEGORIES, WorkflowContext, WorkflowPhase
 from wptgen.phases.utils import confirm_prompts, generate_safe
@@ -54,23 +53,6 @@ def _load_cached_requirements(
   return None
 
 
-async def _fetch_explainer_contents(context: WorkflowContext, ui: UIProvider) -> None:
-  """
-  Fetches explainer contents if they are not already present in the context.
-  """
-  if not context.explainer_contents and context.metadata and context.metadata.explainer_links:
-    ui.print('Fetching explainer content...')
-    with ui.status('Fetching and extracting text from explainers...'):
-      context.explainer_contents = await asyncio.to_thread(
-        fetch_explainer_contents, context.metadata.explainer_links
-      )
-
-      # Check for missing URLs to show warnings
-      for url in context.metadata.explainer_links:
-        if url not in context.explainer_contents:
-          ui.warning(f'Failed to fetch or extract content from explainer: {url}')
-
-
 async def run_requirements_extraction(
   context: WorkflowContext,
   config: Config,
@@ -89,7 +71,6 @@ async def run_requirements_extraction(
   requirements_xml = _load_cached_requirements(web_feature_id, cache_file, config, ui)
 
   if not requirements_xml:
-    await _fetch_explainer_contents(context, ui)
     extraction_prompt = jinja_env.get_template('requirements_extraction.jinja').render(
       feature_name=context.metadata.name,
       feature_description=context.metadata.description,
@@ -155,7 +136,6 @@ async def run_requirements_extraction_categorized(
   requirements_xml = _load_cached_requirements(web_feature_id, cache_file, config, ui)
 
   if not requirements_xml:
-    await _fetch_explainer_contents(context, ui)
     metadata = context.metadata
     assert metadata is not None
 
@@ -297,7 +277,6 @@ async def run_requirements_extraction_iterative(
   requirements_xml = _load_cached_requirements(web_feature_id, cache_file, config, ui)
 
   if not requirements_xml:
-    await _fetch_explainer_contents(context, ui)
     all_requirements: list[str] = []
     iteration = 1
     max_iterations = 10

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -68,7 +68,12 @@ class UIProvider(Protocol):
   # Domain-specific reporting
   def report_metadata(self, metadata: FeatureMetadata) -> None: ...
   def report_context_summary(
-    self, spec_len: int, mdn_count: int, test_count: int, dep_count: int
+    self,
+    spec_len: int,
+    explainer_count: int | None = None,
+    mdn_count: int | None = None,
+    test_count: int | None = None,
+    dep_count: int | None = None,
   ) -> None: ...
   def report_token_usage(
     self,
@@ -176,6 +181,10 @@ class RichUIProvider:
     metadata_table.add_row('[bold]Description:[/bold]', metadata.description)
     metadata_table.add_row('[bold]Spec URL:[/bold]', f'[blue]{metadata.specs[0]}[/blue]')
 
+    if metadata.explainer_links:
+      explainer_links = '\n'.join(metadata.explainer_links)
+      metadata_table.add_row('[bold]Explainer URLs:[/bold]', f'[blue]{explainer_links}[/blue]')
+
     self.console.print(
       Panel(
         metadata_table,
@@ -186,14 +195,24 @@ class RichUIProvider:
     )
 
   def report_context_summary(
-    self, spec_len: int, mdn_count: int, test_count: int, dep_count: int
+    self,
+    spec_len: int,
+    explainer_count: int | None = None,
+    mdn_count: int | None = None,
+    test_count: int | None = None,
+    dep_count: int | None = None,
   ) -> None:
-    self.success(
-      f'Context gathered: {spec_len} chars of spec, '
-      f'{mdn_count} MDN pages, '
-      f'{test_count} tests, '
-      f'{dep_count} dependency files.'
-    )
+    parts = [f'{spec_len} chars of spec']
+    if explainer_count is not None:
+      parts.append(f'{explainer_count} explainers')
+    if mdn_count is not None:
+      parts.append(f'{mdn_count} MDN pages')
+    if test_count is not None:
+      parts.append(f'{test_count} tests')
+    if dep_count is not None:
+      parts.append(f'{dep_count} dependency files')
+
+    self.success(f'Context gathered: {", ".join(parts)}.')
 
   def report_token_usage(
     self,


### PR DESCRIPTION
## Background & Motivation
When running `wpt-gen chromestatus <id>`, the tool's display was missing "Explainers," which are often more descriptive than raw specifications. Additionally, the tool was attempting redundant MDN documentation fetches for ChromeStatus features.

## Proposed Changes
1.  **Explainer Display**: Updated `RichUIProvider.report_metadata` to include explainer URLs in the "Feature Metadata" panel.
2.  **Context Assembly Update**:
    *   `run_context_assembly` now fetches explainers during Phase 1.
    *   MDN fetching is now skipped when `config.chromestatus` is enabled.
3.  **Dynamic Context Summary**: Refactored `UIProvider.report_context_summary` and its `RichUIProvider` implementation to accept optional arguments. It now only displays the context that was actually gathered (e.g., hiding "0 MDN pages" if not requested).
4.  **Command-Specific UI**: Tailored the "Context gathered" output:
    *   For **ChromeStatus**: shows `spec`, `explainer`, and `tests`.
    *   For **Standard Generate**: shows `spec`, `MDN`, `tests`, and `dependencies`.
5.  **Requirements Extraction Cleanup**: Removed redundant explainer fetching logic from Phase 2.
6.  **Test Coverage**: Added and updated tests in `tests/test_ui.py` and `tests/test_phases.py` to cover explainer fetching, reporting, dynamic summary logic, and ChromeStatus-specific behavior.

Resolves #363
