### PR TITLE
feat: add `skip-run` flag to generate command to opt out of test execution

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -80,6 +80,7 @@ def default_load_config_kwargs() -> dict[str, bool | str | int | None | list[str
     'suggestions_only': False,
     'brief_suggestions': False,
     'resume_override': False,
+    'skip_run_override': False,
     'resume_from_override': None,
     'state_dir_override': None,
     'max_retries_override': 3,

--- a/wptgen/agents/adk_test_generator.py
+++ b/wptgen/agents/adk_test_generator.py
@@ -75,7 +75,13 @@ async def generate_test_with_adk(
     return {'status': 'success', 'message': 'Generation recorded.'}
 
   tools: list[Any] = list(
-    create_agent_tools(wpt_root, ui, config.run_on_browser, config.run_on_channel)
+    create_agent_tools(
+      wpt_root,
+      ui,
+      config.run_on_browser,
+      config.run_on_channel,
+      include_run_tool=not config.skip_run,
+    )
   )
   tools.append(FunctionTool(func=report_generation_complete))
 

--- a/wptgen/agents/tools.py
+++ b/wptgen/agents/tools.py
@@ -126,7 +126,7 @@ def _validate_safe_path(target_path: Path, wpt_root: Path) -> Path:
 
 
 def create_agent_tools(
-  wpt_path: Path, ui: UIProvider, browser: str, channel: str
+  wpt_path: Path, ui: UIProvider, browser: str, channel: str, include_run_tool: bool = True
 ) -> list[FunctionTool]:
   """Creates a suite of strictly validated tools for the ADK agent.
 
@@ -623,7 +623,7 @@ def create_agent_tools(
     except (OSError, ValueError) as e:
       return {'status': 'error', 'error': str(e)}
 
-  return [
+  tools = [
     FunctionTool(func=read_file),
     FunctionTool(func=write_file),
     FunctionTool(func=search_files),
@@ -633,9 +633,11 @@ def create_agent_tools(
     FunctionTool(func=delete_file),
     FunctionTool(func=move_file),
     FunctionTool(func=run_wpt_lint),
-    FunctionTool(func=run_wpt_test),
     FunctionTool(func=search_feature_tests),
     FunctionTool(func=fetch_spec_content),
     FunctionTool(func=search_file_contents),
     FunctionTool(func=replace_in_file),
   ]
+  if include_run_tool:
+    tools.append(FunctionTool(func=run_wpt_test))
+  return tools

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -72,6 +72,7 @@ class Config:
   suggestions_only: bool = False
   brief_suggestions: bool = False
   resume: bool = False
+  skip_run: bool = False
   max_retries: int = 3
   timeout: int = DEFAULT_LLM_TIMEOUT
   cache_path: str | None = None
@@ -189,6 +190,7 @@ def load_config(
   suggestions_only: bool = False,
   brief_suggestions: bool = False,
   resume_override: bool = False,
+  skip_run_override: bool = False,
   resume_from_override: WorkflowPhase | None = None,
   state_dir_override: str | None = None,
   max_retries_override: int | None = None,
@@ -278,6 +280,7 @@ def load_config(
   suggestions_only = suggestions_only or yaml_data.get('suggestions_only', False)
   brief_suggestions = brief_suggestions or yaml_data.get('brief_suggestions', False)
   resume = resume_override or yaml_data.get('resume', False)
+  skip_run = skip_run_override or yaml_data.get('skip_run', False)
 
   resume_from_raw = resume_from_override or yaml_data.get('resume_from')
   resume_from = WorkflowPhase(resume_from_raw) if resume_from_raw else None
@@ -345,6 +348,7 @@ def load_config(
     suggestions_only=suggestions_only,
     brief_suggestions=brief_suggestions,
     resume=resume,
+    skip_run=skip_run,
     max_retries=max_retries,
     timeout=timeout,
     cache_path=cache_path,

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -304,6 +304,13 @@ def generate(
       help='Only generate test titles and descriptions for suggestions (omits detailed blueprints).',
     ),
   ] = False,
+  skip_run: Annotated[
+    bool,
+    typer.Option(
+      '--skip-run',
+      help='Opt out of running generated tests.',
+    ),
+  ] = False,
   resume: Annotated[
     bool,
     typer.Option(
@@ -482,6 +489,7 @@ def generate(
       suggestions_only=suggestions_only,
       brief_suggestions=brief_suggestions,
       resume_override=resume,
+      skip_run_override=skip_run,
       resume_from_override=resume_from,
       state_dir_override=str(state_dir) if state_dir else None,
       max_retries_override=max_retries,
@@ -1030,6 +1038,13 @@ def audit(
       help='Only generate test titles and descriptions for suggestions (omits detailed blueprints).',
     ),
   ] = False,
+  skip_run: Annotated[
+    bool,
+    typer.Option(
+      '--skip-run',
+      help='Opt out of running generated tests.',
+    ),
+  ] = False,
   resume: Annotated[
     bool,
     typer.Option(
@@ -1201,6 +1216,7 @@ def audit(
       suggestions_only=True,
       brief_suggestions=brief_suggestions,
       resume_override=resume,
+      skip_run_override=skip_run,
       resume_from_override=resume_from,
       state_dir_override=str(state_dir) if state_dir else None,
       max_retries_override=max_retries,

--- a/wptgen/skills/wpt-generator/SKILL.md
+++ b/wptgen/skills/wpt-generator/SKILL.md
@@ -78,7 +78,7 @@ Before completing the task, you MUST validate that the code you generated is syn
 1. **Linting:** Use the `run_wpt_lint` tool on the file you created/modified.
    - If the linter reports errors (e.g., `TRAILING WHITESPACE`, `INDENT TABS`), you MUST use the `replace_in_file` tool to fix the errors and re-run the linter until it passes cleanly. This saves context tokens compared to rewriting the entire file.
 
-2. **Execution:** Use the `run_wpt_test` tool on the file you created/modified.
+2. **Execution:** If the `run_wpt_test` tool is available, use it on the file you created/modified. If the user prompt explicitly instructs you to skip running tests, or if the tool is not in your toolset, you MUST SKIP this execution step.
    - **CRITICAL RULE - Manual Tests:** If the test you created or modified is a manual test (e.g., ends in `-manual.html` or requires human intervention), you **MUST SKIP** this execution step entirely. Rely strictly on the linter for manual tests.
    - **Analyze the Output:** Read the test runner's output carefully.
    - **Self-Correct:** If the runner reports a `Harness Error`, `SyntaxError`, a timeout, or a failure that indicates a flaw in your test logic (e.g., calling an undefined helper function or making an incorrect assertion), you MUST use the `replace_in_file` or `write_file` tools to fix the bug, and re-run the test. Use `replace_in_file` whenever possible.


### PR DESCRIPTION
Resolves #327

## Overview
Adds a `--skip-run` flag to the `generate` command to explicitly opt out of test execution during the test generation workflow.

## Root Cause / Motivation
Currently, users do not have a way to skip running generated tests using `./wpt run ...` during the generation workflow. This flag provides flexibility to bypass the execution step, which can save time when only test file generation is desired.

## Detailed Changelog
* **`wptgen/main.py`**: Added `--skip-run` CLI flag to the `generate` command and passed the value down to `load_config`.
* **`wptgen/config.py`**: Added `skip_run` boolean to `Config` object to hydrate it via `load_config`.
* **`wptgen/agents/tools.py`**: Updated `create_agent_tools` to accept `include_run_tool` and conditionally include `run_wpt_test` in the toolset.
* **`wptgen/agents/adk_test_generator.py`**: Passed `not config.skip_run` to `create_agent_tools` call.
* **`wptgen/skills/wpt-generator/SKILL.md`**: Updated agent instructions to handle cases where `run_wpt_test` tool is not available or explicitly asked to skip.