### PR TITLE
feat: Add OpenAI model prefix handling in ADK Test Generator

### DIFF
--- a/tests/agents/test_adk_test_generator.py
+++ b/tests/agents/test_adk_test_generator.py
@@ -356,3 +356,63 @@ async def test_generate_test_with_anthropic_provider(
     # Assert that the 'anthropic/' prefix was added to the model string
     agent = mock_runner_cls.call_args.kwargs["agent"]
     assert agent.model == "anthropic/claude-3-5-sonnet-20240620"
+
+
+@pytest.mark.asyncio
+async def test_generate_test_with_openai_provider(
+    tmp_path: Path, mocker: MagicMock, mock_jinja_env: MagicMock
+) -> None:
+    wpt_root = tmp_path / "wpt"
+    wpt_root.mkdir()
+
+    # Mock Runner to assert agent configuration
+    mock_runner_cls = mocker.patch("wptgen.agents.adk_test_generator.Runner")
+    mock_runner_instance = mock_runner_cls.return_value
+    mock_runner_instance.close = mocker.AsyncMock()
+
+    async def mock_run_async(*args: Any, **kwargs: Any) -> Any:
+        yield MagicMock()
+
+    mock_runner_instance.run_async = mock_run_async
+
+    # Mock environment setup
+    mocker.patch(
+        "wptgen.agents.adk_test_generator.setup_adk_environment",
+        return_value="gpt-4o",
+    )
+
+    mocker.patch(
+        "wptgen.agents.adk_test_generator.Path.is_dir", return_value=False
+    )
+
+    config = Config(
+        provider="openai",
+        default_model="gpt-4o",
+        api_key="fake",
+        wpt_path=str(wpt_root),
+        output_dir="",
+        categories={},
+        phase_model_mapping={},
+    )
+
+    context = WorkflowContext(
+        feature_id="my-feature",
+        spec_contents={"spec1": "fake spec"},
+        metadata=None,
+        audit_response="fake audit",
+    )
+
+    mock_ui = MagicMock()
+    await generate_test_with_adk(
+        suggestion_xml="<test_suggestion></test_suggestion>",
+        root_name="my-feature-1",
+        test_type_enum=WPTTestType.JAVASCRIPT,
+        context=context,
+        config=config,
+        jinja_env=mock_jinja_env,
+        ui=mock_ui,
+    )
+
+    # Assert that the 'openai/' prefix was added to the model string
+    agent = mock_runner_cls.call_args.kwargs["agent"]
+    assert agent.model == "openai/gpt-4o"

--- a/wptgen/agents/adk_test_generator.py
+++ b/wptgen/agents/adk_test_generator.py
@@ -63,6 +63,10 @@ async def generate_test_with_adk(
         "anthropic/"
     ):
         model_string = f"anthropic/{model_string}"
+    elif config.provider.lower() == "openai" and not model_string.startswith(
+        "openai/"
+    ):
+        model_string = f"openai/{model_string}"
     wpt_root = Path(config.wpt_path)
 
     # We need to extract the paths from the agent's final tool call.


### PR DESCRIPTION
Resolves #465

## Overview
Adds model string prefixing for OpenAI models (similarly to Anthropic) in the ADK Test Generator.

## Root Cause / Motivation
To ensure correct model loading when the provider is explicitly set to `openai` and the model string lacks the prefix. 

## Detailed Changelog
* **`wptgen/agents/adk_test_generator.py`**: Added an `elif` condition to check if the configured provider is `openai` and, if the model string lacks the `openai/` prefix, it is prepended.
* **`tests/agents/test_adk_test_generator.py`**: Added a new test `test_generate_test_with_openai_provider` to verify the logic correctly adds the prefix for OpenAI models.
