### PR TITLE
Replace addlicense Go dependency with Python script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,11 +35,6 @@ jobs:
         python-version: '3.13'
         cache: 'pip'
 
-    - name: Set up Go
-      uses: actions/setup-go@v6
-      with:
-        go-version: '1.22'
-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ PYLINT := pylint
 MYPY := mypy
 PYTEST := pytest
 PACKAGE_NAME := wptgen
-ADDLICENSE := go run github.com/google/addlicense@latest
-ADDLICENSE_IGNORE := -ignore '.venv/**' -ignore 'venv/**' -ignore 'build/**' -ignore 'dist/**' -ignore '.mypy_cache/**' -ignore '.ruff_cache/**' -ignore '.pytest_cache/**' -ignore '.git/**' -ignore 'wpt_gen.egg-info/**' -ignore '.agents/**' -ignore '.coverage'
+ADDLICENSE := $(PYTHON) scripts/check_license.py
+ADDLICENSE_IGNORE := 
 
 help:
 	@echo "Available commands:"
@@ -41,10 +41,10 @@ lock:
 	pip-compile pyproject.toml -o requirements.txt
 	pip-compile --extra dev pyproject.toml -o requirements-dev.txt
 license-check:
-	$(ADDLICENSE) -check -c "Google LLC" -l apache $(ADDLICENSE_IGNORE) .
+	$(ADDLICENSE)
 
 license-fix:
-	$(ADDLICENSE) -c "Google LLC" -l apache $(ADDLICENSE_IGNORE) .
+	$(ADDLICENSE) --fix
 
 lint: license-check
 	$(RUFF) check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ known-first-party = ["wptgen"]
 [tool.mypy]
 python_version = "3.10"
 strict = true
+mypy_path = "scripts"
 
 [tool.pytest.ini_options]
 addopts = "--cov=wptgen --cov-report=term-missing --cov-fail-under=80"

--- a/scripts/check_license.py
+++ b/scripts/check_license.py
@@ -65,7 +65,11 @@ IGNORE_DIRS = [
 ]
 
 
