### PR TITLE
build(deps): force Dependabot to bump python dependency ranges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    versioning-strategy: "increase"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Overview
Forces Dependabot to bump Python dependency versions defined with open lower bounds in `pyproject.toml`.

## Root Cause / Motivation
By default, the Dependabot `pip` package-ecosystem uses the `increase-if-necessary` versioning strategy. Because all Python dependencies in `pyproject.toml` are defined with `>=` open ranges (e.g., `google-adk>=1.27.2`), Dependabot considers newer versions to already be permitted by the existing range and does not generate pull requests to update the lower bounds. This change explicitly switches the pip strategy to `increase`, ensuring that PRs are created to bump these minimum required versions when updates are available.

## Detailed Changelog
* **`.github/dependabot.yml`**: Added `versioning-strategy: "increase"` to the `pip` package-ecosystem configuration to force updates to `pyproject.toml` dependencies.