### PR TITLE
chore: Bump version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wpt-gen"
-version = "0.4.0"
+version = "0.5.0"
 description = "A CLI Tool for AI-Powered Web Platform Test Generation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/wptgen/__init__.py
+++ b/wptgen/__init__.py
@@ -14,4 +14,4 @@
 
 """WPT-Gen: An agentic tool for automating Web Platform Tests."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"


### PR DESCRIPTION
## Overview
This pull request bumps the WPT-Gen version from 0.4.0 to 0.5.0.

## Root Cause / Motivation
A version update was requested to prepare for the 0.5.0 release.

## Detailed Changelog
* **`pyproject.toml`**: Updated the `version` field in the `[project]` section to 0.5.0.
* **`wptgen/__init__.py`**: Updated the `__version__` string to 0.5.0.