### PR TITLE
Fix: Remove hardcoded temperature overrides to use provider defaults

### DIFF
--- a/wptgen/phases/coverage_audit.py
+++ b/wptgen/phases/coverage_audit.py
@@ -206,7 +206,6 @@ async def run_coverage_audit(
                 ui,
                 config,
                 system_instruction=audit_system_prompt,
-                temperature=0.01,
                 model=config.get_model_for_phase(WorkflowPhase.COVERAGE_AUDIT),
             )
             return idx, res

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -247,7 +247,6 @@ async def run_requirements_extraction_categorized(
                 ui,
                 config,
                 system_instruction=extraction_system_prompt,
-                temperature=0.01,
                 model=config.get_model_for_phase(
                     WorkflowPhase.REQUIREMENTS_EXTRACTION
                 ),
@@ -437,7 +436,6 @@ async def run_requirements_extraction_iterative(
                 ui,
                 config,
                 system_instruction=extraction_system_prompt,
-                temperature=0.01,
                 model=config.get_model_for_phase(
                     WorkflowPhase.REQUIREMENTS_EXTRACTION
                 ),


### PR DESCRIPTION
Resolves #437

## Overview
Removes the hardcoded `0.01` temperature overrides from the Requirements Extraction and Coverage Audit phases, allowing them to fall back to the provider's default model temperature.

## Root Cause / Motivation
Previously, the `requirements_extraction` and `coverage_audit` phases explicitly hardcoded their temperature to `0.01` when making LLM requests. This prevented the LLM's default temperature from being used and ignored the tool's intended fallback mechanism where no override allows the default to be respected.

## Detailed Changelog
* **`wptgen/phases/requirements_extraction.py`**: Removed the `temperature` keyword argument when calling `generate_safe`, allowing the API client to use the provider's default temperature.
* **`wptgen/phases/coverage_audit.py`**: Removed the `temperature` keyword argument when calling `generate_safe`, allowing the API client to use the provider's default temperature.