### PR TITLE
[vendoring] Implement report rendering and Jinja template (#447)

### DIFF
--- a/tests/test_report_render.py
+++ b/tests/test_report_render.py
@@ -15,6 +15,9 @@
 """Tests for report_render.py."""
 
 from wptgen.phases.report_render import (
+    MarkdownReportRenderer,
+    RequirementAudit,
+    SuggestionData,
     parse_audit_worksheet,
     parse_test_suggestions,
 )
@@ -133,3 +136,68 @@ def test_parse_test_suggestions_invalid() -> None:
     results = parse_test_suggestions(xml)
     # Should skip suggestions without description
     assert len(results) == 0
+
+
+def test_render_basic() -> None:
+    """Test rendering with mixed coverage results."""
+    renderer = MarkdownReportRenderer()
+
+    audit_rows = [
+        RequirementAudit(
+            id="R1",
+            category="Existence",
+            text="Interface must exist",
+            status="COVERED",
+            tests=["test1.html"],
+        ),
+        RequirementAudit(
+            id="R2",
+            category="Common Use Cases",
+            text="Basic behavior works",
+            status="UNCOVERED",
+        ),
+    ]
+
+    suggestions = [SuggestionData(description="Add test for basic behavior")]
+
+    report = renderer.render(audit_rows, suggestions)
+
+    # Verify headers are present
+    assert "#### 1. Feature Existence" in report
+    assert "#### 2. Common Use Cases" in report
+    assert "### Test Suggestions" in report
+
+    # Verify status mapping
+    assert "* **Status:** Covered" in report  # For Existence
+    assert "* **Status:** Not Covered" in report  # For Common Use Cases
+
+    # Verify evidence and gaps
+    assert "Verified in `test1.html`" in report
+    assert "Missing test coverage for: Basic behavior works" in report
+
+    # Verify suggestions are listed
+    assert "Add test for basic behavior" in report
+
+
+def test_render_empty_suggestions() -> None:
+    """Test rendering when all requirements are covered."""
+    renderer = MarkdownReportRenderer()
+
+    audit_rows = [
+        RequirementAudit(
+            id="R1",
+            category="Existence",
+            text="Interface must exist",
+            status="COVERED",
+            tests=["test1.html"],
+        )
+    ]
+
+    suggestions: list[SuggestionData] = []
+
+    report = renderer.render(audit_rows, suggestions)
+
+    assert (
+        "No test suggestions found. This feature has great test coverage!"
+        in report
+    )

--- a/wptgen/phases/report_render.py
+++ b/wptgen/phases/report_render.py
@@ -141,7 +141,7 @@ class MarkdownReportRenderer:
             loader=PackageLoader("wptgen", "templates"),
             autoescape=select_autoescape(),
         )
-        self.template = self.env.get_template("report_rendering.jinja")
+        self.template = self.env.get_template("report_render.jinja")
 
     def render(
         self,
@@ -186,7 +186,7 @@ class MarkdownReportRenderer:
             gaps = "None"
             if row.status == "COVERED":
                 evidence = (
-                    f"Verified in `{', '.join(row.tests)}`"
+                    f'Verified in `{", ".join(row.tests)}`'
                     if row.tests
                     else "Verified"
                 )

--- a/wptgen/phases/report_render.py
+++ b/wptgen/phases/report_render.py
@@ -16,7 +16,9 @@
 
 import re
 from dataclasses import dataclass, field
+from typing import Any
 from bs4 import BeautifulSoup
+from jinja2 import Environment, PackageLoader, select_autoescape
 
 
 @dataclass
@@ -129,3 +131,118 @@ def parse_test_suggestions(suggestions_xml: str) -> list[SuggestionData]:
         )
 
     return results
+
+
+class MarkdownReportRenderer:
+    """Renders parsed audit data into a specific Markdown format."""
+
+    def __init__(self) -> None:
+        self.env = Environment(
+            loader=PackageLoader("wptgen", "templates"),
+            autoescape=select_autoescape(),
+        )
+        self.template = self.env.get_template("report_rendering.jinja")
+
+    def render(
+        self,
+        audit_rows: list[RequirementAudit],
+        suggestions: list[SuggestionData],
+    ) -> str:
+        """Renders the report based on structured data."""
+        data = self._prepare_data(audit_rows, suggestions)
+        return self.template.render(**data)
+
+    def _prepare_data(
+        self,
+        audit_rows: list[RequirementAudit],
+        suggestions: list[SuggestionData],
+    ) -> dict[str, Any]:
+        """Groups and maps data into the structure expected by the template."""
+        categories: dict[str, dict[str, Any]] = {
+            "existence": {"status": "Not Covered", "records": []},
+            "common_use_cases": {"status": "Not Covered", "records": []},
+            "error_scenarios": {"status": "Not Covered", "records": []},
+            "invalidation": {"status": "Not Covered", "records": []},
+            "integration": {"status": "Not Covered", "records": []},
+        }
+
+        def map_category(cat: str) -> str:
+            cat_lower = cat.lower()
+            if "existence" in cat_lower:
+                return "existence"
+            if "common" in cat_lower or "use case" in cat_lower:
+                return "common_use_cases"
+            if "error" in cat_lower or "exception" in cat_lower:
+                return "error_scenarios"
+            if "invalidation" in cat_lower or "dynamic" in cat_lower:
+                return "invalidation"
+            if "integration" in cat_lower or "interact" in cat_lower:
+                return "integration"
+            return "common_use_cases"
+
+        for row in audit_rows:
+            key = map_category(row.category)
+            evidence = "None"
+            gaps = "None"
+            if row.status == "COVERED":
+                evidence = (
+                    f"Verified in `{', '.join(row.tests)}`"
+                    if row.tests
+                    else "Verified"
+                )
+            else:
+                gaps = f"Missing test coverage for: {row.text}"
+
+            categories[key]["records"].append(
+                {"requirement": row.text, "evidence": evidence, "gaps": gaps}
+            )
+
+        for _, cat_data in categories.items():
+            if not cat_data["records"]:
+                cat_data["status"] = "N/A"
+                continue
+
+            all_covered = all(
+                item["gaps"] == "None" for item in cat_data["records"]
+            )
+            all_uncovered = all(
+                item["evidence"] == "None" for item in cat_data["records"]
+            )
+
+            if all_covered:
+                cat_data["status"] = "Covered"
+            elif all_uncovered:
+                cat_data["status"] = "Not Covered"
+            else:
+                cat_data["status"] = "Partially Covered"
+
+        sug_data: dict[str, Any] = {
+            "status": "GAPS_FOUND" if suggestions else "SATISFIED",
+            "existence": [],
+            "common_use_cases": [],
+            "error_scenarios": [],
+            "invalidation": [],
+            "integration": [],
+        }
+
+        for sug in suggestions:
+            desc_lower = sug.description.lower()
+            if "existence" in desc_lower:
+                sug_data["existence"].append(sug.description)
+            elif "error" in desc_lower or "exception" in desc_lower:
+                sug_data["error_scenarios"].append(sug.description)
+            elif "invalidation" in desc_lower or "dynamic" in desc_lower:
+                sug_data["invalidation"].append(sug.description)
+            elif "integration" in desc_lower or "interact" in desc_lower:
+                sug_data["integration"].append(sug.description)
+            else:
+                sug_data["common_use_cases"].append(sug.description)
+
+        return {
+            "existence": categories["existence"],
+            "common_use_cases": categories["common_use_cases"],
+            "error_scenarios": categories["error_scenarios"],
+            "invalidation": categories["invalidation"],
+            "integration": categories["integration"],
+            "suggestions": sug_data,
+        }

