### PR TITLE
fix(cli): disable directory inference for `generate` command

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -152,7 +152,7 @@ def test_run_workflow_sync(engine: WPTGenEngine, mocker: MockerFixture) -> None:
     """Tests the synchronous wrapper."""
     mock_async_workflow = mocker.patch.object(engine, "_run_async_workflow")
     engine.run_workflow("feat-id")
-    mock_async_workflow.assert_called_once_with("feat-id")
+    mock_async_workflow.assert_called_once_with("feat-id", False)
 
 
 @pytest.mark.asyncio

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -151,7 +151,9 @@ def test_generate_success(
     mock_load_config.assert_called_once_with(**expected_kwargs)
 
     # Verify config was passed correctly
-    mock_engine_instance.run_workflow.assert_called_once_with("grid")
+    mock_engine_instance.run_workflow.assert_called_once_with(
+        "grid", disable_directory_inference=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -545,7 +547,9 @@ def test_audit_success(
     assert kwargs["suggestions_only"] is True
     assert kwargs["provider_override"] == "gemini"
 
-    mock_engine_instance.run_workflow.assert_called_once_with("grid")
+    mock_engine_instance.run_workflow.assert_called_once_with(
+        "grid", disable_directory_inference=False
+    )
 
 
 def test_config_show_command(

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -65,9 +65,15 @@ class WPTGenEngine:
         self.cache_dir = Path(self.config.cache_path)
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
-    def run_workflow(self, web_feature_id: str) -> WorkflowContext:
+    def run_workflow(
+        self, web_feature_id: str, disable_directory_inference: bool = False
+    ) -> WorkflowContext:
         """Entry point for the synchronous CLI to launch the async workflow."""
-        return asyncio.run(self._run_async_workflow(web_feature_id))
+        return asyncio.run(
+            self._run_async_workflow(
+                web_feature_id, disable_directory_inference
+            )
+        )
 
     def _get_resume_file_path(self, web_feature_id: str) -> Path:
         """Returns the path to the resume file for a given web feature ID."""
@@ -215,7 +221,9 @@ class WPTGenEngine:
             with open(tests_json, "w", encoding="utf-8") as f:
                 json.dump(tests_data, f, indent=2)
 
-    async def _run_async_workflow(self, web_feature_id: str) -> WorkflowContext:
+    async def _run_async_workflow(
+        self, web_feature_id: str, disable_directory_inference: bool = False
+    ) -> WorkflowContext:
         """Orchestrates the end-to-end WPT generation workflow."""
         context = None
 
@@ -256,7 +264,7 @@ class WPTGenEngine:
 
             self._save_resume_state(context)
 
-        if not self.config.output_dir:
+        if not self.config.output_dir and not disable_directory_inference:
             from wptgen.utils import determine_output_directory
 
             self.config.output_dir = determine_output_directory(

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -225,6 +225,7 @@ def _execute_workflow(
     wf_yml_update: bool,
     output_dir: Path | None,
     is_audit: bool = False,
+    disable_directory_inference: bool = False,
 ) -> None:
     """Instantiates the engine and runs the end-to-end workflow.
 
@@ -241,7 +242,9 @@ def _execute_workflow(
     engine = WPTGenEngine(config=config, ui=ui)
 
     # Execute the workflow
-    context = engine.run_workflow(web_feature_id)
+    context = engine.run_workflow(
+        web_feature_id, disable_directory_inference=disable_directory_inference
+    )
 
     if is_audit:
         console.print()
@@ -641,6 +644,7 @@ def generate(
             wf_yml_update=wf_yml_update,
             output_dir=output_dir,
             is_audit=False,
+            disable_directory_inference=True,
         )
 
 


### PR DESCRIPTION
## Overview
This PR refactors the output directory inference logic to be conditionally disabled and disables it for the `generate` command.

## Root Cause / Motivation
The `wpt-gen generate` command was automatically inferring an output directory via `determine_output_directory` when none was provided by the user. However, this logic is redundant and conflicts with the underlying test generation phase (the ADK agent), which already includes its own logic to infer and manage the output directory appropriately. By disabling this top-level inference for `generate`, we allow the test generation skill to handle it as intended, while preserving the inference capability for commands like `chromestatus` and `audit` which still rely on it.

## Detailed Changelog
* **`wptgen/engine.py`**: Added a `disable_directory_inference` parameter to `run_workflow` and `_run_async_workflow`. Only runs `determine_output_directory` if this flag is `False` and no explicit `output_dir` is set.
* **`wptgen/main.py`**: Passed `disable_directory_inference=True` to `_execute_workflow` for the `generate` and `generate-single` commands, preventing inference.
* **`tests/test_engine.py`**: Updated `test_run_workflow_sync` to expect the new `disable_directory_inference` parameter.
* **`tests/test_main.py`**: Updated the mock calls for `engine.run_workflow` in the generation and audit command tests to assert the correct boolean value for `disable_directory_inference`.