### PR TITLE
chore: add missing license headers to test files

### DIFF
--- a/tests/test_llm_coverage.py
+++ b/tests/test_llm_coverage.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from unittest.mock import MagicMock, patch
 
 import anthropic

--- a/tests/test_metadata_coverage.py
+++ b/tests/test_metadata_coverage.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from pathlib import Path
 
 import yaml

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 from pathlib import Path
 


### PR DESCRIPTION
Follow-up to #340

## Overview
This PR adds the standard Apache 2.0 license headers to several test files that were previously missing them.

## Root Cause / Motivation
To ensure full compliance with the project's licensing requirements and the recent integration of `addlicense`, all source and test files must include the appropriate license header. These three test files were missing the header.

## Detailed Changelog
* **`tests/test_llm_coverage.py`**: Appended the standard Apache 2.0 license header block at the top of the file.
* **`tests/test_metadata_coverage.py`**: Appended the standard Apache 2.0 license header block at the top of the file.
* **`tests/test_observability.py`**: Appended the standard Apache 2.0 license header block at the top of the file.
