### PR TITLE
[vendoring] Implement data models and parsers for Markdown report (#447)

### DIFF
--- a/tests/test_report_render.py
+++ b/tests/test_report_render.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for report_render.py."""
+
+from wptgen.phases.report_render import (
+    parse_audit_worksheet,
+    parse_test_suggestions,
+)
+
+
+def test_parse_audit_worksheet_basic() -> None:
+    """Test parsing a simple worksheet with mixed results."""
+    worksheet = """
+    [Category 1]
+    R1: Spec requirement 1 -> [COVERED by test1.html]
+    R2: Spec requirement 2 -> [UNCOVERED]
+
+    [Category 2]
+    R3: Spec requirement 3 -> [COVERED by test2.html, test3.html]
+    """
+
+    results = parse_audit_worksheet(worksheet)
+
+    assert len(results) == 3
+
+    # Check R1
+    assert results[0].id == "R1"
+    assert results[0].category == "Category 1"
+    assert results[0].text == "Spec requirement 1"
+    assert results[0].status == "COVERED"
+    assert results[0].tests == ["test1.html"]
+
+    # Check R2
+    assert results[1].id == "R2"
+    assert results[1].category == "Category 1"
+    assert results[1].text == "Spec requirement 2"
+    assert results[1].status == "UNCOVERED"
+    assert results[1].tests == []
+
+    # Check R3
+    assert results[2].id == "R3"
+    assert results[2].category == "Category 2"
+    assert results[2].text == "Spec requirement 3"
+    assert results[2].status == "COVERED"
+    assert results[2].tests == ["test2.html", "test3.html"]
+
+
+def test_parse_audit_worksheet_uncategorized() -> None:
+    """Test parsing when no category is specified."""
+    worksheet = "R1: Req text -> [UNCOVERED]"
+    results = parse_audit_worksheet(worksheet)
+
+    assert len(results) == 1
+    assert results[0].category == "Uncategorized"
+
+
+def test_parse_test_suggestions_full() -> None:
+    """Test parsing full mode suggestions."""
+    xml = """
+    <test_suggestions>
+      <test_suggestion>
+        <title>Test Title</title>
+        <description>Test Description</description>
+        <test_type>JavaScript test</test_type>
+        <pre_conditions><![CDATA[<div></div>]]></pre_conditions>
+        <steps>
+          <step>Step 1</step>
+          <step>Step 2</step>
+        </steps>
+        <expected_result>Success</expected_result>
+      </test_suggestion>
+    </test_suggestions>
+    """
+
+    results = parse_test_suggestions(xml)
+
+    assert len(results) == 1
+    assert results[0].title == "Test Title"
+    assert results[0].description == "Test Description"
+    assert results[0].test_type == "JavaScript test"
+    assert results[0].pre_conditions == "<div></div>"
+    assert results[0].steps == ["Step 1", "Step 2"]
+    assert results[0].expected_result == "Success"
+
+
+def test_parse_test_suggestions_brief() -> None:
+    """Test parsing brief mode suggestions."""
+    xml = """
+    <test_suggestions>
+      <test_suggestion>
+        <description>Test Description</description>
+      </test_suggestion>
+    </test_suggestions>
+    """
+
+    results = parse_test_suggestions(xml)
+
+    assert len(results) == 1
+    assert results[0].description == "Test Description"
+    assert results[0].title is None
+    assert results[0].steps == []
+    assert results[0].test_type is None
+
+
+def test_parse_test_suggestions_empty() -> None:
+    """Test parsing empty suggestions."""
+    xml = "<test_suggestions></test_suggestions>"
+    results = parse_test_suggestions(xml)
+    assert len(results) == 0
+
+
+def test_parse_test_suggestions_invalid() -> None:
+    """Test parsing invalid XML (missing description)."""
+    xml = """
+    <test_suggestions>
+      <test_suggestion>
+        <title>Only Title</title>
+      </test_suggestion>
+    </test_suggestions>
+    """
+    results = parse_test_suggestions(xml)
+    # Should skip suggestions without description
+    assert len(results) == 0

--- a/wptgen/phases/report_render.py
+++ b/wptgen/phases/report_render.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data models and parsers for generating WPT coverage reports."""
+
+import re
+from dataclasses import dataclass, field
+from bs4 import BeautifulSoup
+
+
+@dataclass
+class RequirementAudit:
+    """Represents the audit result for a single requirement."""
+
+    id: str
+    category: str
+    text: str
+    status: str  # "COVERED" or "UNCOVERED"
+    tests: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SuggestionData:
+    """Represents a suggested test blueprint."""
+
+    description: str
+    title: str | None = None
+    test_type: str | None = None
+    pre_conditions: str | None = None
+    steps: list[str] = field(default_factory=list)
+    expected_result: str | None = None
+
+
+def parse_audit_worksheet(worksheet_text: str) -> list[RequirementAudit]:
+    """Parses the semi-structured audit worksheet text.
+
+    Expected format:
+    [Category Name]
+    R1: Requirement text -> [COVERED by file.html]
+    R2: Requirement text -> [UNCOVERED]
+    """
+    results = []
+    current_category = "Uncategorized"
+
+    # Regex to match lines like "R1: text -> [COVERED by file.html]"
+    row_re = re.compile(
+        r"^(R\d+):\s*(.*?)\s*->\s*\[(COVERED|UNCOVERED)(?:\s*by\s*(.*))?\]$"
+    )
+
+    for line in worksheet_text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+
+        # Check if it's a category header
+        if line.startswith("[") and line.endswith("]") and "->" not in line:
+            current_category = line[1:-1].strip()
+            continue
+
+        match = row_re.match(line)
+        if match:
+            req_id = match.group(1)
+            req_text = match.group(2)
+            status = match.group(3)
+            tests_str = match.group(4)
+
+            tests = []
+            if tests_str:
+                # Handle comma-separated list of tests if present
+                tests = [t.strip() for t in tests_str.split(",")]
+
+            results.append(
+                RequirementAudit(
+                    id=req_id,
+                    category=current_category,
+                    text=req_text,
+                    status=status,
+                    tests=tests,
+                )
+            )
+
+    return results
+
+
+def parse_test_suggestions(suggestions_xml: str) -> list[SuggestionData]:
+    """Parses the structured XML test suggestions."""
+    results = []
+    soup = BeautifulSoup(suggestions_xml, "xml")
+
+    for suggestion in soup.find_all("test_suggestion"):
+        description = suggestion.find("description")
+        if not description:
+            continue
+
+        title = suggestion.find("title")
+        test_type = suggestion.find("test_type")
+        pre_conditions = suggestion.find("pre_conditions")
+        expected_result = suggestion.find("expected_result")
+
+        steps = []
+        steps_tag = suggestion.find("steps")
+        if steps_tag:
+            steps = [step.text.strip() for step in steps_tag.find_all("step")]
+
+        results.append(
+            SuggestionData(
+                description=description.text.strip(),
+                title=title.text.strip() if title else None,
+                test_type=test_type.text.strip() if test_type else None,
+                pre_conditions=(
+                    pre_conditions.text.strip() if pre_conditions else None
+                ),
+                steps=steps,
+                expected_result=(
+                    expected_result.text.strip() if expected_result else None
+                ),
+            )
+        )
+
+    return results


### PR DESCRIPTION
### Background
This PR implements Subtask 1 of issue #447, which is to create the data models and parser functions needed to transform WPT-Gen's XML output into a structured form for Markdown rendering.

### Proposed Changes
- Created `wptgen/markdown_report.py` containing `MdRequirementAudit` and `MdSuggestionData` dataclasses, and `parse_audit_worksheet_for_md` and `parse_suggestions_for_md` functions.
- Created `tests/test_markdown_report.py` containing unit tests for these parsers.

Partially fixes #447
