### PR TITLE
[vendoring] Add CI script to verify sync of pyproject.toml files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ lint: license-check
 	$(RUFF) check .
 	$(BLACK) --check .
 	$(PYLINT) $(PACKAGE_NAME) tests
+	$(PYTHON) scripts/check_pyproject.py
 
 lint-fix: license-fix
 	$(BLACK) .

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -21,7 +21,7 @@ name = "wpt-gen-lib"
 version = "0.5.0"
 description = "A Core Library for AI-Powered Web Platform Test Analysis"
 readme = "../README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "Apache-2.0"
 authors = [
     {name = "Google LLC"}
@@ -33,7 +33,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Testing",

--- a/scripts/check_pyproject.py
+++ b/scripts/check_pyproject.py
@@ -44,7 +44,7 @@ def main():
     ]
     lib_deps = lib_data.get("project", {}).get("dependencies", [])
 
-    if root_deps != lib_deps:
+    if set(root_deps) != set(lib_deps):
         print("Error: Dependencies in pyproject.toml files are out of sync!")
         print(f"Root dependencies (filtered): {root_deps}")
         print(f"Lib dependencies: {lib_deps}")

--- a/scripts/check_pyproject.py
+++ b/scripts/check_pyproject.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Script to verify that root and lib pyproject.toml files are in sync."""
+
+import sys
+from pathlib import Path
+import tomllib
+
+
+def main():
+    root_dir = Path(__file__).parent.parent
+    root_toml_path = root_dir / "pyproject.toml"
+    lib_toml_path = root_dir / "lib" / "pyproject.toml"
+
+    if not root_toml_path.exists():
+        print(f"Error: Root pyproject.toml not found at {root_toml_path}")
+        sys.exit(1)
+    if not lib_toml_path.exists():
+        print(f"Error: Lib pyproject.toml not found at {lib_toml_path}")
+        sys.exit(1)
+
+    with open(root_toml_path, "rb") as f:
+        root_data = tomllib.load(f)
+    with open(lib_toml_path, "rb") as f:
+        lib_data = tomllib.load(f)
+
+    # Compare dependencies (excluding google-adk from root)
+    root_deps = [
+        d
+        for d in root_data.get("project", {}).get("dependencies", [])
+        if not d.startswith("google-adk")
+    ]
+    lib_deps = lib_data.get("project", {}).get("dependencies", [])
+
+    if root_deps != lib_deps:
+        print("Error: Dependencies in pyproject.toml files are out of sync!")
+        print(f"Root dependencies (filtered): {root_deps}")
+        print(f"Lib dependencies: {lib_deps}")
+        sys.exit(1)
+
+    # Compare project metadata except expected differences
+    # Readme path is different in lib (../README.md vs README.md)
+    root_proj = dict(root_data.get("project", {}))
+    root_proj.pop("name", None)
+    root_proj.pop("dependencies", None)
+    root_proj.pop("readme", None)
+    root_proj.pop("description", None)
+    root_proj.pop("optional-dependencies", None)
+    root_proj.pop("scripts", None)
+    root_proj.pop("urls", None)
+
+    lib_proj = dict(lib_data.get("project", {}))
+    lib_proj.pop("name", None)
+    lib_proj.pop("dependencies", None)
+    lib_proj.pop("readme", None)
+    lib_proj.pop("description", None)
+    lib_proj.pop("optional-dependencies", None)
+    lib_proj.pop("scripts", None)
+    lib_proj.pop("urls", None)
+
+    if root_proj != lib_proj:
+        print("Error: Project metadata in pyproject.toml files is out of sync!")
+        import difflib
+        import pprint
+
+        root_str = pprint.pformat(root_proj).splitlines()
+        lib_str = pprint.pformat(lib_proj).splitlines()
+
+        for line in difflib.unified_diff(
+            root_str, lib_str, fromfile="root_project", tofile="lib_project"
+        ):
+            print(line)
+
+        sys.exit(1)
+
+    print(
+        "Success: pyproject.toml files are in sync (apart from expected differences)."
+    )
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Background
This PR adds a CI script to ensure that the root `pyproject.toml` and the new `lib/pyproject.toml` stay in sync, as part of issue #448.

### Proposed Changes
- Created `scripts/check_pyproject.py` that compares the two TOML files, ignoring expected differences.
- Updated `Makefile` to run this script as part of the `lint` target.

This PR is stacked on top of #500.
Partially fixes #448
