### PR TITLE
[vendoring] implement remote WPT test fetching in library mode

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -31,6 +31,7 @@ from wptgen.context import (
     fetch_and_extract_text,
     fetch_feature_yaml,
     fetch_mdn_urls,
+    fetch_remote_wpt_context,
     find_feature_tests,
     gather_local_test_context,
     is_wpt_test_file,
@@ -817,3 +818,65 @@ def test_fetch_feature_yaml_draft(mocker: MockerFixture) -> None:
         == "https://raw.githubusercontent.com/web-platform-dx/"
         "web-features/main/features/draft/spec/draft-feature.yml"
     )
+
+
+@pytest.mark.asyncio
+async def test_fetch_remote_wpt_context(mocker: MockerFixture) -> None:
+    """Test successfully fetching remote WPT test files over HTTP."""
+    mock_urlopen = mocker.patch("wptgen.context._ssrf_safe_opener.open")
+
+    mock_response_html = mocker.MagicMock()
+    mock_response_html.read.return_value = b"<!DOCTYPE html><html>test</html>"
+    mock_response_html.__enter__.return_value = mock_response_html
+
+    mock_response_js = mocker.MagicMock()
+    mock_response_js.read.return_value = b"// test script"
+    mock_response_js.__enter__.return_value = mock_response_js
+
+    def mock_open_impl(req: Any, **kwargs: Any) -> Any:
+        if "test1.html" in req.full_url:
+            return mock_response_html
+        if "test2.html" in req.full_url:
+            raise urllib.error.HTTPError(
+                url="", code=404, msg="Not Found", hdrs=Message(), fp=None
+            )
+        if "test2.js" in req.full_url:
+            return mock_response_js
+        raise Exception(f"Unexpected URL: {req.full_url}")
+
+    mock_urlopen.side_effect = mock_open_impl
+    mocker.patch("time.sleep")
+
+    urls = [
+        "css/css-text/text-transform/test1.html",
+        "css/css-text/text-transform/test2.html",
+    ]
+
+    context = await fetch_remote_wpt_context(urls)
+
+    assert len(context.test_contents) == 2
+    assert "/css/css-text/text-transform/test1.html" in context.test_contents
+    assert "/css/css-text/text-transform/test2.js" in context.test_contents
+    assert (
+        context.test_contents["/css/css-text/text-transform/test1.html"]
+        == "<!DOCTYPE html><html>test</html>"
+    )
+    assert (
+        context.test_contents["/css/css-text/text-transform/test2.js"]
+        == "// test script"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_remote_wpt_context_empty() -> None:
+    """Test that empty list returns empty context."""
+    context = await fetch_remote_wpt_context([])
+    assert not context.test_contents
+
+
+@pytest.mark.asyncio
+async def test_fetch_remote_wpt_context_limit() -> None:
+    """Test that exceeding MAX limit raises ValueError."""
+    urls = [f"test{i}.html" for i in range(51)]
+    with pytest.raises(ValueError, match="Too many tests found"):
+        await fetch_remote_wpt_context(urls)

--- a/tests/test_phase_context_assembly.py
+++ b/tests/test_phase_context_assembly.py
@@ -471,3 +471,51 @@ async def test_run_context_assembly_spec_fetch_exception(
         "Failed to fetch spec (http://spec-error): 404 Not Found"
     )
     mock_ui.error.assert_any_call("Failed to extract spec content.")
+
+
+@pytest.mark.asyncio
+async def test_run_context_assembly_library_mode_remote_fetching(
+    mock_config: Config, mock_ui: MagicMock, mocker: MockerFixture
+) -> None:
+    """Test that library mode correctly populates wpt_context via remote fetching."""
+    mock_config.library_mode = True
+    mock_config.wpt_path = None
+    mock_config.chromestatus = True
+
+    metadata = FeatureMetadata("Feat", "Desc", ["http://spec"])
+    metadata.wpt_descr = """
+    Here are the WPT results for this feature:
+    - https://wpt.fyi/results/css/css-grid/grid-model?label=master
+    - https://wpt.fyi/results/css/css-flexbox/flex-minimum-height-flex-items-005.xht?run_id=12345
+    Check these out.
+    """
+    mocker.patch(
+        "wptgen.phases.context_assembly.fetch_chromestatus_metadata",
+        return_value=metadata,
+    )
+    mocker.patch(
+        "wptgen.phases.context_assembly.fetch_and_extract_text",
+        return_value="Spec Content",
+    )
+
+    mock_remote_context = WPTContext(
+        test_contents={
+            "/css/css-grid/grid-model": "grid content",
+            "/css/css-flexbox/flex-minimum-height-flex-items-005.xht": "flex content",
+        }
+    )
+    mock_fetch_remote = mocker.patch(
+        "wptgen.phases.context_assembly.fetch_remote_wpt_context",
+        return_value=mock_remote_context,
+    )
+
+    context = await run_context_assembly("517399", mock_config, mock_ui)
+
+    assert context is not None
+    assert context.wpt_context == mock_remote_context
+    mock_fetch_remote.assert_called_once_with(
+        [
+            "css/css-flexbox/flex-minimum-height-flex-items-005.xht",
+            "css/css-grid/grid-model",
+        ]
+    )

--- a/wptgen/__init__.py
+++ b/wptgen/__init__.py
@@ -60,6 +60,7 @@ def generate_audit_report(
     config.library_mode = True
     config.wpt_path = None
     config.suggestions_only = True
+    config.chromestatus = True
     if model:
         config.default_model = model
     if api_key:

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -746,7 +746,7 @@ async def fetch_remote_wpt_context(wpt_urls: list[str]) -> WPTContext:
         content = None
         try:
             content = _try_url(url)
-        except Exception as e:
+        except (urllib.error.HTTPError, urllib.error.URLError) as e:
             logger.warning(f"Failed to fetch remote WPT file ({url}): {e}")
 
         if content is None and clean_path.endswith(".html"):
@@ -756,7 +756,7 @@ async def fetch_remote_wpt_context(wpt_urls: list[str]) -> WPTContext:
                 content = _try_url(js_url)
                 if content is not None:
                     clean_path = js_path
-            except Exception as e:
+            except (urllib.error.HTTPError, urllib.error.URLError) as e:
                 logger.warning(
                     f"Failed to fetch remote WPT file ({js_url}): {e}"
                 )

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -22,6 +22,7 @@ import re
 import socket
 import urllib.error
 import urllib.request
+import asyncio
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -467,8 +468,8 @@ def extract_wpt_paths(wpt_descr: str) -> list[str]:
     if not wpt_descr:
         return []
 
-    # Regex to match any URL-like structure starting with http/https
-    url_pattern = r"https?://[^\s\n,]+"
+    # Regex matching ChromeStatus framework extraction exactly
+    url_pattern = r"(https?://wpt\.fyi/results[^\s?]+)"
     urls = re.findall(url_pattern, wpt_descr)
 
     extracted_paths: set[str] = set()
@@ -704,6 +705,74 @@ def resolve_dependency_path(
     except (ValueError, OSError):
         pass
     return None
+
+
+async def fetch_remote_wpt_context(wpt_urls: list[str]) -> WPTContext:
+    """Fetches WPT test file contents remotely from GitHub over HTTP.
+
+    Intended for library mode when a local WPT checkout is not available.
+    Enforces MAXIMUM_TEST_SUITE_SIZE.
+    """
+    test_contents: dict[str, str] = {}
+    if not wpt_urls:
+        return WPTContext(test_contents=test_contents)
+
+    unique_urls = sorted(set(wpt_urls))
+    if len(unique_urls) > MAXIMUM_TEST_SUITE_SIZE:
+        raise ValueError(
+            f"Too many tests found ({len(unique_urls)}). "
+            f"Max allowed is {MAXIMUM_TEST_SUITE_SIZE}."
+        )
+
+    base_github_url = (
+        "https://raw.githubusercontent.com/web-platform-tests/wpt/master/"
+    )
+
+    def _fetch_single(rel_path: str) -> tuple[str, str | None]:
+        clean_path = normalize_wpt_path(rel_path.lstrip("/"))
+        url = base_github_url + clean_path
+
+        @retry(
+            (urllib.error.HTTPError, urllib.error.URLError),
+            max_attempts=MAX_RETRIES,
+        )
+        def _try_url(target_url: str) -> str:
+            validate_url_against_ssrf(target_url)
+            headers = {"User-Agent": "Mozilla/5.0 (compatible; WPT-Gen/1.0)"}
+            req = urllib.request.Request(target_url, headers=headers)
+            with _ssrf_safe_opener.open(req, timeout=10) as response:
+                return str(response.read().decode("utf-8"))
+
+        content = None
+        try:
+            content = _try_url(url)
+        except Exception as e:
+            logger.warning(f"Failed to fetch remote WPT file ({url}): {e}")
+
+        if content is None and clean_path.endswith(".html"):
+            js_path = clean_path[:-5] + ".js"
+            js_url = base_github_url + js_path
+            try:
+                content = _try_url(js_url)
+                if content is not None:
+                    clean_path = js_path
+            except Exception as e:
+                logger.warning(
+                    f"Failed to fetch remote WPT file ({js_url}): {e}"
+                )
+
+        return "/" + clean_path, content
+
+    tasks = [asyncio.to_thread(_fetch_single, u) for u in unique_urls]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for res in results:
+        if isinstance(res, tuple):
+            path, content = res
+            if content is not None:
+                test_contents[path] = content
+
+    return WPTContext(test_contents=test_contents)
 
 
 def gather_local_test_context(

--- a/wptgen/phases/context_assembly.py
+++ b/wptgen/phases/context_assembly.py
@@ -25,6 +25,7 @@ from wptgen.context import (
     fetch_chromestatus_metadata,
     fetch_feature_yaml,
     fetch_mdn_urls,
+    fetch_remote_wpt_context,
     find_feature_tests,
     gather_local_test_context,
     validate_wpt_paths,
@@ -169,19 +170,29 @@ async def run_context_assembly(
                         test_paths = sorted(set(test_paths) | set(valid_paths))
                     except ValueError as e:
                         ui.warning(f"Skipping ChromeStatus tests: {e}")
+        wpt_context = gather_local_test_context(test_paths, config.wpt_path)
     elif config.library_mode:
         ui.info("Skipping local WPT scan (Library Mode).")
+        if config.chromestatus and metadata.wpt_descr:
+            with ui.status("Extracting remote tests from ChromeStatus..."):
+                extracted_wpt_urls = extract_wpt_paths(metadata.wpt_descr)
+                if extracted_wpt_urls:
+                    try:
+                        wpt_context = await fetch_remote_wpt_context(
+                            extracted_wpt_urls
+                        )
+                    except ValueError as e:
+                        ui.warning(f"Skipping remote ChromeStatus tests: {e}")
+                        wpt_context = WPTContext()
+                else:
+                    wpt_context = WPTContext()
+        else:
+            wpt_context = WPTContext()
     else:
         raise ValueError("WPT path must be configured for CLI usage.")
 
     if not test_paths and config.wpt_path:
         ui.warning("No existing Web Platform Tests were successfully loaded.")
-
-    wpt_context = (
-        gather_local_test_context(test_paths, config.wpt_path)
-        if config.wpt_path
-        else WPTContext()
-    )
 
     mdn_contents: list[str] | None = None
     if config.include_mdn_docs and not config.chromestatus:


### PR DESCRIPTION
This PR implements remote WPT test fetching over HTTP in library mode, resolving #511.

### Proposed Changes
- Implements `fetch_remote_wpt_context()` in `wptgen/context.py` using `asyncio.to_thread` and `asyncio.gather` to download WPT test files concurrently from raw GitHub URLs.
- Includes automatic `.html` to `.js` fallback logic for WPT script tests.
- Updates `extract_wpt_paths()` to use `url_pattern = r"(https?://wpt\.fyi/results[^\s?]+)"`, matching ChromeStatus framework extraction exactly.
- Adds robust async unit tests in `tests/test_context.py`.

Resolves #511
