### PR TITLE
[vendoring] Expose generate_audit_report programmatic API (#450)

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,18 +14,16 @@
 
 """Tests for the exposed programmatic API."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from typing import Any
 from wptgen import generate_audit_report
 from wptgen.models import WorkflowContext
 from wptgen.config import Config
 
 
-@patch("wptgen.config.load_config")
-@patch("wptgen.WPTGenEngine")
-def test_generate_audit_report_success(
-    mock_engine_class: MagicMock, mock_load_config: MagicMock
-) -> None:
+def test_generate_audit_report_success(mocker: Any) -> None:
+    mock_load_config = mocker.patch("wptgen.config.load_config")
+    mock_engine_class = mocker.patch("wptgen.WPTGenEngine")
     """Test that generate_audit_report correctly initializes the engine."""
     mock_context = MagicMock(spec=WorkflowContext)
     mock_context.markdown_report = "# Fake Report"
@@ -51,11 +49,9 @@ def test_generate_audit_report_success(
     assert report == "# Fake Report"
 
 
-@patch("wptgen.config.load_config")
-@patch("wptgen.WPTGenEngine")
-def test_generate_audit_report_opt_out_explainer(
-    mock_engine_class: MagicMock, mock_load_config: MagicMock
-) -> None:
+def test_generate_audit_report_opt_out_explainer(mocker: Any) -> None:
+    mock_load_config = mocker.patch("wptgen.config.load_config")
+    mock_engine_class = mocker.patch("wptgen.WPTGenEngine")
     """Test that generate_audit_report respects empty explainer list (opt-out)."""
     mock_context = MagicMock(spec=WorkflowContext)
     mock_context.markdown_report = "# Fake Report"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,6 +15,7 @@
 """Tests for the exposed programmatic API."""
 
 from unittest.mock import MagicMock, patch
+from typing import Any
 from wptgen import generate_audit_report
 from wptgen.models import WorkflowContext
 from wptgen.config import Config
@@ -22,7 +23,9 @@ from wptgen.config import Config
 
 @patch("wptgen.config.load_config")
 @patch("wptgen.WPTGenEngine")
-def test_generate_audit_report_success(mock_engine_class, mock_load_config):
+def test_generate_audit_report_success(
+    mock_engine_class: MagicMock, mock_load_config: MagicMock
+) -> None:
     """Test that generate_audit_report correctly initializes the engine."""
     mock_context = MagicMock(spec=WorkflowContext)
     mock_context.markdown_report = "# Fake Report"
@@ -51,8 +54,8 @@ def test_generate_audit_report_success(mock_engine_class, mock_load_config):
 @patch("wptgen.config.load_config")
 @patch("wptgen.WPTGenEngine")
 def test_generate_audit_report_opt_out_explainer(
-    mock_engine_class, mock_load_config
-):
+    mock_engine_class: MagicMock, mock_load_config: MagicMock
+) -> None:
     """Test that generate_audit_report respects empty explainer list (opt-out)."""
     mock_context = MagicMock(spec=WorkflowContext)
     mock_context.markdown_report = "# Fake Report"
@@ -64,11 +67,11 @@ def test_generate_audit_report_opt_out_explainer(
     # To make it clear that it overrides something, we simulate that load_config
     # initially loads a list with an old explainer, but then applies the override.
     def mock_load_config_impl(
-        provider_override=None,
-        yes_tokens_override=False,
-        explainer_urls_override=None,
-        **kwargs,
-    ):
+        provider_override: str | None = None,
+        yes_tokens_override: bool = False,
+        explainer_urls_override: list[str] | None = None,
+        **kwargs: Any,
+    ) -> MagicMock:
         cfg = MagicMock(spec=Config)
         # Simulate pre-existing explainers loaded from defaults
         cfg.explainer_urls = ["https://example.com/old-explainer"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,88 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the exposed programmatic API."""
+
+from unittest.mock import MagicMock, patch
+from wptgen import generate_audit_report
+from wptgen.models import WorkflowContext
+from wptgen.config import Config
+
+
+@patch("wptgen.config.load_config")
+@patch("wptgen.WPTGenEngine")
+def test_generate_audit_report_success(mock_engine_class, mock_load_config):
+    """Test that generate_audit_report correctly initializes the engine."""
+    mock_context = MagicMock(spec=WorkflowContext)
+    mock_context.markdown_report = "# Fake Report"
+
+    mock_engine = MagicMock()
+    mock_engine.run_workflow.return_value = mock_context
+    mock_engine_class.return_value = mock_engine
+
+    mock_config = MagicMock(spec=Config)
+    mock_load_config.return_value = mock_config
+
+    report = generate_audit_report(feature_id="12345", provider="gemini")
+
+    # Assertions
+    mock_load_config.assert_called_once()
+    kwargs = mock_load_config.call_args.kwargs
+    assert kwargs["provider_override"] == "gemini"
+    assert kwargs["yes_tokens_override"] is True
+
+    assert mock_config.library_mode is True
+
+    mock_engine.run_workflow.assert_called_once_with("12345")
+    assert report == "# Fake Report"
+
+
+@patch("wptgen.config.load_config")
+@patch("wptgen.WPTGenEngine")
+def test_generate_audit_report_opt_out_explainer(mock_engine_class, mock_load_config):
+    """Test that generate_audit_report respects empty explainer list (opt-out)."""
+    mock_context = MagicMock(spec=WorkflowContext)
+    mock_context.markdown_report = "# Fake Report"
+
+    mock_engine = MagicMock()
+    mock_engine.run_workflow.return_value = mock_context
+    mock_engine_class.return_value = mock_engine
+
+    # To make it clear that it overrides something, we simulate that load_config
+    # initially loads a list with an old explainer, but then applies the override.
+    def mock_load_config_impl(provider_override=None, yes_tokens_override=False, explainer_urls_override=None, **kwargs):
+        cfg = MagicMock(spec=Config)
+        # Simulate pre-existing explainers loaded from defaults
+        cfg.explainer_urls = ["https://example.com/old-explainer"]
+        # Apply override if it was provided
+        if explainer_urls_override is not None:
+            cfg.explainer_urls = explainer_urls_override
+        return cfg
+
+    mock_load_config.side_effect = mock_load_config_impl
+
+    report = generate_audit_report(
+        feature_id="12345",
+        explainer_urls=[],
+    )
+
+    # Assertions
+    mock_load_config.assert_called_once()
+    
+    # Verify that the final config passed to the engine has empty explainers!
+    args, kwargs = mock_engine_class.call_args
+    config = kwargs["config"]
+    assert config.explainer_urls == []
+
+    assert report == "# Fake Report"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,7 +50,9 @@ def test_generate_audit_report_success(mock_engine_class, mock_load_config):
 
 @patch("wptgen.config.load_config")
 @patch("wptgen.WPTGenEngine")
-def test_generate_audit_report_opt_out_explainer(mock_engine_class, mock_load_config):
+def test_generate_audit_report_opt_out_explainer(
+    mock_engine_class, mock_load_config
+):
     """Test that generate_audit_report respects empty explainer list (opt-out)."""
     mock_context = MagicMock(spec=WorkflowContext)
     mock_context.markdown_report = "# Fake Report"
@@ -61,7 +63,12 @@ def test_generate_audit_report_opt_out_explainer(mock_engine_class, mock_load_co
 
     # To make it clear that it overrides something, we simulate that load_config
     # initially loads a list with an old explainer, but then applies the override.
-    def mock_load_config_impl(provider_override=None, yes_tokens_override=False, explainer_urls_override=None, **kwargs):
+    def mock_load_config_impl(
+        provider_override=None,
+        yes_tokens_override=False,
+        explainer_urls_override=None,
+        **kwargs,
+    ):
         cfg = MagicMock(spec=Config)
         # Simulate pre-existing explainers loaded from defaults
         cfg.explainer_urls = ["https://example.com/old-explainer"]
@@ -79,7 +86,7 @@ def test_generate_audit_report_opt_out_explainer(mock_engine_class, mock_load_co
 
     # Assertions
     mock_load_config.assert_called_once()
-    
+
     # Verify that the final config passed to the engine has empty explainers!
     args, kwargs = mock_engine_class.call_args
     config = kwargs["config"]

--- a/wptgen/__init__.py
+++ b/wptgen/__init__.py
@@ -16,4 +16,56 @@
 
 from __future__ import annotations
 
+from wptgen.config import Config
+from wptgen.engine import WPTGenEngine
+from wptgen.ui import LoggingUIProvider
+
 __version__ = "0.5.0"
+
+
+def generate_audit_report(
+    feature_id: str,
+    provider: str | None = None,
+    model: str | None = None,
+    api_key: str | None = None,
+    explainer_urls: list[str] | None = None,
+) -> str:
+    """Generates a structured Markdown WPT coverage report for a given feature.
+
+    This function serves as the primary entry point for non-interactive
+    library use (e.g., on a server like ChromeStatus). It automatically
+    configures the engine for library mode, suppressing interactive prompts
+    and terminal-specific UI elements.
+
+    Args:
+        feature_id: The numeric ChromeStatus feature ID or a Web Feature ID string.
+        provider: The LLM provider to use (e.g., "gemini", "openai", "anthropic").
+        model: The specific model to use for reasoning phases.
+        api_key: Optional API key override for the provider.
+
+    Returns:
+        A string containing the full, rendered Markdown report.
+    """
+    from wptgen.config import load_config
+
+    # 1. Build configuration for library mode
+    config = load_config(
+        provider_override=provider,
+        yes_tokens_override=True,
+        explainer_urls_override=explainer_urls,
+    )
+    config.library_mode = True
+    if model:
+        config.default_model = model
+    if api_key:
+        config.api_key = api_key
+
+    # 2. Instantiate non-interactive UI
+    ui = LoggingUIProvider()
+
+    # 3. Execute workflow
+    engine = WPTGenEngine(config=config, ui=ui)
+    context = engine.run_workflow(feature_id)
+
+    # 4. Return the generated report
+    return context.markdown_report

--- a/wptgen/__init__.py
+++ b/wptgen/__init__.py
@@ -69,9 +69,9 @@ def generate_audit_report(
     context = engine.run_workflow(feature_id)
 
     # 4. Return the generated report
-    if context.markdown_report is None:  # type: ignore[attr-defined]
+    if context.markdown_report is None:
         from wptgen.models import WorkflowError
 
         raise WorkflowError("Markdown report was not generated.")
 
-    return context.markdown_report  # type: ignore[attr-defined, no-any-return]
+    return context.markdown_report

--- a/wptgen/__init__.py
+++ b/wptgen/__init__.py
@@ -43,6 +43,8 @@ def generate_audit_report(
             "anthropic").
         model: The specific model to use for reasoning phases.
         api_key: Optional API key override for the provider.
+        explainer_urls: Optional list of explainer URLs to use instead of
+            scraping them from the feature ID.
 
     Returns:
         A string containing the full, rendered Markdown report.

--- a/wptgen/__init__.py
+++ b/wptgen/__init__.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-from wptgen.config import Config
 from wptgen.engine import WPTGenEngine
 from wptgen.ui import LoggingUIProvider
 
@@ -38,8 +37,10 @@ def generate_audit_report(
     and terminal-specific UI elements.
 
     Args:
-        feature_id: The numeric ChromeStatus feature ID or a Web Feature ID string.
-        provider: The LLM provider to use (e.g., "gemini", "openai", "anthropic").
+        feature_id: The numeric ChromeStatus feature ID or a Web Feature ID
+            string.
+        provider: The LLM provider to use (e.g., "gemini", "openai",
+            "anthropic").
         model: The specific model to use for reasoning phases.
         api_key: Optional API key override for the provider.
 
@@ -68,4 +69,9 @@ def generate_audit_report(
     context = engine.run_workflow(feature_id)
 
     # 4. Return the generated report
-    return context.markdown_report
+    if context.markdown_report is None:  # type: ignore[attr-defined]
+        from wptgen.models import WorkflowError
+
+        raise WorkflowError("Markdown report was not generated.")
+
+    return context.markdown_report  # type: ignore[attr-defined, no-any-return]

--- a/wptgen/config.py
+++ b/wptgen/config.py
@@ -89,6 +89,7 @@ class Config:
     run_on_browser: BrowserType = BrowserType.CHROME
     run_on_channel: BrowserChannel = BrowserChannel.CANARY
     spec_urls: list[str] | None = None
+    explainer_urls: list[str] | None = None
     feature_description: str | None = None
     detailed_requirements: bool = False
     include_mdn_docs: bool = False
@@ -239,6 +240,7 @@ def load_config(
     max_retries_override: int | None = None,
     timeout_override: int | None = None,
     spec_urls_override: list[str] | None = None,
+    explainer_urls_override: list[str] | None = None,
     feature_description_override: str | None = None,
     detailed_requirements_override: bool = False,
     include_mdn_docs_override: bool = False,
@@ -452,6 +454,7 @@ def load_config(
             else BrowserChannel(yaml_data.get("run_on_channel", "canary"))
         ),
         spec_urls=spec_urls_override,
+        explainer_urls=explainer_urls_override,
         feature_description=feature_description_override,
         detailed_requirements=detailed_requirements,
         include_mdn_docs=include_mdn_docs,


### PR DESCRIPTION
### Background
This PR implements the programmatic API for library mode in WPT-Gen, as discussed for issue #450. It exposes a clean entry point for external tools like ChromeStatus to generate audit reports.

### Proposed Changes
- Created `generate_audit_report` function in `wptgen/__init__.py`.
- Added `explainer_urls` to `Config` and `load_config` to support overrides and opt-outs.
- Added unit tests in `tests/test_api.py` verifying standard behavior and the specific "opt-out" (empty list) override using a robust mock with side effects.

**Note:** Due to GitHub issues with creating stacked PRs on new branches, this PR is created with base `main`. The diff here will include changes from PR #500 and PR #499 as well. For a clean review of only this PR's changes, please look at the last commit `e3b3d84`.

Partially fixes #450
