### PR TITLE
Update test generation message

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -303,7 +303,7 @@ def test_report_generation_start(
 ) -> None:
     ui.report_generation_start(5)
     mock_console.print.assert_called_once_with(
-        "\nGenerating [bold]5[/bold] tests in parallel..."
+        "\nGenerating [bold]5[/bold] tests..."
     )
 
 

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -477,9 +477,7 @@ class RichUIProvider:
 
     def report_generation_start(self, count: int) -> None:
         """Displays the start of the test generation phase."""
-        self.console.print(
-            f"\nGenerating [bold]{count}[/bold] tests in parallel..."
-        )
+        self.console.print(f"\nGenerating [bold]{count}[/bold] tests...")
 
     def report_test_generated(
         self,


### PR DESCRIPTION
Previously, we were generating the tests in parallel, but now we're handling the generation tasks sequentially, because the process does not necessarily generate a new file for each test anymore. Sometimes, assertions are added to existing files.

This is just a small change to remove the parallelism reference