### PR TITLE
[vendoring] Move WorkflowError to models to decouple imports (#445)

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -21,8 +21,8 @@ import pytest
 from pytest_mock import MockerFixture
 
 from wptgen.config import Config
-from wptgen.engine import WorkflowError, WPTGenEngine
-from wptgen.models import WorkflowContext, WorkflowPhase
+from wptgen.engine import WPTGenEngine
+from wptgen.models import WorkflowContext, WorkflowError, WorkflowPhase
 
 
 @pytest.fixture
@@ -569,3 +569,17 @@ def test_engine_hydrate_context_html_files(
     paths = [p for p, c, s in context.generated_tests]
     assert html_file_1 in paths
     assert html_file_2 in paths
+
+
+def test_engine_isolated_import() -> None:
+    """Verify that the engine can be imported without CLI dependencies."""
+    import subprocess
+    import sys
+
+    # Run import in a separate process to avoid sys.modules pollution.
+    result = subprocess.run(
+        [sys.executable, "-c", "import wptgen.engine"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Import failed: {result.stderr}"

--- a/tests/test_workflow_failure.py
+++ b/tests/test_workflow_failure.py
@@ -22,7 +22,8 @@ from pytest_mock import MockerFixture
 from typer.testing import CliRunner
 
 from wptgen.config import Config
-from wptgen.engine import WorkflowError, WPTGenEngine
+from wptgen.engine import WPTGenEngine
+from wptgen.models import WorkflowError
 from wptgen.main import app
 
 runner = CliRunner()

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -22,7 +22,7 @@ from jinja2 import Environment, FileSystemLoader
 
 from wptgen.config import TEMPLATE_DIR, Config
 from wptgen.llm import get_llm_client
-from wptgen.models import WorkflowContext, WorkflowPhase
+from wptgen.models import WorkflowContext, WorkflowError, WorkflowPhase
 from wptgen.phases.context_assembly import run_context_assembly
 from wptgen.phases.coverage_audit import (
     provide_coverage_report,
@@ -46,10 +46,6 @@ __all__ = [
     "provide_coverage_report",
     "run_test_generation",
 ]
-
-
-class WorkflowError(Exception):
-    """Raised when a phase of the workflow fails to complete."""
 
 
 class WPTGenEngine:

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -46,13 +46,14 @@ from wptgen.context import (
     extract_feature_metadata,
     fetch_feature_yaml,
 )
-from wptgen.engine import WorkflowError, WPTGenEngine
+from wptgen.engine import WPTGenEngine
 from wptgen.llm import LLMTimeoutError
 from wptgen.metadata import update_web_features_yml
 from wptgen.models import (
     BrowserChannel,
     BrowserType,
     ModelCategory,
+    WorkflowError,
     WorkflowPhase,
 )
 from wptgen.phases.generation import (

--- a/wptgen/models.py
+++ b/wptgen/models.py
@@ -20,6 +20,10 @@ from pathlib import Path
 from typing import Any
 
 
+class WorkflowError(Exception):
+    """Raised when a phase of the workflow fails to complete."""
+
+
 class WorkflowPhase(str, Enum):
     """Enumeration of the phases in the WPT generation workflow."""
 


### PR DESCRIPTION
### Background
This PR decouples the core layers from the CLI driver to allow standalone programmatic usage of WPTGenEngine.

### Proposed Changes
- Relocated `WorkflowError` from `wptgen/engine.py` to the lower-level `wptgen/models.py`.
- Updated all imports across core orchestration modules, entrypoints, and test suites to reference the isolated exception from `wptgen.models`.
- Merged isolated import tests into `tests/test_engine.py` to ensure no circular dependency regressions.

Resolves #445
