### PR TITLE
Rename Blueprints to Test Suggestions in test generation phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Browser interoperability is critical for the web. While the W3C and WHATWG write
 *   **Context Assembly:** Automatically resolves Web Feature IDs (via `web-features`) to fetch specification and MDN documentation (if available), using BeautifulSoup and Markdownify to preserve critical code blocks and semantic structure.
 *   **Deep Local Analysis:** Scans your local WPT repository using `WEB_FEATURES.yml` metadata to identify existing tests and their dependencies.
 *   **Gap Analysis:** Compares technical requirements synthesized from specifications against current test coverage to pinpoint missing assertions.
-*   **Test Suggestions:** Brainstorms specific, actionable test scenarios (blueprints) that address identified gaps.
-*   **Automated Generation:** Produces atomic, WPT-compliant HTML and JavaScript test files based on user-approved blueprints using an autonomous agent powered by `google-adk`.
+*   **Test Suggestions:** Brainstorms specific, actionable test scenarios (test suggestions) that address identified gaps.
+*   **Automated Generation:** Produces atomic, WPT-compliant HTML and JavaScript test files based on user-approved test suggestions using an autonomous agent powered by `google-adk`.
 *   **Multi-Provider Support:** Built-in support for Google Gemini (via `google-genai` and thinking models), OpenAI, and Anthropic models.
 
 ## How it Works
@@ -37,7 +37,7 @@ flowchart TD
     subgraph Analysis[Requirement & Gap Analysis]
         B & D --> E{{Requirements Extraction}}
         E --> F{{Coverage Audit}}
-        F --> G[Test Blueprints]
+        F --> G[test suggestions]
     end
 
     subgraph Generation[Test Generation]
@@ -54,8 +54,8 @@ For an in-depth explanation of the internal logic, inputs, outputs, and LLM inte
 
 1.  **Phase 1: Context Assembly:** Aggregates the "Source of Truth" from external documentation (W3C Specs, MDN) and identifies existing test coverage in the local WPT repository.
 2.  **Phase 2: Requirements Extraction:** Uses an LLM to synthesize specification text into structured, granular technical requirements. Supports parallel and iterative extraction modes for complex specs.
-3.  **Phase 3: Coverage Audit:** Performs a delta analysis by comparing the synthesized requirements against the local test suite. This phase outputs an audit worksheet and high-level test blueprints.
-4.  **Phase 4: Test Generation:** Translates user-selected blueprints into functional WPT-compliant code (JavaScript, Reftests, or Crashtests) using an autonomous agent powered by `google-adk`, which leverages specialized file-system tools and style guide instructions.
+3.  **Phase 3: Coverage Audit:** Performs a delta analysis by comparing the synthesized requirements against the local test suite. This phase outputs an audit worksheet and high-level test suggestions.
+4.  **Phase 4: Test Generation:** Translates user-selected test suggestions into functional WPT-compliant code (JavaScript, Reftests, or Crashtests) using an autonomous agent powered by `google-adk`, which leverages specialized file-system tools and style guide instructions.
 
 ## Prerequisites
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,8 +31,8 @@ wpt-gen generate [OPTIONS] WEB_FEATURE_ID
 | Option | Description |
 | :--- | :--- |
 | `--resume` | Resume the workflow from the last successful phase for this feature ID. |
-| `--suggestions-only` | Stop after generating test blueprints/suggestions. Skip the actual test file generation. |
-| `--brief-suggestions` | Only generate test titles and descriptions for suggestions, omitting detailed blueprints. |
+| `--suggestions-only` | Stop after generating test suggestions. Skip the actual test file generation. |
+| `--brief-suggestions` | Only generate test titles and descriptions for suggestions, omitting detailed test suggestions. |
 | `--yes-tokens` | Automatically confirm all prompts related to LLM token counts. |
 | `--max-parallel-requests` | Limit the number of concurrent asynchronous LLM requests. |
 

--- a/docs/explicit-phase-resumption.md
+++ b/docs/explicit-phase-resumption.md
@@ -13,7 +13,7 @@ To support this, WPT-Gen automatically checkpoints its state after every major p
 As WPT-Gen completes each major phase, it automatically serializes the structured output to your system's cache directory (or a custom directory if provided). The key artifacts saved include:
 
 1. **`requirements.json`**: Saved after Phase 2 (Requirements Extraction). Contains the extracted technical requirements from the specification.
