### PR TITLE
fix: implement robust SSRF protection for external fetches

### DIFF
--- a/tests/test_chromestatus.py
+++ b/tests/test_chromestatus.py
@@ -36,7 +36,9 @@ def test_fetch_chromestatus_metadata_success(mocker: MockerFixture) -> None:
     mock_response = mocker.MagicMock()
     mock_response.read.return_value = json.dumps(mock_data).encode("utf-8")
     mock_response.__enter__.return_value = mock_response
-    mocker.patch("urllib.request.urlopen", return_value=mock_response)
+    mocker.patch(
+        "wptgen.context._ssrf_safe_opener.open", return_value=mock_response
+    )
 
     metadata = fetch_chromestatus_metadata("12345")
 
@@ -67,7 +69,9 @@ def test_fetch_chromestatus_metadata_with_prefix(mocker: MockerFixture) -> None:
     mock_response = mocker.MagicMock()
     mock_response.read.return_value = prefix_content.encode("utf-8")
     mock_response.__enter__.return_value = mock_response
-    mocker.patch("urllib.request.urlopen", return_value=mock_response)
+    mocker.patch(
+        "wptgen.context._ssrf_safe_opener.open", return_value=mock_response
+    )
 
     metadata = fetch_chromestatus_metadata("1238765")
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -217,7 +217,7 @@ def test_validate_wpt_paths_outside_root(tmp_path: Path) -> None:
 
 def test_fetch_mdn_urls_success(mocker: MockerFixture) -> None:
     """Test successfully fetching MDN URLs from the mapping JSON."""
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
     mock_response = mocker.MagicMock()
     mock_response.read.return_value = b'{"fetch": [{"url": "https://developer.mozilla.org/en-US/docs/Web/API/fetch"}]}'
     mock_urlopen.return_value.__enter__.return_value = mock_response
