### PR TITLE
fix: Prevent argument injection in subprocess calls (Issue #401)

### DIFF
--- a/tests/agents/test_adk_tools.py
+++ b/tests/agents/test_adk_tools.py
@@ -592,3 +592,57 @@ def test_replace_in_file(tmp_path: Path) -> None:
 
     result = tool.func("/tmp/outside", "foo", "bar")
     assert result["status"] == "error"
+
+
+def test_agent_tools_run_wpt_lint_flag_injection(
+    tmp_path: Path, mocker: Any
+) -> None:
+    wpt_root = tmp_path / "wpt"
+    wpt_root.mkdir()
+    test_file = wpt_root / "--dummy-flag.html"
+    test_file.touch()
+
+    tools = create_agent_tools(
+        wpt_root, MagicMock(spec=UIProvider), "chrome", "canary"
+    )
+    tool = next(t for t in tools if t.name == "run_wpt_lint")
+
+    mock_run = mocker.patch("wptgen.agents.tools.subprocess.run")
+    mock_run.return_value.returncode = 0
+    mock_run.return_value.stdout = ""
+    mock_run.return_value.stderr = ""
+
+    result = tool.func(str(test_file))
+
+    assert result["status"] == "success"
+    mock_run.assert_called_once()
+    args, kwargs = mock_run.call_args
+    assert args[0] == ["./wpt", "lint", "./--dummy-flag.html"]
+
+
+def test_agent_tools_run_wpt_test_flag_injection(
+    tmp_path: Path, mocker: Any
+) -> None:
+    wpt_root = tmp_path / "wpt"
+    wpt_root.mkdir()
+    test_file = wpt_root / "--dummy-flag.html"
+    test_file.touch()
+
+    tools = create_agent_tools(
+        wpt_root, MagicMock(spec=UIProvider), "chrome", "canary"
+    )
+    tool = next(t for t in tools if t.name == "run_wpt_test")
+
+    mock_run = mocker.patch("wptgen.agents.tools.subprocess.run")
+    mock_run.return_value.returncode = 0
+    mock_run.return_value.stdout = ""
+    mock_run.return_value.stderr = ""
+
+    result = tool.func(str(test_file))
+
+    assert result["status"] == "success"
+    mock_run.assert_called_once()
+    args, kwargs = mock_run.call_args
+    # cmd looks like: ['./wpt', 'run', '--channel', 'canary', '--headless', '--log-raw', ..., 'chrome', './--dummy-flag.html']
+    assert args[0][-1] == "./--dummy-flag.html"
+    assert args[0][0:2] == ["./wpt", "run"]

--- a/wptgen/agents/tools.py
+++ b/wptgen/agents/tools.py
@@ -408,7 +408,7 @@ def create_agent_tools(
             # We use subprocess.run directly as these tools are executed synchronously by ADK currently
             try:
                 result = subprocess.run(
-                    ["./wpt", "lint", rel_path],
+                    ["./wpt", "lint", f"./{rel_path}"],
                     cwd=str(wpt_path),
                     capture_output=True,
                     text=True,
@@ -473,7 +473,7 @@ def create_agent_tools(
                         "--log-raw",
                         log_path,
                         browser,
-                        rel_path,
+                        f"./{rel_path}",
                     ]
                 )
 


### PR DESCRIPTION
Resolves #401

## Overview
This PR resolves an argument injection vulnerability in the `run_wpt_lint` and `run_wpt_test` tools by securely formatting file path arguments passed to the WPT CLI.

## Root Cause / Motivation
The `run_wpt_lint` and `run_wpt_test` functions pass relative file paths directly to `subprocess.run`. A file with a malicious or accidental flag-like name (e.g., `--dummy-flag.html`) could be interpreted by the `./wpt` executable as a command-line flag instead of a file target.

## Detailed Changelog
* **`wptgen/agents/tools.py`**: Updated the subprocess command arguments in both `run_wpt_lint` and `run_wpt_test` to prepend `./` to the `rel_path` string (e.g., `f'./{rel_path}'`), ensuring the paths are explicitly parsed as files by the CLI tools.
* **`tests/agents/test_adk_tools.py`**: Added unit tests `test_agent_tools_run_wpt_lint_flag_injection` and `test_agent_tools_run_wpt_test_flag_injection` that mock `subprocess.run` to verify that files named `--dummy-flag.html` are safely formatted without triggering CLI flags.