### PR TITLE
Restrict Dependabot pip grouping to direct dependencies to fix transitive upgrade conflicts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
     schedule:
       interval: "weekly"
     versioning-strategy: "increase-if-necessary"
+    allow:
+      - dependency-type: "direct"
     groups:
       all-pip-dependencies:
         patterns:


### PR DESCRIPTION
## Overview
This PR refines the Dependabot configuration to exclusively update direct project dependencies, eliminating the `ResolutionImpossible` conflicts caused by aggressive transitive dependency upgrades.

## Root Cause / Motivation
By previously grouping `*`, Dependabot was instructed to upgrade every single dependency (including transitive ones) to its latest version. Dependabot accomplished this by explicitly passing `--upgrade-package` to `pip-compile` for transitive dependencies (such as `google-cloud-discoveryengine==0.18.0` and `starlette==1.0.0`). 

However, direct dependencies in this project (like `google-adk`) impose strict maximum bounds on these transitive packages. By explicitly forcing transitive upgrades, Dependabot created an impossible resolution state for `pip-compile`, leading to the `ResolutionImpossible` CI failure in the grouped PR.

## Detailed Changelog
* **`.github/dependabot.yml`**: Added `allow: - dependency-type: "direct"` to the pip ecosystem configuration. This explicitly restricts Dependabot to only creating updates for the direct dependencies defined in `pyproject.toml`. Because it acts as a global filter for pip, the `patterns: - "*"` in the group rule now seamlessly groups only the allowed direct dependencies, removing the need to manually list them all. This allows `pip-compile` to safely resolve transitive dependency versions natively without forced bounds conflicts.