@@ -232,7 +232,7 @@ def test_fetch_mdn_urls_success(mocker: MockerFixture) -> None:
 
 def test_fetch_mdn_urls_not_found(mocker: MockerFixture) -> None:
     """Test that if a feature ID is not in the mapping, it returns an empty list."""
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
     mock_response = mocker.MagicMock()
     mock_response.read.return_value = (
         b'{"fetch": [{"url": "https://example.com"}]}'
@@ -246,7 +246,7 @@ def test_fetch_mdn_urls_not_found(mocker: MockerFixture) -> None:
 
 def test_fetch_mdn_urls_error(mocker: MockerFixture) -> None:
     """Test that HTTP errors during mapping fetch return an empty list."""
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
     mock_urlopen.side_effect = urllib.error.HTTPError(
         url="", code=404, msg="Not Found", hdrs=Message(), fp=None
     )
@@ -258,7 +258,7 @@ def test_fetch_mdn_urls_error(mocker: MockerFixture) -> None:
 
 def test_fetch_feature_yaml_success(mocker: MockerFixture) -> None:
     """Test the happy path where the YAML file is successfully fetched and parsed."""
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
 
     # Setup the context manager mock so it returns a byte string when .read() is called
     mock_response = mocker.MagicMock()
@@ -278,7 +278,7 @@ def test_fetch_feature_yaml_success(mocker: MockerFixture) -> None:
 
 def test_fetch_feature_yaml_not_found(mocker: MockerFixture) -> None:
     """Test that a 404 error from GitHub safely returns None."""
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
 
     # Simulate a 404 HTTPError
     mock_urlopen.side_effect = urllib.error.HTTPError(
@@ -292,7 +292,7 @@ def test_fetch_feature_yaml_not_found(mocker: MockerFixture) -> None:
 
 def test_fetch_feature_yaml_server_error(mocker: MockerFixture) -> None:
     """Test that a 500 error (or rate limit) raises an exception."""
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
 
     # Simulate a 500 HTTPError
     mock_urlopen.side_effect = urllib.error.HTTPError(
@@ -344,9 +344,39 @@ def test_extract_feature_metadata_defaults() -> None:
     assert result.specs == []
 
 
+def test_fetch_and_extract_text_ssrf_validation_blocks_localhost() -> None:
+    """Test that fetching from localhost is blocked by the SSRF validation."""
+    with pytest.raises(
+        ValueError, match="URL resolves to a restricted IP address"
+    ):
+        fetch_and_extract_text("http://localhost/spec")
+
+
+def test_fetch_and_extract_text_ssrf_validation_blocks_private_ip() -> None:
+    """Test that fetching from a private IP is blocked by the SSRF validation."""
+    with pytest.raises(
+        ValueError, match="URL resolves to a restricted IP address"
+    ):
+        fetch_and_extract_text("http://192.168.1.5/admin")
+
+
+def test_fetch_and_extract_text_ssrf_validation_blocks_metadata() -> None:
+    """Test that fetching from a cloud metadata IP is blocked by the SSRF validation."""
+    with pytest.raises(
+        ValueError, match="URL resolves to a restricted IP address"
+    ):
+        fetch_and_extract_text("http://169.254.169.254/latest/meta-data/")
+
+
+def test_fetch_and_extract_text_ssrf_validation_invalid_url() -> None:
+    """Test that an invalid URL without a hostname raises an error."""
+    with pytest.raises(ValueError, match="Invalid URL scheme: file"):
+        fetch_and_extract_text("file:///etc/passwd")
+
+
 def test_fetch_and_extract_text_success(mocker: MockerFixture) -> None:
     """Test the happy path where HTML is downloaded and successfully converted to Markdown."""
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
     mock_response = mocker.MagicMock()
     mock_response.read.return_value = (
         b"<html><body><main><h1>Spec</h1><p>Text</p></main></body></html>"
@@ -362,7 +392,7 @@ def test_fetch_and_extract_text_success(mocker: MockerFixture) -> None:
 
 def test_fetch_and_extract_text_retry_success(mocker: MockerFixture) -> None:
     """Test that fetch_and_extract_text retries on transient errors and eventually succeeds."""
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
 
     mock_response = mocker.MagicMock()
     mock_response.read.return_value = (
@@ -397,7 +427,7 @@ def test_fetch_and_extract_text_retry_max_reached(
     """Test that fetch_and_extract_text eventually gives up after MAX_RETRIES."""
     from wptgen.utils import MAX_RETRIES
 
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
 
     error429 = urllib.error.HTTPError(
         url="https://example.com",
@@ -421,7 +451,7 @@ def test_fetch_and_extract_text_retry_max_reached(
 
 def test_fetch_and_extract_text_fetch_fails(mocker: MockerFixture) -> None:
     """Test that if the URL cannot be fetched, the function returns None."""
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
     mock_urlopen.side_effect = Exception("Network error")
 
     result = fetch_and_extract_text("https://example.com")
@@ -431,7 +461,7 @@ def test_fetch_and_extract_text_fetch_fails(mocker: MockerFixture) -> None:
 
 def test_fetch_and_extract_text_extract_fails(mocker: MockerFixture) -> None:
     """Test that if no content is found, the function returns None."""
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
     mock_response = mocker.MagicMock()
     mock_response.read.return_value = b"<html></html>"
     mock_urlopen.return_value.__enter__.return_value = mock_response
@@ -445,7 +475,7 @@ def test_fetch_and_extract_text_preserves_internal_links(
     mocker: MockerFixture,
 ) -> None:
     """Test that internal spec links are preserved while external links are stripped."""
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
     mock_response = mocker.MagicMock()
     mock_response.read.return_value = (
         b"<html><body><main><h1>Spec</h1>\n"
@@ -666,7 +696,7 @@ def test_gather_local_test_context(tmp_path: Path) -> None:
 
 def test_fetch_feature_yaml_not_a_dict(mocker: MockerFixture) -> None:
     """Test that if the YAML file is not a dictionary, it returns None."""
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
     mock_response = mocker.MagicMock()
     mock_response.read.return_value = b'["not", "a", "dict"]'
     mock_urlopen.return_value.__enter__.return_value = mock_response
@@ -729,7 +759,7 @@ def test_gather_local_test_context_exception(
 
 def test_fetch_feature_yaml_draft(mocker: MockerFixture) -> None:
     """Test that fetching a draft feature constructs the correct URL."""
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
 
     mock_response = mocker.MagicMock()
     mock_response.read.return_value = b"name: 'Draft Feature'"

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import http.client
+import ipaddress
 import json
 import logging
 import re
+import socket
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -72,7 +75,7 @@ def fetch_feature_yaml(
         # Use standard library to avoid bloating dependencies
         # Set User-Agent to bypass generic bot filters and identify our crawler
         req = urllib.request.Request(url)
-        with urllib.request.urlopen(req) as response:
+        with _ssrf_safe_opener.open(req, timeout=10) as response:
             yaml_content = response.read().decode("utf-8")
 
             # Use safe_load to securely parse the YAML string into a Python dictionary
@@ -99,7 +102,7 @@ def fetch_chromestatus_metadata(feature_id: str) -> FeatureMetadata | None:
 
     try:
         req = urllib.request.Request(url, headers={"User-Agent": "WPT-Gen/1.0"})
-        with urllib.request.urlopen(req) as response:
+        with _ssrf_safe_opener.open(req, timeout=10) as response:
             content = response.read().decode("utf-8")
             # ChromeStatus API often prefixes JSON with a vulnerability protection string.
             if content.startswith(")]}'\n"):
@@ -161,7 +164,7 @@ def fetch_mdn_urls(web_feature_id: str) -> list[str]:
     try:
         # Set User-Agent to bypass generic bot filters and identify our crawler
         req = urllib.request.Request(MDN_MAPPINGS_URL)
-        with urllib.request.urlopen(req) as response:
+        with _ssrf_safe_opener.open(req, timeout=10) as response:
             json_content = response.read().decode("utf-8")
             data = json.loads(json_content)
 
@@ -194,6 +197,172 @@ def extract_feature_metadata(feature_data: dict[str, Any]) -> FeatureMetadata:
     )
 
 
+def validate_ip_against_ssrf(ip: str) -> None:
+    ip_obj = ipaddress.ip_address(ip)
+    if (
+        ip_obj.is_loopback
+        or ip_obj.is_private
+        or ip_obj.is_link_local
+        or ip_obj.is_multicast
+        or ip_obj.is_reserved
+        or ip == "0.0.0.0"
+    ):
+        raise ValueError(f"URL resolves to a restricted IP address: {ip}")
+
+
+class SafeHTTPConnection(http.client.HTTPConnection):
+
+    def connect(self) -> None:
+        err = None
+        for res in socket.getaddrinfo(
+            self.host, self.port, 0, socket.SOCK_STREAM
+        ):
+            af, socktype, proto, _, sa = res
+            ip = str(sa[0])
+            validate_ip_against_ssrf(ip)
+            try:
+                self.sock = socket.socket(af, socktype, proto)
+                if hasattr(self, "timeout") and self.timeout is not getattr(
+                    socket, "_GLOBAL_DEFAULT_TIMEOUT", object()
+                ):
+                    self.sock.settimeout(self.timeout)
+                self.sock.connect(sa)
+                if getattr(self, "_tunnel_host", None):
+                    self._tunnel()  # type: ignore[attr-defined]
+                return
+            except OSError as e:
+                err = e
+                if self.sock:
+                    self.sock.close()
+        if err is not None:
+            raise err
+        else:
+            raise OSError(f"getaddrinfo returns an empty list for {self.host}")
+
+
+class SafeHTTPSConnection(http.client.HTTPSConnection):
+
+    def connect(self) -> None:
+        err = None
+        for res in socket.getaddrinfo(
+            self.host, self.port, 0, socket.SOCK_STREAM
+        ):
+            af, socktype, proto, _, sa = res
+            ip = str(sa[0])
+            validate_ip_against_ssrf(ip)
+            try:
+                self.sock = socket.socket(af, socktype, proto)
+                if hasattr(self, "timeout") and self.timeout is not getattr(
+                    socket, "_GLOBAL_DEFAULT_TIMEOUT", object()
+                ):
+                    self.sock.settimeout(self.timeout)
+                self.sock.connect(sa)
+                if getattr(self, "_tunnel_host", None):
+                    self._tunnel()  # type: ignore[attr-defined]
+                tunnel_host = getattr(self, "_tunnel_host", None)
+                server_hostname = tunnel_host if tunnel_host else self.host
+                self.sock = self._context.wrap_socket(  # type: ignore[attr-defined]
+                    self.sock, server_hostname=server_hostname
+                )
+                return
+            except OSError as e:
+                err = e
+                if self.sock:
+                    self.sock.close()
+        if err is not None:
+            raise err
+        else:
+            raise OSError(f"getaddrinfo returns an empty list for {self.host}")
+
+
+class SafeHTTPHandler(urllib.request.HTTPHandler):
+
+    def http_open(self, req: urllib.request.Request) -> Any:
+        return self.do_open(SafeHTTPConnection, req)
+
+
+class SafeHTTPSHandler(urllib.request.HTTPSHandler):
+
+    def https_open(self, req: urllib.request.Request) -> Any:
+        return self.do_open(
+            SafeHTTPSConnection, req, context=getattr(self, "_context", None)
+        )
+
+
+class SafeHTTPRedirectHandler(urllib.request.HTTPRedirectHandler):
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        if not newurl.lower().startswith(("http://", "https://")):
+            raise ValueError(f"Redirection to non-HTTP URL forbidden: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+class BlockedFileHandler(urllib.request.FileHandler):
+
+    def file_open(self, req: urllib.request.Request) -> Any:
+        raise ValueError(
+            f"file:// scheme is blocked for SSRF protection: {req.full_url}"
+        )
+
+
+class BlockedFTPHandler(urllib.request.FTPHandler):
+
+    def ftp_open(self, req: urllib.request.Request) -> Any:
+        raise ValueError(
+            f"ftp:// scheme is blocked for SSRF protection: {req.full_url}"
+        )
+
+
+class BlockedDataHandler(urllib.request.DataHandler):
+
+    def data_open(self, req: urllib.request.Request) -> Any:
+        raise ValueError(
+            f"data: scheme is blocked for SSRF protection: {req.full_url}"
+        )
+
+
+_ssrf_safe_opener = urllib.request.build_opener(
+    SafeHTTPHandler,
+    SafeHTTPSHandler,
+    SafeHTTPRedirectHandler,
+    BlockedFileHandler,
+    BlockedFTPHandler,
+    BlockedDataHandler,
+)
+
+
+def validate_url_against_ssrf(url: str) -> None:
+    """
+    Validates an initial URL to prevent Server-Side Request Forgery (SSRF) attacks.
+    This provides a fast path failure before attempting a connection.
+    (Further validation occurs at connection time to prevent TOCTOU and redirect bypass).
+    """
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Invalid URL scheme: {parsed.scheme}")
+
+    if not hostname:
+        raise ValueError("Invalid URL or missing hostname.")
+
+    try:
+        # Use getaddrinfo for IPv6 support
+        addr_info = socket.getaddrinfo(hostname, None)
+        for res in addr_info:
+            validate_ip_against_ssrf(str(res[4][0]))
+    except socket.gaierror as e:
+        raise ValueError(f"Could not resolve hostname: {hostname}") from e
+
+
 def fetch_and_extract_text(url: str) -> str | None:
     """
     Fetches the HTML content from a URL and extracts the core textual content,
@@ -201,6 +370,7 @@ def fetch_and_extract_text(url: str) -> str | None:
     Returns the content formatted as Markdown.
     """
     logger.info(f"Fetching content from: {url}")
+    validate_url_against_ssrf(url)
 
     @retry(
         (urllib.error.HTTPError, urllib.error.URLError),
@@ -211,11 +381,17 @@ def fetch_and_extract_text(url: str) -> str | None:
         req = urllib.request.Request(
             url, headers={"User-Agent": "Mozilla/5.0 (compatible; WPT-Gen/1.0)"}
         )
-        with urllib.request.urlopen(req) as response:
+        with _ssrf_safe_opener.open(req, timeout=10) as response:
             return str(response.read().decode("utf-8"))
 
     try:
         html = _fetch()
+    except ValueError as e:
+        # Rethrow SSRF validation errors that occur during redirects or connection
+        if "resolves to a restricted IP address" in str(e):
+            raise
+        logger.error(f"Failed to download HTML from {url}: {e}")
+        return None
     except Exception as e:
         logger.error(f"Failed to download HTML from {url}: {e}")
         return None


### PR DESCRIPTION
Resolves #398

## Overview
Implements a robust SSRF (Server-Side Request Forgery) protection mechanism for fetching external content (e.g., WPT specs, MDN URLs, ChromeStatus metadata), and addresses critical vulnerabilities in the initial implementation such as scheme bypasses and global state manipulation.

## Root Cause / Motivation
The original WPT-Gen implementation used default `urllib.request.urlopen` calls without any IP validation, leaving the application vulnerable to SSRF. An initial fix attempted to add a custom opener but left significant flaws:
- **Scheme Bypasses:** The default `urllib` handlers (`FileHandler`, `FTPHandler`) were not removed, allowing attackers to bypass IP checks via DNS rebinding or `302 Redirects` to `file://` or `ftp://` schemes.
- **Missing Timeouts:** Lack of timeouts on HTTP requests exposed the system to Denial of Service (DoS) attacks via "tarpitting" by malicious servers.
- **Global State Pollution:** Installing the secure opener globally with `urllib.request.install_opener` broke the principle of least privilege and would block legitimate internal requests from other components.

## Detailed Changelog
* **`wptgen/context.py`**: 
  - Created `SafeHTTPRedirectHandler` to restrict redirects to strictly `http` and `https` schemes.
  - Stripped unsafe handlers (`FileHandler`, `FTPHandler`, `DataHandler`) from the `_ssrf_safe_opener` to prevent scheme bypasses.
  - Updated `validate_url_against_ssrf` to fail fast on non-HTTP/HTTPS schemes.
  - Removed global `urllib.request.install_opener` and replaced all instances of `urllib.request.urlopen` with `_ssrf_safe_opener.open`.
  - Added explicit `timeout=10` to all untrusted external fetch requests to prevent DoS.
* **`tests/test_context.py`**: Updated mock targets from `urllib.request.urlopen` to `wptgen.context._ssrf_safe_opener.open` and adjusted expected exception messages for scheme validation.
* **`tests/test_chromestatus.py`**: Updated mock targets to use the new secure opener instance.