### PR TITLE
Fix #379: Clarify the test generation summary output message

### DIFF
--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -331,6 +331,6 @@ class RichUIProvider:
 
       self.console.print()
       self.console.print(summary_table)
-      self.success(f'{len(generated_tests)} tests generated successfully.')
+      self.success(f'{len(generated_tests)} files created or updated successfully.')
     else:
       self.error('No tests were successfully generated.')


### PR DESCRIPTION
Resolves #379

## Overview
This PR updates the summary output message at the end of the test generation process to clarify that the count reflects files created or updated, rather than exclusively tests.

## Root Cause / Motivation
The previous message "X tests generated successfully" was misleading because the count included support artifacts like reference files (`-ref.html`) and configuration updates (`WEB_FEATURE.yml`). By changing the phrasing, the summary accurately reflects that multiple types of artifacts might have been created or updated.

## Detailed Changelog
* **`wptgen/ui.py`**: Updated the phrasing in `report_generation_summary` from "tests generated successfully" to "files created or updated successfully."