### PR TITLE
[vendoring] Integrate report rendering and simplify summary

### DIFF
--- a/tests/test_report_render.py
+++ b/tests/test_report_render.py
@@ -164,6 +164,13 @@ def test_render_basic() -> None:
 
     # Verify headers are present
     assert "#### 1. Feature Existence" in report
+    assert (
+        "**Conclusion:** Some test suggestions are available. See below."
+        in report
+    )
+    assert (
+        "**Summary of Analysis:** The audit analyzed 2 requirements" in report
+    )
     assert "#### 2. Common Use Cases" in report
     assert "### Test Suggestions" in report
 

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -329,6 +329,36 @@ class WPTGenEngine:
             self._save_resume_state(context)
             self._save_phase_artifacts(context, WorkflowPhase.COVERAGE_AUDIT)
 
+        if self.config.library_mode:
+            from wptgen.phases.report_render import (
+                MarkdownReportRenderer,
+                parse_audit_worksheet,
+                parse_test_suggestions,
+            )
+            from wptgen.utils import extract_xml_tag
+
+            renderer = MarkdownReportRenderer()
+            audit_worksheet = extract_xml_tag(
+                context.audit_response or "", "audit_worksheet"
+            )
+            test_suggestions_block = extract_xml_tag(
+                context.audit_response or "", "test_suggestions"
+            )
+
+            if audit_worksheet and test_suggestions_block:
+                audit_rows = parse_audit_worksheet(audit_worksheet)
+                suggestions = parse_test_suggestions(test_suggestions_block)
+
+                markdown_report = renderer.render(audit_rows, suggestions)
+                context.markdown_report = markdown_report
+
+                self.ui.success("Generated Markdown report in context.")
+            else:
+                self.ui.warning(
+                    "Failed to extract audit worksheet or suggestions for "
+                    "report."
+                )
+
         # Skip Phase 4 if the user only wants the coverage audit report.
         if self.config.suggestions_only or self.config.brief_suggestions:
             await provide_coverage_report(context, self.config, self.ui)

--- a/wptgen/models.py
+++ b/wptgen/models.py
@@ -185,6 +185,7 @@ class WorkflowContext:
     mdn_contents: list[str] | None = None
     generated_tests: list[tuple[Path, str, str]] | None = None
     wpt_urls: list[str] | None = None
+    markdown_report: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Converts the context to a dictionary."""
@@ -207,6 +208,7 @@ class WorkflowContext:
                 else None
             ),
             "wpt_urls": self.wpt_urls,
+            "markdown_report": self.markdown_report,
         }
         return data
 
@@ -250,4 +252,5 @@ class WorkflowContext:
             mdn_contents=data.get("mdn_contents"),
             generated_tests=generated_tests,
             wpt_urls=data.get("wpt_urls"),
+            markdown_report=data.get("markdown_report"),
         )

--- a/wptgen/phases/report_render.py
+++ b/wptgen/phases/report_render.py
@@ -150,6 +150,27 @@ class MarkdownReportRenderer:
     ) -> str:
         """Renders the report based on structured data."""
         data = self._prepare_data(audit_rows, suggestions)
+
+        # Generate rule-based summary
+        total = len(audit_rows)
+        covered = sum(1 for row in audit_rows if row.status == "COVERED")
+        uncovered = total - covered
+
+        conclusion = (
+            "No test suggestions found. This feature has great test coverage!"
+            if uncovered == 0
+            else "Some test suggestions are available. See below."
+        )
+
+        summary = (
+            f"The audit analyzed {total} requirements extracted from the "
+            f"specification. {covered} requirements are covered by existing "
+            f"tests, and {uncovered} requirements lack test coverage."
+        )
+
+        data["conclusion"] = conclusion
+        data["summary"] = summary
+
         return self.template.render(**data)
 
     def _prepare_data(


### PR DESCRIPTION
### Background
This PR implements Subtask 3 of issue #447, which is to wire up the report rendering into the engine for library mode and generate a rule-based summary.

### Proposed Changes
- Updated `WPTGenEngine` to call `MarkdownReportRenderer` at the end of Phase 3 in `library_mode`.
- Simplified the summary generation to use pure Python logic instead of an LLM call, keeping it fast and reliable.
- Updated `WorkflowContext` to store the final Markdown report.
- Added unit tests in `tests/test_report_render.py` to verify the rule-based summary.

This PR is stacked on top of #498 (Subtask 2).
Partially fixes #447
