### PR TITLE
feat(tools): allow agents to specify non-headless mode in run_wpt_test

### DIFF
--- a/wptgen/agents/tools.py
+++ b/wptgen/agents/tools.py
@@ -377,13 +377,14 @@ def create_agent_tools(
     except (OSError, ValueError, subprocess.SubprocessError) as e:
       return {'status': 'error', 'error': str(e)}
 
-  def run_wpt_test(file_path: str) -> dict[str, Any]:
+  def run_wpt_test(file_path: str, headless: bool = True) -> dict[str, Any]:
     """Executes a specific test file using the local WPT test runner infrastructure.
 
     This command can take a while to complete (e.g. 10-20 seconds).
 
     Args:
         file_path: The path to the test file to run.
+        headless: Set to False to run tests with a visible browser UI for debugging.
 
     Returns:
         A dictionary containing the 'status', any 'failing_tests' messages,
@@ -400,18 +401,22 @@ def create_agent_tools(
         log_path = f.name
 
       try:
-        # Use headless browser for testing
         cmd = [
           './wpt',
           'run',
           '--channel',
           channel,
-          '--headless',
-          '--log-raw',
-          log_path,
-          browser,
-          rel_path,
         ]
+        if headless:
+          cmd.append('--headless')
+        cmd.extend(
+          [
+            '--log-raw',
+            log_path,
+            browser,
+            rel_path,
+          ]
+        )
 
         try:
           result = subprocess.run(


### PR DESCRIPTION
Resolves #338

## Overview
Adds a `headless` boolean parameter to the `run_wpt_test` agent tool, defaulting to `True`, allowing agents to run specific web platform tests in headful mode.

## Root Cause / Motivation
Agents occasionally need to execute tests in a non-headless (headful) environment to debug complicated browser-specific issues or to evaluate APIs that differ in behavior between headless and headful modes. Providing this toggle provides the LLM more flexibility while retaining the speed of headless test runs as the default path.

## Detailed Changelog
* **`wptgen/agents/tools.py`**: Updated the `run_wpt_test` function signature to include `headless: bool = True`. Updated its docstring to inform the LLM about this capability. Modified the `./wpt run` command list to conditionally append `--headless` only when `headless` evaluates to `True`.
