### PR TITLE
chore: update litellm to >=1.84.0 to resolve click conflict in chromestatus vendoring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "openai>=2.20.0",
     "anthropic>=0.84.0",
     "tiktoken>=0.12.0",
-    "litellm>=1.83.8",
+    "litellm>=1.84.0",
 
     # Context & Scraping
     "beautifulsoup4>=4.12.0",


### PR DESCRIPTION
## Overview
Resolves #506. Follow-up to #507.

This PR upgrades the `litellm` dependency constraint to `>=1.84.0` in the root `pyproject.toml` file.

## Context
* In version `1.84.0`, the `litellm` maintainers adopted SemVer 2.0 and relaxed their strict `click==8.1.8` pin in PyPI metadata to the standard range `click>=8.0.0,<9.0`.
* This allows downstream projects (like ChromeStatus / `chromium-dashboard` which pins `click==8.3.3`) to install `wpt-gen` directly from root Git reference (`@main`) without any version conflict.

All tests, static typing, and formatting checks passed successfully (`make check` completed).
