### PR TITLE
fix(adk): add `anthropic/` prefix to bypass Vertex AI routing for Claude models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "openai>=2.20.0",
     "anthropic>=0.84.0",
     "tiktoken>=0.12.0",
+    "litellm>=1.83.8",
 
     # Context & Scraping
     "beautifulsoup4>=4.12.0",

--- a/tests/agents/test_adk_test_generator.py
+++ b/tests/agents/test_adk_test_generator.py
@@ -296,3 +296,63 @@ async def test_generate_test_invalid_path(
         "Failed to read securely generated file '/etc/passwd'"
         in mock_ui.error.call_args[0][0]
     )
+
+
+@pytest.mark.asyncio
+async def test_generate_test_with_anthropic_provider(
+    tmp_path: Path, mocker: MagicMock, mock_jinja_env: MagicMock
+) -> None:
+    wpt_root = tmp_path / "wpt"
+    wpt_root.mkdir()
+
+    # Mock Runner to assert agent configuration
+    mock_runner_cls = mocker.patch("wptgen.agents.adk_test_generator.Runner")
+    mock_runner_instance = mock_runner_cls.return_value
+    mock_runner_instance.close = mocker.AsyncMock()
+
+    async def mock_run_async(*args: Any, **kwargs: Any) -> Any:
+        yield MagicMock()
+
+    mock_runner_instance.run_async = mock_run_async
+
+    # Mock environment setup
+    mocker.patch(
+        "wptgen.agents.adk_test_generator.setup_adk_environment",
+        return_value="claude-3-5-sonnet-20240620",
+    )
+
+    mocker.patch(
+        "wptgen.agents.adk_test_generator.Path.is_dir", return_value=False
+    )
+
+    config = Config(
+        provider="anthropic",
+        default_model="claude-3-5-sonnet-20240620",
+        api_key="fake",
+        wpt_path=str(wpt_root),
+        output_dir="",
+        categories={},
+        phase_model_mapping={},
+    )
+
+    context = WorkflowContext(
+        feature_id="my-feature",
+        spec_contents={"spec1": "fake spec"},
+        metadata=None,
+        audit_response="fake audit",
+    )
+
+    mock_ui = MagicMock()
+    await generate_test_with_adk(
+        suggestion_xml="<test_suggestion></test_suggestion>",
+        root_name="my-feature-1",
+        test_type_enum=WPTTestType.JAVASCRIPT,
+        context=context,
+        config=config,
+        jinja_env=mock_jinja_env,
+        ui=mock_ui,
+    )
+
+    # Assert that the 'anthropic/' prefix was added to the model string
+    agent = mock_runner_cls.call_args.kwargs["agent"]
+    assert agent.model == "anthropic/claude-3-5-sonnet-20240620"

--- a/wptgen/agents/adk_test_generator.py
+++ b/wptgen/agents/adk_test_generator.py
@@ -59,6 +59,10 @@ async def generate_test_with_adk(
         A list of tuples containing (file_path, file_content, suggestion_xml).
     """
     model_string = setup_adk_environment(config)
+    if config.provider.lower() == "anthropic" and not model_string.startswith(
+        "anthropic/"
+    ):
+        model_string = f"anthropic/{model_string}"
     wpt_root = Path(config.wpt_path)
 
     # We need to extract the paths from the agent's final tool call.


### PR DESCRIPTION
## Overview
This PR prepends the `anthropic/` provider prefix to the model configuration in `wptgen/agents/adk_test_generator.py` when using Anthropic models, ensuring LiteLLM connects directly to the native Anthropic API instead of attempting Vertex AI routing. It also includes a test to verify the prefix logic and updates project dependencies to include `litellm`.

## Root Cause / Motivation
The Google Agent Development Kit (ADK) uses LiteLLM for routing LLM connections. When an Anthropic model is requested without an explicit provider prefix, ADK's LiteLLM configuration often defaults to using the `vertex_ai/` prefix. This attempts to route requests to Google Cloud's Vertex AI Model Garden, which subsequently looks for Google Cloud credentials (`GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`). For users working outside of a Google Cloud project with a native Anthropic API key, this causes immediate authentication and configuration errors. Explicitly prepending `anthropic/` forces LiteLLM to use the native provider and the existing `ANTHROPIC_API_KEY`.

## Detailed Changelog
* **`wptgen/agents/adk_test_generator.py`**: Added a check to see if the provider is `anthropic`. If so, it verifies whether the model string already has an `anthropic/` prefix, and if not, prepends it.
* **`tests/agents/test_adk_test_generator.py`**: Added `test_generate_test_with_anthropic_provider` to mock an Anthropic provider setup and assert that the `Runner` correctly receives the agent with an `anthropic/claude-3-5-sonnet-20240620` model configuration.
* **`pyproject.toml`**: Added the `litellm` package dependency, as it is required by ADK for the routing mechanism to explicitly map the `anthropic/` prefix.
