### PR TITLE
Refactor ADKStreamManager to use a frozen dataclass for configuration

### DIFF
--- a/tests/agents/test_streaming.py
+++ b/tests/agents/test_streaming.py
@@ -20,7 +20,7 @@ from google.genai import types
 from rich.panel import Panel
 from rich.table import Table
 
-from wptgen.agents.streaming import ADKStreamManager
+from wptgen.agents.streaming import ADKStreamManager, StreamConfig
 
 
 def test_adk_stream_manager_text(capsys: pytest.CaptureFixture[str]) -> None:
@@ -42,7 +42,7 @@ def test_adk_stream_manager_thought() -> None:
   part = types.Part(text='Pondering deeply...', thought=True)
   event = Event(author='agent', content=types.Content(parts=[part]))
 
-  with ADKStreamManager(ui_mock, include_thoughts=True) as manager:
+  with ADKStreamManager(ui_mock, config=StreamConfig(include_thoughts=True)) as manager:
     manager.process_event(event)
 
   ui_mock.stream_text.assert_called_once_with('Pondering deeply...')

--- a/wptgen/agents/adk_test_generator.py
+++ b/wptgen/agents/adk_test_generator.py
@@ -26,7 +26,7 @@ from google.genai import types
 from jinja2 import Environment
 
 from wptgen.agents.provider import setup_adk_environment
-from wptgen.agents.streaming import ADKStreamManager
+from wptgen.agents.streaming import ADKStreamManager, StreamConfig
 from wptgen.agents.tools import _validate_safe_path, create_agent_tools
 from wptgen.config import SKILLS_DIR, Config
 from wptgen.models import TestType, WorkflowContext
@@ -154,7 +154,9 @@ async def generate_test_with_adk(
     events = runner.run_async(session_id=session.id, user_id='cli_user', new_message=content)
 
     # We just consume the stream to let the agent run.
-    with ADKStreamManager(ui, include_thoughts=config.include_thoughts) as stream_manager:
+    with ADKStreamManager(
+      ui, config=StreamConfig(include_thoughts=config.include_thoughts)
+    ) as stream_manager:
       async for event in events:
         stream_manager.process_event(event)
 

--- a/wptgen/agents/streaming.py
+++ b/wptgen/agents/streaming.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from google.adk.events import Event
@@ -101,12 +102,19 @@ def format_tool_call(tool_name: str, args: Any, agent_name: str = 'WPT-Gen Agent
   )
 
 
+@dataclass(frozen=True)
+class StreamConfig:
+  """Configuration for the ADKStreamManager."""
+
+  include_thoughts: bool = False
+
+
 class ADKStreamManager:
   """Manages the streaming of ADK events into the UI."""
 
-  def __init__(self, ui: UIProvider, include_thoughts: bool = False):
+  def __init__(self, ui: UIProvider, config: StreamConfig | None = None):
     self.ui = ui
-    self.include_thoughts = include_thoughts
+    self.config = config or StreamConfig()
 
   def __enter__(self) -> ADKStreamManager:
     return self
@@ -128,7 +136,7 @@ class ADKStreamManager:
 
       if part.text:
         if is_thought:
-          if self.include_thoughts:
+          if self.config.include_thoughts:
             # Stream the agent's internal thought process directly to stdout in dim italic text
             self.ui.stream_text(part.text)
         else:


### PR DESCRIPTION
Resolves #354

## Overview
Refactors `ADKStreamManager` to use a frozen dataclass `StreamConfig` for its configuration parameters instead of relying on individual kwargs.

## Root Cause / Motivation
Currently, `ADKStreamManager` accepts configuration options like `include_thoughts` individually. As more options are added, this becomes unwieldy. Transitioning to a dedicated `StreamConfig` frozen dataclass logically groups these configurations, increasing maintainability and readability while future-proofing the API.

## Detailed Changelog
* **`wptgen/agents/streaming.py`**: Added `StreamConfig` frozen dataclass. Updated `ADKStreamManager.__init__` to accept `config: StreamConfig | None = None`. Updated internal logic to use `self.config.include_thoughts`.
* **`wptgen/agents/adk_test_generator.py`**: Updated instantiation of `ADKStreamManager` to pass `config=StreamConfig(include_thoughts=...)`.
* **`tests/agents/test_streaming.py`**: Updated all tests to use the new `StreamConfig` object when instantiating the `ADKStreamManager` and testing its configurations.
