### PR TITLE
Exclude Reference Files (`-ref`) from Coverage Audit Context

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -43,6 +43,8 @@ def test_is_wpt_test_file() -> None:
   assert is_wpt_test_file(Path('test.html')) is True
   assert is_wpt_test_file(Path('test.js')) is True
   assert is_wpt_test_file(Path('test.any.js')) is True
+  assert is_wpt_test_file(Path('test-ref.html')) is False
+  assert is_wpt_test_file(Path('test-ref.js')) is False
   assert is_wpt_test_file(Path('test.md')) is False
   assert is_wpt_test_file(Path('test.py')) is False
   assert is_wpt_test_file(Path('test.yml')) is False

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -316,6 +316,10 @@ def is_wpt_test_file(path: Path) -> bool:
   if filename in ('MANIFEST', 'META.yml', 'WEB_FEATURES.yml'):
     return False
 
+  # Filter out reference files
+  if '-ref.' in filename:
+    return False
+
   # Filter out hidden files
   if filename.startswith('.'):
     return False
@@ -521,6 +525,11 @@ def gather_local_test_context(test_paths: list[str], wpt_root: str) -> WPTContex
     idx += 1
 
     curr_p = Path(curr_p_str)
+
+    # Exclude reference files from context assembly
+    if is_test and '-ref.' in curr_p.name:
+      continue
+
     try:
       content = curr_p.read_text(encoding='utf-8')
       if is_test:


### PR DESCRIPTION
Resolves #378

## Overview
This PR updates the context assembly logic to exclude Web Platform Test reference files (files with `-ref.` in their name) from being included in the LLM's context window.

## Root Cause / Motivation
Currently, reference files used for visual rendering tests are included in the coverage audit context. These files bloat the context window with unnecessary information that isn't relevant to understanding the core logic of what is being tested, increasing token usage and potentially degrading the LLM's focus. 

## Detailed Changelog
* **`wptgen/context.py`**: Added a check in `is_wpt_test_file` to filter out files with `-ref.` in their filename to prevent them from counting towards the max test suite limit. Also added a check in `gather_local_test_context` to exclude them from the context assembly.
* **`tests/test_context.py`**: Added unit tests to verify that `is_wpt_test_file` correctly identifies and excludes reference files like `test-ref.html` and `test-ref.js`.