-def check_license(fix=False, directories=DIRECTORIES, exit_on_fail=True):
+def check_license(
+    fix: bool = False,
+    directories: list[str] = DIRECTORIES,
+    exit_on_fail: bool = True,
+) -> list[str]:
     """Checks for and optionally fixes missing license headers in files.
 
     Args:
@@ -102,8 +106,8 @@ def check_license(fix=False, directories=DIRECTORIES, exit_on_fail=True):
     if not fix:
         if missing_license:
             print("The following files are missing the Apache license:")
-            for f in missing_license:
-                print(f"  {f}")
+            for missing_file in missing_license:
+                print(f"  {missing_file}")
             print("\\nRun `make lint-fix` (or script with --fix) to add them.")
             if exit_on_fail:
                 sys.exit(1)

--- a/scripts/check_license.py
+++ b/scripts/check_license.py
@@ -1,0 +1,156 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Checks and enforces Apache 2.0 license headers across project files.
+
+This script scans specified directories for Python files. It verifies
+that each file contains the Apache 2.0 license header. It can also automatically
+inject missing headers using the `--fix` flag.
+"""
+
+import argparse
+import datetime
+import os
+import sys
+
+YEAR = datetime.datetime.now().year
+
+PY_LICENSE = f"""# Copyright {YEAR} Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+DIRECTORIES = [
+    ".",
+]
+EXTENSIONS = {
+    ".py": PY_LICENSE,
+}
+
+# Directories or files to explicitly ignore if necessary
+IGNORE_DIRS = [
+    ".venv",
+    "venv",
+    ".venv_fresh",
+    "build",
+    "dist",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+    ".git",
+    "wpt_gen.egg-info",
+    ".agents",
+    ".wptgen",
+]
+
+
+def check_license(fix=False, directories=DIRECTORIES, exit_on_fail=True):
+    """Checks for and optionally fixes missing license headers in files.
+
+    Args:
+        fix: If True, injects the license header into files missing it.
+        directories: A list of directory paths to scan.
+        exit_on_fail: If True, calls sys.exit() with status code 1 when missing
+            licenses are found (and not fixed). Useful for CI/CD pipelines.
+
+    Returns:
+        A list of file paths that are missing the license header.
+    """
+    missing_license = []
+
+    for directory in directories:
+        if not os.path.exists(directory):
+            continue
+        for root, dirs, files in os.walk(directory):
+            # Modify dirs in-place to avoid traversing ignored directories
+            dirs[:] = [d for d in dirs if d not in IGNORE_DIRS]
+
+            for file in files:
+                ext = os.path.splitext(file)[1]
+                if ext in EXTENSIONS:
+                    filepath = os.path.join(root, file)
+                    with open(filepath, encoding="utf-8") as f:
+                        content = f.read()
+
+                    if (
+                        "Licensed under the Apache License, Version 2.0"
+                        not in content
+                    ):
+                        missing_license.append(filepath)
+
+    if not fix:
+        if missing_license:
+            print("The following files are missing the Apache license:")
+            for f in missing_license:
+                print(f"  {f}")
+            print("\\nRun `make lint-fix` (or script with --fix) to add them.")
+            if exit_on_fail:
+                sys.exit(1)
+        else:
+            print("All files have the Apache license.")
+            if exit_on_fail:
+                sys.exit(0)
+    else:
+        if missing_license:
+            for filepath in missing_license:
+                ext = os.path.splitext(filepath)[1]
+                template = EXTENSIONS[ext]
+
+                with open(filepath, encoding="utf-8") as f:
+                    content = f.read()
+
+                # Special handling for scripts that might have a shebang or encoding comment
+                lines = content.splitlines(keepends=True)
+                insert_idx = 0
+                for i, line in enumerate(lines):
+                    if line.startswith("#!") or line.startswith("# -*-"):
+                        insert_idx = i + 1
+                    else:
+                        break
+
+                new_content = (
+                    "".join(lines[:insert_idx])
+                    + template
+                    + "".join(lines[insert_idx:])
+                )
+
+                with open(filepath, "w", encoding="utf-8") as f:
+                    f.write(new_content)
+
+            print(f"Added license to {len(missing_license)} files.")
+        else:
+            print("All files already have the Apache license.")
+
+    return missing_license
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Check or fix missing Apache license headers."
+    )
+    parser.add_argument(
+        "--fix", action="store_true", help="Fix missing licenses"
+    )
+    args = parser.parse_args()
+    check_license(fix=args.fix)

--- a/tests/test_check_license.py
+++ b/tests/test_check_license.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import tempfile
+
+# Add scripts directory to path to import check_license
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+)
+from check_license import check_license, PY_LICENSE  # type: ignore
+
+
+def test_check_license_no_missing() -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        # Create a file with a license
+        file_path = os.path.join(tempdir, "test.py")
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(PY_LICENSE + '\\nprint("Hello")\\n')
+
+        # Check license
+        missing = check_license(
+            fix=False, directories=[tempdir], exit_on_fail=False
+        )
+        assert len(missing) == 0
+
+
+def test_check_license_missing() -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        # Create a file without a license
+        file_path = os.path.join(tempdir, "test.py")
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write('print("Hello")\\n')
+
+        # Check license
+        missing = check_license(
+            fix=False, directories=[tempdir], exit_on_fail=False
+        )
+        assert len(missing) == 1
+        assert missing[0] == file_path
+
+
+def test_check_license_fix() -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        # Create a file without a license
+        file_path = os.path.join(tempdir, "test.py")
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write('print("Hello")\\n')
+
+        # Fix license
+        missing_before = check_license(
+            fix=True, directories=[tempdir], exit_on_fail=False
+        )
+        assert len(missing_before) == 1
+        assert missing_before[0] == file_path
+
+        # Verify license is added
+        with open(file_path, encoding="utf-8") as f:
+            content = f.read()
+        assert "Licensed under the Apache License" in content
+        assert 'print("Hello")' in content
+
+        # Check again
+        missing_after = check_license(
+            fix=False, directories=[tempdir], exit_on_fail=False
+        )
+        assert len(missing_after) == 0

--- a/tests/test_check_license.py
+++ b/tests/test_check_license.py
@@ -20,7 +20,7 @@ import tempfile
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
 )
-from check_license import check_license, PY_LICENSE  # type: ignore
+from check_license import check_license, PY_LICENSE
 
 
 def test_check_license_no_missing() -> None:


### PR DESCRIPTION
Resolves #468

## Overview
Replaces the Go-based `addlicense` tool with a custom Python script to verify and enforce Apache 2.0 license headers for Python files, removing Go entirely from the CI pipeline.

## Root Cause / Motivation
The project previously relied on downloading and compiling a Go binary (`github.com/google/addlicense@latest`) during the linting phase and required setting up Go in the CI pipeline. This added an unnecessary toolchain dependency to a Python-centric project. By replacing it with a Python script, we simplify the development environment, eliminate the Go CI dependency, and align with similar practices in other Chrome-related repositories like ChromeStatus.

## Detailed Changelog
* **`Makefile`**: Removed the `go run github.com/google/addlicense@latest` dependency and updated `ADDLICENSE` to use the new Python script. Updated `license-check` and `license-fix` targets accordingly.
* **`.github/workflows/main.yml`**: Removed the `actions/setup-go` step from the `Continuous Integration` workflow since Go is no longer needed to run the license checks.
* **`scripts/check_license.py`**: Added a new Python script that recursively scans specified directories (ignoring virtual environments and caches) to verify the presence of the Apache 2.0 "Google LLC" license header specifically in `.py` source files. It also implements a `--fix` argument to prepend missing headers.
* **`tests/test_check_license.py`**: Added unit tests to verify the behavior of the new license checking and fixing logic, ensuring Python files correctly pass, fail, or get fixed.