-2. **`blueprints.json`**: Saved after Phase 3 (Coverage Audit). Contains the gap analysis and proposed test blueprints.
+2. **`test_suggestions.json`**: Saved after Phase 3 (Coverage Audit). Contains the gap analysis and proposed test suggestions.
 3. **`generated_tests.json`**: Saved after Phase 4 (Test Generation). Contains the raw generated test code and file paths.
 
 These artifacts act as the "memory" of the workflow, allowing `wpt-gen` to seamlessly pick up where it left off.

--- a/docs/workflow-phases.md
+++ b/docs/workflow-phases.md
@@ -27,19 +27,19 @@ The `wpt-gen generate` command orchestrates a complex, multi-phase agentic workf
 
 ## Phase 3: Coverage Audit (`coverage_audit.py`)
 
-*   **Responsibility:** Performs a delta analysis by comparing the synthesized requirements against the local test suite. This phase identifies gaps in coverage and produces high-level test blueprints.
+*   **Responsibility:** Performs a delta analysis by comparing the synthesized requirements against the local test suite. This phase identifies gaps in coverage and produces high-level test suggestions.
 *   **Inputs:** `WorkflowContext` (with requirements and local test tree), `Config`, `LLMClient`, `UIProvider`, `jinja_env`.
-*   **Outputs:** A string of XML representing the audit response (including missing test blueprints), saved to `WorkflowContext.audit_response`.
+*   **Outputs:** A string of XML representing the audit response (including missing test suggestions), saved to `WorkflowContext.audit_response`.
 *   **LLM Integration:** Uses the LLM to cross-reference extracted requirements with existing test files to intelligently determine what new tests are needed. It automatically partitions requirements into chunks (e.g., `max_threshold=40`) to remain within context limits.
     *   **System Prompt:** `coverage_audit_system.jinja`
     *   **User Prompt:** `coverage_audit.jinja`
 
 ## Phase 4: Test Generation (`generation.py`)
 
-*   **Responsibility:** Translates user-selected blueprints into functional WPT-compliant code (e.g., JavaScript tests, Reftests, or Crashtests) using specific style guide instructions.
-*   **Inputs:** `WorkflowContext` (with the audit response/blueprints), `Config`, `LLMClient`, `UIProvider`, `jinja_env`.
+*   **Responsibility:** Translates user-selected test suggestions into functional WPT-compliant code (e.g., JavaScript tests, Reftests, or Crashtests) using specific style guide instructions.
+*   **Inputs:** `WorkflowContext` (with the audit response/test suggestions), `Config`, `LLMClient`, `UIProvider`, `jinja_env`.
 *   **Outputs:** A list of generated test files, each represented as a tuple of `(Path, string content, suggestion_xml)`. Saves the initial versions of these files to disk.