--- a/wptgen/templates/report_render.jinja
+++ b/wptgen/templates/report_render.jinja
@@ -1,3 +1,11 @@
+**Conclusion:** {{ conclusion | default("Pending analysis...") }}
+
+**Summary of Analysis:** {{ summary | default("Pending analysis...") }}
+
+-----
+
+### Detailed Coverage Analysis
+
 #### 1. Feature Existence
 * **Status:** {{ existence.status }}
 {% for item in existence.records %}

--- a/wptgen/templates/report_rendering.jinja
+++ b/wptgen/templates/report_rendering.jinja
@@ -1,0 +1,75 @@
+#### 1. Feature Existence
+* **Status:** {{ existence.status }}
+{% for item in existence.records %}
+* **Spec Requirement:** {{ item.requirement }}
+* **Evidence:** {{ item.evidence }}
+* **Gaps:** {{ item.gaps }}
+{% endfor %}
+
+-----
+
+#### 2. Common Use Cases
+* **Status:** {{ common_use_cases.status }}
+{% for item in common_use_cases.records %}
+* **Spec Requirement:** {{ item.requirement }}
+* **Evidence:** {{ item.evidence }}
+* **Gaps:** {{ item.gaps }}
+{% endfor %}
+
+-----
+
+#### 3. Likely Error Scenarios
+* **Status:** {{ error_scenarios.status }}
+{% for item in error_scenarios.records %}
+* **Spec Requirement:** {{ item.requirement }}
+* **Evidence:** {{ item.evidence }}
+* **Gaps:** {{ item.gaps }}
+{% endfor %}
+
+-----
+
+#### 4. Invalidation & Dynamic Behavior
+* **Status:** {{ invalidation.status }}
+{% for item in invalidation.records %}
+* **Spec Requirement:** {{ item.requirement }}
+* **Evidence:** {{ item.evidence }}
+* **Gaps:** {{ item.gaps }}
+{% endfor %}
+
+-----
+
+#### 5. Integration with Other Features
+* **Status:** {{ integration.status }}
+{% for item in integration.records %}
+* **Spec Requirement:** {{ item.requirement }}
+* **Evidence:** {{ item.evidence }}
+* **Gaps:** {{ item.gaps }}
+{% endfor %}
+
+-----
+
+### Test Suggestions
+{% if suggestions.status == "SATISFIED" %}
+No test suggestions found. This feature has great test coverage!
+{% else %}
+* **Existence:** {{ suggestions.existence | length }} test suggestions.
+{% for sug in suggestions.existence %}
+    * {{ sug }}
+{% endfor %}
+* **Common Use Cases:** {{ suggestions.common_use_cases | length }} test suggestions.
+{% for sug in suggestions.common_use_cases %}
+    * {{ sug }}
+{% endfor %}
+* **Error Scenarios:** {{ suggestions.error_scenarios | length }} test suggestions.
+{% for sug in suggestions.error_scenarios %}
+    * {{ sug }}
+{% endfor %}
+* **Invalidation:** {{ suggestions.invalidation | length }} test suggestions.
+{% for sug in suggestions.invalidation %}
+    * {{ sug }}
+{% endfor %}
+* **Integration:** {{ suggestions.integration | length }} test suggestions.
+{% for sug in suggestions.integration %}
+    * {{ sug }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
### Background
This PR implements Subtask 2 of issue #447, which is to create the Jinja template and the `MarkdownReportRenderer` class to transform structured audit data into the specific Markdown layout requested by ChromeStatus.

### Proposed Changes
- Created `wptgen/templates/report_rendering.jinja` defining the Markdown layout.
- Implemented `MarkdownReportRenderer` class in `wptgen/phases/report_render.py`.
- Added unit tests in `tests/test_report_render.py` for the renderer.

This PR is stacked on top of #497 (Subtask 1).
Partially fixes #447
