### PR TITLE
Chore: Upgrade project to Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.13']
+        python-version: ['3.11', '3.13']
 
     steps:
     - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WPT-Gen: AI-Powered Web Platform Test Generation
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 
 **WPT-Gen** is an agentic CLI tool designed to increase browser interoperability by automating the creation of [Web Platform Tests (WPT)](https://web-platform-tests.org/).
 
@@ -73,7 +73,7 @@ For an in-depth explanation of the internal logic, inputs, outputs, and LLM inte
 
 ## Prerequisites
 
-*   **Python 3.10+**
+*   **Python 3.11+**
 *   **Local WPT Repository:** A local checkout of [web-platform-tests/wpt](https://github.com/web-platform-tests/wpt).
 *   **API Key:** An API key for a supported LLM (Gemini, OpenAI, or Anthropic).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ name = "wpt-gen"
 version = "0.5.0"
 description = "A CLI Tool for AI-Powered Web Platform Test Generation"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "Apache-2.0"
 authors = [
     {name = "Google LLC"}
@@ -33,7 +33,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Testing",
@@ -96,11 +95,11 @@ wptgen = [
 ]
 
 [tool.black]
-target-version = ['py310']
+target-version = ['py311']
 line-length = 80
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 line-length = 80
 indent-width = 4
 
@@ -126,7 +125,7 @@ ignore = [
 known-first-party = ["wptgen"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 strict = true
 mypy_path = "scripts"
 

--- a/wptgen/models.py
+++ b/wptgen/models.py
@@ -15,7 +15,7 @@
 """Data models and enums for the WPT generation workflow."""
 
 from dataclasses import asdict, dataclass, field
-from enum import Enum
+from enum import Enum, StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -24,7 +24,7 @@ class WorkflowError(Exception):
     """Raised when a phase of the workflow fails to complete."""
 
 
-class WorkflowPhase(str, Enum):
+class WorkflowPhase(StrEnum):
     """Enumeration of the phases in the WPT generation workflow."""
 
     CONTEXT_ASSEMBLY = "context_assembly"
@@ -70,14 +70,14 @@ REQUIREMENT_CATEGORIES = [
 ]
 
 
-class DataSource(str, Enum):
+class DataSource(StrEnum):
     """Source of web feature metadata."""
 
     WEB_FEATURES = "web-features"
     CHROMESTATUS = "chromestatus"
 
 
-class BrowserType(str, Enum):
+class BrowserType(StrEnum):
     """Supported browser engines."""
 
     CHROME = "chrome"
@@ -86,7 +86,7 @@ class BrowserType(str, Enum):
     EDGE = "edge"
 
 
-class BrowserChannel(str, Enum):
+class BrowserChannel(StrEnum):
     """Browser release channels."""
 
     CANARY = "canary"
@@ -95,7 +95,7 @@ class BrowserChannel(str, Enum):
     DEV = "dev"
 
 
-class LLMProvider(str, Enum):
+class LLMProvider(StrEnum):
     """Supported LLM providers."""
 
     GEMINI = "gemini"
@@ -104,7 +104,7 @@ class LLMProvider(str, Enum):
     OPENAI = "openai"
 
 
-class ModelCategory(str, Enum):
+class ModelCategory(StrEnum):
     """Categories of LLM models used in the workflow."""
 
     DEFAULT = "default"


### PR DESCRIPTION
### Background
This PR upgrades the project's minimum required Python version to 3.11, as discussed during the review of issue #448. This allows us to use modern features like `tomllib` and `StrEnum` without fallbacks or extra dependencies.

### Proposed Changes
- Updated `requires-python` to `>=3.11` in `pyproject.toml`.
- Updated tool configurations (Black, Ruff, Mypy) in `pyproject.toml` to target Python 3.11.
- Refactored enums in `wptgen/models.py` to use `StrEnum` instead of the old `(str, Enum)` workaround.
- Updated `README.md` badges and prerequisites to state `Python 3.11+`.

This PR is standalone and does not depend on other unmerged branches.
Resolves the compatibility concern raised by Daniel on PR #501.
