### PR TITLE
fix: add required `max_tokens` argument to Anthropic client

### DIFF
--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -87,6 +87,7 @@ def test_anthropic_generate_content(
     # Verify the internal SDK method was called with the correct model and prompt
     mock_instance.messages.create.assert_called_once_with(
         model="claude-3-7-sonnet-20250219",
+        max_tokens=AnthropicClient.DEFAULT_MAX_TOKENS,
         messages=[{"role": "user", "content": "Test prompt"}],
         system="Test instruction",
         temperature=0.7,

--- a/wptgen/llm.py
+++ b/wptgen/llm.py
@@ -328,6 +328,8 @@ class OpenAIClient(LLMClient):
 class AnthropicClient(LLMClient):
     """Client for interacting with Anthropic's API."""
 
+    DEFAULT_MAX_TOKENS = 8192
+
     def __init__(
         self,
         api_key: str,
@@ -378,6 +380,7 @@ class AnthropicClient(LLMClient):
         target_model = model or self.model
         kwargs: dict[str, Any] = {
             "model": target_model,
+            "max_tokens": self.DEFAULT_MAX_TOKENS,
             "messages": [{"role": "user", "content": prompt}],
         }
 


### PR DESCRIPTION
## Overview
This PR resolves the missing argument error encountered when generating tests using the Anthropic Claude model.

## Root Cause / Motivation
The latest version of the Anthropic SDK strictly requires the `max_tokens` argument when using the `messages.create()` method for Claude models. Previously, this argument was omitted, causing a `Missing required arguments` exception during the requirements extraction phase of test generation.

## Detailed Changelog
* **`wptgen/llm.py`**: Added a `DEFAULT_MAX_TOKENS = 8192` class constant to `AnthropicClient`. Included this constant as the `max_tokens` value in the `kwargs` dictionary passed to `messages.create()`.
* **`tests/test_anthropic.py`**: Updated the mock assertion in `test_anthropic_generate_content` to expect `max_tokens=AnthropicClient.DEFAULT_MAX_TOKENS`.