### PR TITLE
fix: configure suggestions_only and disable directory inference in library mode

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,8 +44,12 @@ def test_generate_audit_report_success(mocker: Any) -> None:
     assert kwargs["yes_tokens_override"] is True
 
     assert mock_config.library_mode is True
+    assert mock_config.suggestions_only is True
+    assert mock_config.wpt_path is None
 
-    mock_engine.run_workflow.assert_called_once_with("12345")
+    mock_engine.run_workflow.assert_called_once_with(
+        "12345", disable_directory_inference=True
+    )
     assert report == "# Fake Report"
 
 
@@ -90,5 +94,10 @@ def test_generate_audit_report_opt_out_explainer(mocker: Any) -> None:
     args, kwargs = mock_engine_class.call_args
     config = kwargs["config"]
     assert config.explainer_urls == []
+    assert config.suggestions_only is True
+    assert config.wpt_path is None
 
+    mock_engine.run_workflow.assert_called_once_with(
+        "12345", disable_directory_inference=True
+    )
     assert report == "# Fake Report"

--- a/wptgen/__init__.py
+++ b/wptgen/__init__.py
@@ -58,6 +58,8 @@ def generate_audit_report(
         explainer_urls_override=explainer_urls,
     )
     config.library_mode = True
+    config.wpt_path = None
+    config.suggestions_only = True
     if model:
         config.default_model = model
     if api_key:
@@ -68,7 +70,7 @@ def generate_audit_report(
 
     # 3. Execute workflow
     engine = WPTGenEngine(config=config, ui=ui)
-    context = engine.run_workflow(feature_id)
+    context = engine.run_workflow(feature_id, disable_directory_inference=True)
 
     # 4. Return the generated report
     if context.markdown_report is None:


### PR DESCRIPTION
This PR resolves blocking issues found when integrating and testing `wpt-gen` with ChromeStatus:
- Explicitly clears `wpt_path` to `None` so that Phase 1 correctly skips the local WPT repository scan.
- Sets `config.suggestions_only = True` in `generate_audit_report` so that the engine skips Phase 4 (ADK test generation).
- Passes `disable_directory_inference=True` to `run_workflow` to bypass output directory inference.
- Updates unit tests in `tests/test_api.py` to cover these configuration expectations.