### PR TITLE
feat: add edge browser support to BrowserType enum

### DIFF
--- a/wptgen/models.py
+++ b/wptgen/models.py
@@ -65,6 +65,7 @@ class BrowserType(str, Enum):
     CHROME = "chrome"
     FIREFOX = "firefox"
     SAFARI = "safari"
+    EDGE = "edge"
 
 
 class BrowserChannel(str, Enum):


### PR DESCRIPTION
Resolves #372

## Overview
Adds support for running generated tests against the Microsoft Edge browser using the `--run-on-browser edge` CLI flag.

## Root Cause / Motivation
Currently, `wpt-gen` allows users to specify the browser to run generated tests against via the `--run-on-browser` CLI flag. However, the internal `BrowserType` enum only supported `chrome`, `firefox`, and `safari`. The upstream Web Platform Tests runner (`wpt run`) has built-in support for Microsoft Edge (`edge`). By omitting `edge` from the enum, `wpt-gen` was artificially limiting the browser targets available for test execution. Adding Edge support allows developers to natively verify generated tests against the Microsoft Edge browser engine.

## Detailed Changelog
* **`wptgen/models.py`**: Added `EDGE = 'edge'` to the `BrowserType` string enumeration to enable Edge as a valid browser target.
