### PR TITLE
Fix #378: Exclude Reference Files from Coverage Audit Context

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -646,3 +646,20 @@ def test_fetch_feature_yaml_draft(mocker: MockerFixture) -> None:
     request_obj.full_url
     == 'https://raw.githubusercontent.com/web-platform-dx/web-features/main/features/draft/spec/draft-feature.yml'
   )
+
+
+def test_gather_local_test_context_excludes_refs(tmp_path: Path) -> None:
+  """Test that reference files (containing '-ref.') are excluded."""
+  wpt_root = tmp_path / 'wpt'
+  wpt_root.mkdir()
+
+  test_html = wpt_root / 'test.html'
+  test_html.write_text('<!DOCTYPE html>', encoding='utf-8')
+
+  test_ref = wpt_root / 'test-ref.html'
+  test_ref.write_text('<!DOCTYPE html>', encoding='utf-8')
+
+  context = gather_local_test_context([str(test_html), str(test_ref)], str(wpt_root))
+
+  assert str(test_html) in context.test_contents
+  assert str(test_ref) not in context.test_contents

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -510,6 +510,8 @@ def gather_local_test_context(test_paths: list[str], wpt_root: str) -> WPTContex
   # Initialize queue with (absolute_path, is_test)
   queue: list[tuple[str, bool]] = []
   for p in test_paths:
+    if '-ref.' in Path(p).name:
+      continue
     abs_p = str(Path(p).resolve())
     queue.append((abs_p, True))
     visited.add(abs_p)


### PR DESCRIPTION
Resolves #378

## Overview
This PR excludes reference files (files with `-ref.` in their name) from being included in the context assembled for the coverage audit phase.

## Root Cause / Motivation
Reference files are used for visual rendering verification and do not contain test logic. Including them in the coverage audit context wastes LLM tokens and can distract the model from the actual test cases. By filtering them out early in `gather_local_test_context`, we save processing time and memory.

## Detailed Changelog
* **`wptgen/context.py`**: Added a check in `gather_local_test_context` to filter out any test paths containing `-ref.` before they are processed.
* **`tests/test_context.py`**: Added a new test `test_gather_local_test_context_excludes_refs` to verify that reference files are correctly ignored.