### PR TITLE
fix: suppress noisy non-text parts warning from google-genai

### DIFF
--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -87,6 +87,19 @@ class SuppressDuplicateWarningFilter(logging.Filter):
         return True
 
 
+class SuppressNonTextWarningFilter(logging.Filter):
+    """Filters out noisy non-text parts warnings from google-genai."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if (
+            record.levelno == logging.WARNING
+            and "there are non-text parts in the response"
+            in record.getMessage()
+        ):
+            return False
+        return True
+
+
 # Apply the custom warning formatter globally
 handler = logging.StreamHandler(sys.stderr)
 handler.setFormatter(
@@ -96,6 +109,9 @@ logging.basicConfig(level=logging.WARNING, handlers=[handler], force=True)
 
 logging.getLogger("google_genai._api_client").addFilter(
     SuppressDuplicateWarningFilter()
+)
+logging.getLogger("google_genai.types").addFilter(
+    SuppressNonTextWarningFilter()
 )
 
 # Initialize Typer app and Rich console


### PR DESCRIPTION
## Overview
Suppresses a noisy and benign warning from the `google-genai` SDK related to non-text parts in responses.

## Root Cause / Motivation
When using the Agent Development Kit (`google-adk`), agent tools and actions naturally return `function_call` parts in the response. If the `.text` property of a model response part is accessed when there are non-text parts (like tool calls), the `google-genai` SDK emits a warning. Since `function_call` parts are expected in this agentic workflow, the warning clutters standard error output needlessly.

## Detailed Changelog
* **`wptgen/main.py`**: Added `SuppressNonTextWarningFilter` to intercept and drop warnings containing `"there are non-text parts in the response"` and attached it to the `google_genai.types` logger.