### PR TITLE
[vendoring] refactor context assembly to support remote WPT fetching in library mode

### DIFF
--- a/tests/test_phase_context_assembly.py
+++ b/tests/test_phase_context_assembly.py
@@ -471,3 +471,51 @@ async def test_run_context_assembly_spec_fetch_exception(
         "Failed to fetch spec (http://spec-error): 404 Not Found"
     )
     mock_ui.error.assert_any_call("Failed to extract spec content.")
+
+
+@pytest.mark.asyncio
+async def test_run_context_assembly_library_mode_remote_fetching(
+    mock_config: Config, mock_ui: MagicMock, mocker: MockerFixture
+) -> None:
+    """Test that library mode correctly populates wpt_context via remote fetching."""
+    mock_config.library_mode = True
+    mock_config.wpt_path = None
+    mock_config.chromestatus = True
+
+    metadata = FeatureMetadata("Feat", "Desc", ["http://spec"])
+    metadata.wpt_descr = """
+    Here are the WPT results for this feature:
+    - https://wpt.fyi/results/css/css-grid/grid-model?label=master
+    - https://wpt.fyi/results/css/css-flexbox/flex-minimum-height-flex-items-005.xht?run_id=12345
+    Check these out.
+    """
+    mocker.patch(
+        "wptgen.phases.context_assembly.fetch_chromestatus_metadata",
+        return_value=metadata,
+    )
+    mocker.patch(
+        "wptgen.phases.context_assembly.fetch_and_extract_text",
+        return_value="Spec Content",
+    )
+
+    mock_remote_context = WPTContext(
+        test_contents={
+            "/css/css-grid/grid-model": "grid content",
+            "/css/css-flexbox/flex-minimum-height-flex-items-005.xht": "flex content",
+        }
+    )
+    mock_fetch_remote = mocker.patch(
+        "wptgen.phases.context_assembly.fetch_remote_wpt_context",
+        return_value=mock_remote_context,
+    )
+
+    context = await run_context_assembly("517399", mock_config, mock_ui)
+
+    assert context is not None
+    assert context.wpt_context == mock_remote_context
+    mock_fetch_remote.assert_called_once_with(
+        [
+            "css/css-flexbox/flex-minimum-height-flex-items-005.xht",
+            "css/css-grid/grid-model",
+        ]
+    )

--- a/wptgen/__init__.py
+++ b/wptgen/__init__.py
@@ -60,6 +60,7 @@ def generate_audit_report(
     config.library_mode = True
     config.wpt_path = None
     config.suggestions_only = True
+    config.chromestatus = True
     if model:
         config.default_model = model
     if api_key:

--- a/wptgen/phases/context_assembly.py
+++ b/wptgen/phases/context_assembly.py
@@ -25,6 +25,7 @@ from wptgen.context import (
     fetch_chromestatus_metadata,
     fetch_feature_yaml,
     fetch_mdn_urls,
+    fetch_remote_wpt_context,
     find_feature_tests,
     gather_local_test_context,
     validate_wpt_paths,
@@ -169,19 +170,29 @@ async def run_context_assembly(
                         test_paths = sorted(set(test_paths) | set(valid_paths))
                     except ValueError as e:
                         ui.warning(f"Skipping ChromeStatus tests: {e}")
+        wpt_context = gather_local_test_context(test_paths, config.wpt_path)
     elif config.library_mode:
         ui.info("Skipping local WPT scan (Library Mode).")
+        if config.chromestatus and metadata.wpt_descr:
+            with ui.status("Extracting remote tests from ChromeStatus..."):
+                extracted_wpt_urls = extract_wpt_paths(metadata.wpt_descr)
+                if extracted_wpt_urls:
+                    try:
+                        wpt_context = await fetch_remote_wpt_context(
+                            extracted_wpt_urls
+                        )
+                    except ValueError as e:
+                        ui.warning(f"Skipping remote ChromeStatus tests: {e}")
+                        wpt_context = WPTContext()
+                else:
+                    wpt_context = WPTContext()
+        else:
+            wpt_context = WPTContext()
     else:
         raise ValueError("WPT path must be configured for CLI usage.")
 
     if not test_paths and config.wpt_path:
         ui.warning("No existing Web Platform Tests were successfully loaded.")
-
-    wpt_context = (
-        gather_local_test_context(test_paths, config.wpt_path)
-        if config.wpt_path
-        else WPTContext()
-    )
 
     mdn_contents: list[str] | None = None
     if config.include_mdn_docs and not config.chromestatus:


### PR DESCRIPTION
This stacked PR refactors `context_assembly.py` to support remote WPT fetching in library mode, resolving #512.

### Proposed Changes
- Refactors `run_context_assembly()` in `wptgen/phases/context_assembly.py` to await `fetch_remote_wpt_context(extracted_wpt_urls)` in library mode when `wpt_descr` is present.
- Simplifies library mode configuration checks to `config.chromestatus`, as library mode explicitly enables ChromeStatus mode in `__init__.py`.
- Adds realistic unit test `test_run_context_assembly_library_mode_remote_fetching` in `tests/test_phase_context_assembly.py`.

Resolves #512
