### PR TITLE
[vendoring] Move google-adk to optional dependencies in separate package

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -1,0 +1,67 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[build-system]
+requires = ["setuptools>=82.0.1", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wpt-gen-lib"
+version = "0.5.0"
+description = "A Core Library for AI-Powered Web Platform Test Analysis"
+readme = "../README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [
+    {name = "Google LLC"}
+]
+keywords = ["web-platform-tests", "wpt", "ai", "llm", "testing", "automation"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Testing",
+]
+dependencies = [
+    # Core LLM Integration (Excluding google-adk)
+    "google-genai>=1.62.0",
+    "openai>=2.20.0",
+    "anthropic>=0.84.0",
+    "tiktoken>=0.12.0",
+    "litellm>=1.83.8",
+
+    # Context & Scraping
+    "beautifulsoup4>=4.12.0",
+    "lxml>=6.0.4",
+    "markdownify>=0.14.0",
+
+    # Prompt Templating
+    "jinja2>=3.1.6",
+
+    # CLI Infrastructure
+    "typer>=0.23.0",
+    "rich>=15.0.0",
+    "pyyaml>=6.0.3",
+]
+
+[tool.setuptools]
+packages = ["wptgen"]
+
+[tool.setuptools.package-dir]
+"wptgen" = "../wptgen"

--- a/tests/agents/test_adk_test_generator.py
+++ b/tests/agents/test_adk_test_generator.py
@@ -21,6 +21,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+pytest.importorskip("google.adk")
+
 from wptgen.agents.adk_test_generator import generate_test_with_adk
 from wptgen.config import Config
 from wptgen.models import TestType as WPTTestType

--- a/tests/agents/test_streaming.py
+++ b/tests/agents/test_streaming.py
@@ -17,6 +17,9 @@
 from unittest.mock import MagicMock
 
 import pytest
+
+pytest.importorskip("google.adk")
+
 from google.adk.events import Event
 from google.genai import types
 from rich.panel import Panel

--- a/tests/test_phase_generation.py
+++ b/tests/test_phase_generation.py
@@ -28,6 +28,8 @@ from wptgen.phases.generation import (
     run_test_generation,
 )
 
+pytest.importorskip("google.adk")
+
 
 @pytest.mark.asyncio
 async def test_run_test_generation_satisfied(

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -339,6 +339,15 @@ class WPTGenEngine:
 
         # Phase 4: User Selection & Generation
         if should_run(WorkflowPhase.GENERATION, bool(context.generated_tests)):
+            import importlib.util
+
+            if not importlib.util.find_spec("google.adk"):
+                raise WorkflowError(
+                    "Test generation requires `google-adk`. "
+                    "Please install the full `wpt-gen` package instead of "
+                    "`wpt-gen-lib`."
+                )
+
             generated_tests = await run_test_generation(
                 context, self.config, self.llm, self.ui, self.jinja_env
             )


### PR DESCRIPTION
### Background
This PR implements the design discussed for issue #448, moving `google-adk` to a separate, optional package structure to keep the core library lightweight for server-side integration (like ChromeStatus).

### Proposed Changes
- Created `lib/pyproject.toml` for `wpt-gen-lib` with reduced dependencies.
- Added a guard in `wptgen/engine.py` using `importlib.util.find_spec` to check for `google.adk` before running Phase 4, failing gracefully if missing.
- Updated tests to skip gracefully if `google.adk` is missing.

Partially fixes #448
