### PR TITLE
Fix #379: Clarify test generation summary output message

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -183,8 +183,8 @@ def test_report_test_suggestion(ui: RichUIProvider, mock_console: MagicMock) -> 
 def test_report_generation_summary(ui: RichUIProvider, mock_console: MagicMock) -> None:
   """Test report_generation_summary semantic method."""
   ui.report_generation_summary([(Path('p'), 'c', 's')])
-  # Newline + Table + Success message
-  assert mock_console.print.call_count == 3
+  # Newline + Table + Breakdown Title + Breakdown Item + Success message
+  assert mock_console.print.call_count == 5
 
 
 def test_progress_indicator(mocker: MockerFixture, ui: RichUIProvider) -> None:
@@ -274,7 +274,7 @@ def test_report_test_generated_fail(ui: RichUIProvider, mock_console: MagicMock)
 def test_report_generation_summary_empty(ui: RichUIProvider, mock_console: MagicMock) -> None:
   ui.report_generation_summary([])
   mock_console.print.assert_called_once_with(
-    '[bold red]✘[/bold red] No tests were successfully generated.'
+    '[bold red]✘[/bold red] No files were successfully created.'
   )
 
 

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -321,16 +321,32 @@ class RichUIProvider:
   def report_generation_summary(self, generated_tests: list[tuple[Path, str, str]]) -> None:
     if generated_tests:
       summary_table = Table(
-        title='Generated Tests Summary', show_header=True, header_style='bold green'
+        title='Generated Files Summary', show_header=True, header_style='bold green'
       )
       summary_table.add_column('File Name', style='cyan')
       summary_table.add_column('Full Path', style='dim')
+      summary_table.add_column('Type', style='magenta')
 
+      breakdown: dict[str, int] = {}
       for p, _content, _s_xml in generated_tests:
-        summary_table.add_row(p.name, str(p.absolute()))
+        file_type = 'Core Test'
+        if p.name == 'WEB_FEATURES.yml':
+          file_type = 'Config File'
+        elif p.name.endswith(('-ref.html', '-ref.js', '-ref.any.js', '-ref.sub.html')):
+          file_type = 'Reference File'
+        elif p.name.endswith(('.headers', '.txt')):
+          file_type = 'Support File'
+
+        breakdown[file_type] = breakdown.get(file_type, 0) + 1
+        summary_table.add_row(p.name, str(p.absolute()), file_type)
 
       self.console.print()
       self.console.print(summary_table)
-      self.success(f'{len(generated_tests)} tests generated successfully.')
+
+      self.console.print('[bold cyan]Breakdown:[/bold cyan]')
+      for category, count in breakdown.items():
+        self.console.print(f'  - {category}: {count}')
+
+      self.success(f'{len(generated_tests)} files created or updated successfully.')
     else:
-      self.error('No tests were successfully generated.')
+      self.error('No files were successfully created.')


### PR DESCRIPTION
Resolves #379

## Overview
Updates the CLI summary output at the end of the test generation process to clarify that the count includes all created files/artifacts, not just tests. It also adds a detailed breakdown by file type.

## Root Cause / Motivation
Previously, the summary read "X tests generated successfully", which was misleading because it counted all files (including references and configs) as tests. This change provides a clear and accurate summary of exactly what was generated by categorizing the files based on their suffixes and names.

## Detailed Changelog
* **`wptgen/ui.py`**: Updated `report_generation_summary` to classify generated files into 'Core Test', 'Config File', 'Reference File', or 'Support File' and print a breakdown. The final success message was updated to "X files created or updated successfully."
* **`tests/test_ui.py`**: Updated tests to reflect the new summary table output format and the changed wording for the success/error messages.