-*   **LLM Integration:** The LLM receives the test blueprint, WPT authoring guidelines, and relevant spec context to generate valid, idiomatic code for the new test files.
+*   **LLM Integration:** The LLM receives the test suggestion, WPT authoring guidelines, and relevant spec context to generate valid, idiomatic code for the new test files.
     *   **System Prompt:** `test_generation_system.jinja`
     *   **User Prompt:** `test_generation.jinja`
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -333,7 +333,7 @@ def test_engine_hydrate_context(mocker: MockerFixture, tmp_path: Path, mock_conf
   (Path(mock_config.state_dir) / 'requirements.json').write_text(
     '{"requirements_xml": "<test-reqs/>"}'
   )
-  (Path(mock_config.state_dir) / 'blueprints.json').write_text(
+  (Path(mock_config.state_dir) / 'test_suggestions.json').write_text(
     '{"audit_response": "<test-audit/>"}'
   )
 
@@ -410,7 +410,7 @@ def test_engine_hydrate_context_exceptions(
   # Write valid JSON but wrong types to trigger exceptions after load
   (state_dir / 'resume_mock_feature.json').write_text('null')
   (state_dir / 'requirements.json').write_text('null')
-  (state_dir / 'blueprints.json').write_text('null')
+  (state_dir / 'test_suggestions.json').write_text('null')
 
   # create generated_tests dir and tests json
   tests_dir = state_dir / 'generated_tests'

--- a/wptgen/agents/adk_test_generator.py
+++ b/wptgen/agents/adk_test_generator.py
@@ -42,10 +42,10 @@ async def generate_test_with_adk(
   jinja_env: Environment,
   ui: UIProvider,
 ) -> list[tuple[Path, str, str]]:
-  """Runs the ADK Agent to generate tests for a single blueprint.
+  """Runs the ADK Agent to generate tests for a single test suggestion.
 
   Args:
-      suggestion_xml: The XML blueprint for the test.
+      suggestion_xml: The XML test suggestion for the test.
       root_name: The base filename to use (e.g., 'feature-1').
       test_type_enum: The type of test to generate.
       context: The workflow context (contains metadata).

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -111,7 +111,7 @@ class WPTGenEngine:
       except Exception:
         pass
 
-    audit_file = state_dir / 'blueprints.json'
+    audit_file = state_dir / 'test_suggestions.json'
     if audit_file.exists():
       try:
         with open(audit_file, encoding='utf-8') as f:
@@ -158,7 +158,7 @@ class WPTGenEngine:
         json.dump({'requirements_xml': context.requirements_xml}, f, indent=2)
 
     elif phase == WorkflowPhase.COVERAGE_AUDIT and context.audit_response:
-      audit_file = state_dir / 'blueprints.json'
+      audit_file = state_dir / 'test_suggestions.json'
       with open(audit_file, 'w', encoding='utf-8') as f:
         json.dump({'audit_response': context.audit_response}, f, indent=2)
 

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -192,7 +192,7 @@ def _execute_workflow(
     console.print()
     console.print(
       Panel(
-        '[bold green]✔ Audit completed successfully! Blueprints generated.[/bold green]',
+        '[bold green]✔ Audit completed successfully! Test suggestions generated.[/bold green]',
         border_style='green',
         expand=False,
       )
@@ -301,7 +301,7 @@ def generate(
     bool,
     typer.Option(
       '--brief-suggestions',
-      help='Only generate test titles and descriptions for suggestions (omits detailed blueprints).',
+      help='Only generate test titles and descriptions for suggestions (omits detailed test suggestions).',
     ),
   ] = False,
   resume: Annotated[
@@ -1027,7 +1027,7 @@ def audit(
     bool,
     typer.Option(
       '--brief-suggestions',
-      help='Only generate test titles and descriptions for suggestions (omits detailed blueprints).',
+      help='Only generate test titles and descriptions for suggestions (omits detailed test suggestions).',
     ),
   ] = False,
   resume: Annotated[
@@ -1164,7 +1164,7 @@ def audit(
   ] = None,
 ) -> None:
   """
-  Perform a gap analysis and generate coverage blueprints without generating WPT files.
+  Perform a gap analysis and generate coverage test suggestions without generating WPT files.
   """
   _print_workflow_banner(web_feature_id)
   _check_workflow_flags(

--- a/wptgen/skills/wpt-generator/SKILL.md
+++ b/wptgen/skills/wpt-generator/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: wpt-generator
-description: Generate Web Platform Tests (WPT) from minimal XML blueprints. The agent will autonomously determine the test type and implementation details by analyzing existing repository paradigms. Use when the user asks to generate a Web Platform Test based on a blueprint.
+description: Generate Web Platform Tests (WPT) from minimal XML test suggestions. The agent will autonomously determine the test type and implementation details by analyzing existing repository paradigms. Use when the user asks to generate a Web Platform Test based on a test suggestion.
 ---
 # Web Platform Test Generator
 
-This skill enables an ADK agent to generate Web Platform Tests (WPT) from minimal XML blueprints. Because the blueprint only contains high-level requirements, you must rely on existing codebase paradigms to determine how the test should be written.
+This skill enables an ADK agent to generate Web Platform Tests (WPT) from minimal XML test suggestions. Because the test suggestion only contains high-level requirements, you must rely on existing codebase paradigms to determine how the test should be written.
 
 ## Workflow
 
 **Temporary Files Policy:** If you need to create any temporary files during research, prototyping, or debugging, use the `write_file` tool to place them exclusively inside a `.wpt-generator-tmp/` directory at the root of the repository. Do not scatter temporary files across the codebase.
 
-When asked to generate a WPT from an XML blueprint, follow these steps:
+When asked to generate a WPT from an XML test suggestion, follow these steps:
 
-### 1. Parse the Blueprint
+### 1. Parse the test suggestion
 Extract the following elements from the `<test_suggestion>` XML snippet provided by the user:
 - `<web_feature_id>`: Used to find where the test should live.
 - `<description>`: The underlying requirement or specification behavior to test.
@@ -39,13 +39,13 @@ Since you are not provided with explicit steps or a test type, you MUST research
 ### 4. Determine the Appropriate File(s) & Name
 Before creating a new file, rigorously check if the test logic belongs in existing files. **Minimize boilerplate by reusing existing files whenever possible.**
 1. **Analyze Directory Paradigms:** Check if the target directory splits tests by category (e.g., separating valid vs. invalid values, or computed vs. parsing behavior).
-2. **Split the Blueprint if Necessary:** A single XML blueprint might encompass multiple test categories. If the directory separates testing into distinct files (e.g., `feature-valid.html` and `feature-invalid.html`), **you MUST split the test logic across the respective existing files** rather than creating a single, monolithic new file.
+2. **Split the test suggestion if Necessary:** A single XML test suggestion might encompass multiple test categories. If the directory separates testing into distinct files (e.g., `feature-valid.html` and `feature-invalid.html`), **you MUST split the test logic across the respective existing files** rather than creating a single, monolithic new file.
 3. **Reftest Reference Search:** If you selected **Reftest**, you MUST search the target directory (and any `reference/` subdirectories) for existing reusable reference files (e.g., `ref-filled-green-100px-square.xht`) before deciding to create a new one. Do NOT generate a duplicate reference file if a suitable one exists.
 4. **Create New Only When Necessary:** Only if no logical match is found (even after considering splitting and manual consolidation), plan to create a new file. **Consult `references/wpt_style_guide.md` to determine the correct filename extension and suffixes** (e.g., `.html`, `.window.js`, `.any.js`) based on your chosen test type. Name the file logically based on the `<web_feature_id>`.
 5. **File Existence Check:** Before using `write_file` to create a new test file, you MUST verify that the proposed filename does not already exist in the target directory (e.g., by using the `list_directory` tool).
 6. **Naming Conflicts:** If a file with the proposed name already exists, you MUST either append the new test logic to the existing file (if logically appropriate) or generate a new unique filename by incrementing a numerical suffix (e.g., changing `-001.html` to `-002.html`) to prevent overwriting existing work.
-7. **Existing Test Expansion:** If you detect that the core assertion of the WPT blueprint is already present in an existing test (i.e. a test perfectly matching the blueprint exists), you MUST ensure all specification edge cases, permutations, or multi-level DOM configurations are thoroughly exercised, and expand the existing test file as necessary instead of creating a redundant new test.
-   - **Handling `.tentative` files:** If an existing `.tentative` file matches your blueprint, append your new test cases directly to it. **Do NOT remove the `.tentative` suffix or rename the file** to "upgrade" it unless explicitly instructed to do so by the user.
+7. **Existing Test Expansion:** If you detect that the core assertion of the WPT test suggestion is already present in an existing test (i.e. a test perfectly matching the test suggestion exists), you MUST ensure all specification edge cases, permutations, or multi-level DOM configurations are thoroughly exercised, and expand the existing test file as necessary instead of creating a redundant new test.
+   - **Handling `.tentative` files:** If an existing `.tentative` file matches your test suggestion, append your new test cases directly to it. **Do NOT remove the `.tentative` suffix or rename the file** to "upgrade" it unless explicitly instructed to do so by the user.
 
 ### 5. Load References & Generate the Test
 **Before writing any code**, you MUST read the appropriate style guides to ensure correct formatting and syntax:

--- a/wptgen/skills/wpt-generator/references/automation_guide.md
+++ b/wptgen/skills/wpt-generator/references/automation_guide.md
@@ -151,4 +151,4 @@ promise_test(async t => {
 ```
 
 ### When to use Manual Tests (`-manual`)
-If the blueprint specifically requires simulating OS-level hardware interventions (e.g., physically unplugging a USB device, locking a device, or simulating a hardware fault) AND you have verified that no `testdriver.js` extension or `wdspec` backend exists to mock this specific state, you MUST default to a `-manual` test. Do not attempt to automate physical hardware manipulations if the testing infrastructure lacks a mock interface for it.
+If the test suggestion specifically requires simulating OS-level hardware interventions (e.g., physically unplugging a USB device, locking a device, or simulating a hardware fault) AND you have verified that no `testdriver.js` extension or `wdspec` backend exists to mock this specific state, you MUST default to a `-manual` test. Do not attempt to automate physical hardware manipulations if the testing infrastructure lacks a mock interface for it.

--- a/wptgen/skills/wpt-generator/references/reftest_style_guide.md
+++ b/wptgen/skills/wpt-generator/references/reftest_style_guide.md
@@ -82,8 +82,8 @@ Instead, consolidate the permutations sequentially into a single layout that eva
 
 Tests should be "self-describing" so a human can easily verify them.
 
-### 5.1 Pruning Redundant Scaffolding (Crucial for Blueprints)
-When generating a Reftest from a blueprint, treat the `<pre_conditions>` as structural guidelines, not strict requirements. If the `<pre_conditions>` request multiple HTML elements (like a container with multiple children), but assigning explicit CSS dimensions or applying standard visual patterns (like a single 100x100 green square) makes some of those requested DOM elements visually or geometrically redundant, you **MUST** remove them to minimize boilerplate. Do not blindly copy HTML elements from a blueprint or from legacy "Golden Examples" if they do not participate in the layout or the interaction being tested.
+### 5.1 Pruning Redundant Scaffolding (Crucial for test suggestions)
+When generating a Reftest from a test suggestion, treat the `<pre_conditions>` as structural guidelines, not strict requirements. If the `<pre_conditions>` request multiple HTML elements (like a container with multiple children), but assigning explicit CSS dimensions or applying standard visual patterns (like a single 100x100 green square) makes some of those requested DOM elements visually or geometrically redundant, you **MUST** remove them to minimize boilerplate. Do not blindly copy HTML elements from a test suggestion or from legacy "Golden Examples" if they do not participate in the layout or the interaction being tested.
 - **Prefer Pseudo-Elements:** Whenever a test requires verifying a behavior on pseudo-elements, or for visual tricks like "Red-Under-Green" and stacking context triggers, you MUST attach those pseudo-elements directly to pre-existing structural container nodes. Do not introduce new, dedicated, empty DOM elements purely to host them.
 
 - **The Green Square**: A very common pattern. The test passes if it produces a 100x100 green square.

--- a/wptgen/templates/adk_test_generator_system.jinja
+++ b/wptgen/templates/adk_test_generator_system.jinja
@@ -1,7 +1,7 @@
 You are an expert-level Web Platform Test (WPT) generation agent.
-Your ultimate goal is to generate test files that fulfill a given test blueprint (<test_suggestion>).
+Your ultimate goal is to generate test files that fulfill a given test suggestion (<test_suggestion>).
 
 # DIRECTIVES
-1. Load Skill: When you receive a `<test_suggestion>` blueprint, you MUST immediately use the `load_skill` tool to load the `wpt-generator` skill.
-2. Follow Skill: Once loaded, strictly and thoroughly follow all instructions provided by the `wpt-generator` skill to create the Web Platform Test based on the blueprint.
+1. Load Skill: When you receive a `<test_suggestion>` test suggestion, you MUST immediately use the `load_skill` tool to load the `wpt-generator` skill.
+2. Follow Skill: Once loaded, strictly and thoroughly follow all instructions provided by the `wpt-generator` skill to create the Web Platform Test based on the test suggestion.
 3. Finish: Once you have successfully completed the process defined by the skill and written ALL necessary files to disk, you MUST call the `report_generation_complete` tool with the list of the file paths you created, and then stop.


### PR DESCRIPTION
Resolves #374

## Overview
Replaces the inaccurate terminology "Blueprints" with "Test Suggestions" globally across the repository.

## Root Cause / Motivation
During the coverage audit phase, the LLM no longer provides highly-detailed, step-by-step instructions. Consequently, the term "Blueprint" is inaccurate and misleading for the agent and users. Renaming this to "Test Suggestions" aligns the terminology with the current simplified output describing what needs to be tested.

## Detailed Changelog
* **`wptgen/main.py` & `wptgen/engine.py`**: Updated CLI flags descriptions, output logs, and renamed the state file from `blueprints.json` to `test_suggestions.json`.
* **`tests/test_engine.py` & `docs/*`**: Updated references from `blueprints.json` to `test_suggestions.json` and revised project documentation terminology.
* **`wptgen/agents/adk_test_generator.py` & `wptgen/templates/*`**: Replaced references of "blueprint" with "test suggestion" in prompt templates, docstrings, and execution logic.
