### PR TITLE
[vendoring] Make WPT path optional for library mode (#446)

### DIFF
--- a/wptgen/agents/adk_test_generator.py
+++ b/wptgen/agents/adk_test_generator.py
@@ -67,6 +67,8 @@ async def generate_test_with_adk(
         "openai/"
     ):
         model_string = f"openai/{model_string}"
+    if not config.wpt_path:
+        raise ValueError("WPT path is required to generate tests.")
     wpt_root = Path(config.wpt_path)
 
     # We need to extract the paths from the agent's final tool call.

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -69,9 +69,10 @@ class Config:
     provider: str
     default_model: str
     api_key: str | None
-    wpt_path: str
     categories: dict[str, str]
     phase_model_mapping: dict[str, str]
+    wpt_path: str | None = None
+    library_mode: bool = False
     output_dir: str | None = None
     show_responses: bool = False
     yes_tokens: bool = False

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -266,9 +266,13 @@ class WPTGenEngine:
         if not self.config.output_dir and not disable_directory_inference:
             from wptgen.utils import determine_output_directory
 
-            self.config.output_dir = determine_output_directory(
-                context, self.config, self.ui
-            )
+            try:
+                self.config.output_dir = determine_output_directory(
+                    context, self.config, self.ui
+                )
+            except ValueError as e:
+                self.ui.error(str(e))
+                raise WorkflowError(f"Directory inference failed: {e}") from e
 
         # Phase 2: Requirements Extraction
         if should_run(

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -1085,23 +1085,27 @@ def doctor_command(
         ui.error(f"API key for {config.provider} is missing.")
         success = False
 
-    wpt_path = Path(config.wpt_path)
-    if wpt_path.is_dir():
-        ui.success(f"WPT directory found: {wpt_path}")
-        if (wpt_path / ".git").exists():
-            ui.success("WPT directory is a valid git repository.")
-        else:
-            ui.error("WPT directory is not a git repository.")
-            success = False
+    if config.wpt_path:
+        wpt_path = Path(config.wpt_path)
+        if wpt_path.is_dir():
+            ui.success(f"WPT directory found: {wpt_path}")
+            if (wpt_path / ".git").exists():
+                ui.success("WPT directory is a valid git repository.")
+            else:
+                ui.error("WPT directory is not a git repository.")
+                success = False
 
-        wpt_exec = wpt_path / "wpt"
-        if wpt_exec.exists() and os.access(wpt_exec, os.X_OK):
-            ui.success("WPT executable (./wpt) is runnable.")
+            wpt_exec = wpt_path / "wpt"
+            if wpt_exec.exists() and os.access(wpt_exec, os.X_OK):
+                ui.success("WPT executable (./wpt) is runnable.")
+            else:
+                ui.error("WPT executable (./wpt) is missing or not executable.")
+                success = False
         else:
-            ui.error("WPT executable (./wpt) is missing or not executable.")
+            ui.error(f"WPT directory not found: {wpt_path}")
             success = False
     else:
-        ui.error(f"WPT directory not found: {wpt_path}")
+        ui.error("WPT path is not configured.")
         success = False
 
     ui.print()

--- a/wptgen/phases/context_assembly.py
+++ b/wptgen/phases/context_assembly.py
@@ -29,7 +29,7 @@ from wptgen.context import (
     gather_local_test_context,
     validate_wpt_paths,
 )
-from wptgen.models import WorkflowContext
+from wptgen.models import WorkflowContext, WPTContext
 from wptgen.ui import UIProvider
 
 
@@ -141,35 +141,47 @@ async def run_context_assembly(
                         f"explainer: {url}"
                     )
 
-    ui.print(
-        "Scanning local WPT repository for existing tests and dependencies..."
-    )
-    test_paths = find_feature_tests(config.wpt_path, web_feature_id)
-    extracted_wpt_urls: list[str] | None = None
+    test_paths = []
+    extracted_wpt_urls = None
 
-    # If ChromeStatus is enabled, extract and validate tests from wpt_descr
-    if config.chromestatus and metadata.wpt_descr:
-        with ui.status("Extracting tests from ChromeStatus..."):
-            extracted_wpt_urls = extract_wpt_paths(metadata.wpt_descr)
-            if extracted_wpt_urls:
-                try:
-                    valid_paths, invalid_paths = validate_wpt_paths(
-                        extracted_wpt_urls, config.wpt_path
-                    )
-                    for invalid in invalid_paths:
-                        ui.warning(
-                            "Referenced WPT test file could not be found or "
-                            f"read: {invalid}"
+    if config.wpt_path:
+        ui.print(
+            "Scanning local WPT repository for existing tests and "
+            "dependencies..."
+        )
+        test_paths = find_feature_tests(config.wpt_path, web_feature_id)
+
+        # If ChromeStatus is enabled, extract and validate tests from wpt_descr
+        if config.chromestatus and metadata.wpt_descr:
+            with ui.status("Extracting tests from ChromeStatus..."):
+                extracted_wpt_urls = extract_wpt_paths(metadata.wpt_descr)
+                if extracted_wpt_urls:
+                    try:
+                        valid_paths, invalid_paths = validate_wpt_paths(
+                            extracted_wpt_urls, config.wpt_path
                         )
-                    # Merge unique valid paths
-                    test_paths = sorted(set(test_paths) | set(valid_paths))
-                except ValueError as e:
-                    ui.warning(f"Skipping ChromeStatus tests: {e}")
+                        for invalid in invalid_paths:
+                            ui.warning(
+                                "Referenced WPT test file could not be "
+                                f"found or read: {invalid}"
+                            )
+                        # Merge unique valid paths
+                        test_paths = sorted(set(test_paths) | set(valid_paths))
+                    except ValueError as e:
+                        ui.warning(f"Skipping ChromeStatus tests: {e}")
+    elif config.library_mode:
+        ui.info("Skipping local WPT scan (Library Mode).")
+    else:
+        raise ValueError("WPT path must be configured for CLI usage.")
 
-    if not test_paths:
+    if not test_paths and config.wpt_path:
         ui.warning("No existing Web Platform Tests were successfully loaded.")
 
-    wpt_context = gather_local_test_context(test_paths, config.wpt_path)
+    wpt_context = (
+        gather_local_test_context(test_paths, config.wpt_path)
+        if config.wpt_path
+        else WPTContext()
+    )
 
     mdn_contents: list[str] | None = None
     if config.include_mdn_docs and not config.chromestatus:

--- a/wptgen/utils.py
+++ b/wptgen/utils.py
@@ -420,6 +420,15 @@ def determine_output_directory(
     context: WorkflowContext, config: Config, ui: UIProvider
 ) -> str:
     """Infers or prompts the user for the test output directory."""
+    if not config.wpt_path:
+        if config.library_mode:
+            ui.info("Skipping output directory inference (Library Mode).")
+            return ""
+        ui.warning("Cannot infer output directory without a WPT path.")
+        if config.output_dir:
+            return config.output_dir
+        raise ValueError("WPT path is required to generate tests.")
+
     wpt_path = Path(config.wpt_path).resolve()
 
     # 1. Infer from existing tests


### PR DESCRIPTION
### Background
This PR enables `wpt-gen` to run without a local checkout of the WPT repository, which is required for server-side integrations like ChromeStatus.

### Proposed Changes
- Made `wpt_path` optional in `Config` dataclass.
- Updated `context_assembly.py` to skip local WPT scanning when `wpt_path` is missing.
- Restructured `determine_output_directory` in `utils.py` to handle missing WPT path and skip work if only generating suggestions.
- Safeguarded directory inference call in `engine.py`.

Resolves #446

TESTED = tested wpt-gen generate locally. worked fine.
