### PR TITLE
[vendoring] fix BeautifulSoup XML root truncation for test suggestions

### DIFF
--- a/tests/test_report_render.py
+++ b/tests/test_report_render.py
@@ -138,6 +138,22 @@ def test_parse_test_suggestions_invalid() -> None:
     assert len(results) == 0
 
 
+def test_parse_test_suggestions_multiple_roots() -> None:
+    """Test parsing multiple sibling test_suggestion tags without an enclosing root tag."""
+    xml = """
+    <test_suggestion>
+      <description>Desc 1</description>
+    </test_suggestion>
+    <test_suggestion>
+      <description>Desc 2</description>
+    </test_suggestion>
+    """
+    results = parse_test_suggestions(xml)
+    assert len(results) == 2
+    assert results[0].description == "Desc 1"
+    assert results[1].description == "Desc 2"
+
+
 def test_render_basic() -> None:
     """Test rendering with mixed coverage results."""
     renderer = MarkdownReportRenderer()

--- a/wptgen/phases/report_render.py
+++ b/wptgen/phases/report_render.py
@@ -98,7 +98,7 @@ def parse_audit_worksheet(worksheet_text: str) -> list[RequirementAudit]:
 def parse_test_suggestions(suggestions_xml: str) -> list[SuggestionData]:
     """Parses the structured XML test suggestions."""
     results = []
-    soup = BeautifulSoup(suggestions_xml, "xml")
+    soup = BeautifulSoup(f"<root>{suggestions_xml}</root>", "xml")
 
     for suggestion in soup.find_all("test_suggestion"):
         description = suggestion.find("description")


### PR DESCRIPTION
This stacked PR fixes a BeautifulSoup XML root truncation bug when rendering test suggestions in library mode.

### Proposed Changes
- Wraps `suggestions_xml` in a `<root>` tag before BeautifulSoup parsing in `wptgen/phases/report_render.py` to ensure `lxml` correctly parses multiple sibling root `<test_suggestion>` elements without truncation.
- Adds unit test `test_parse_test_suggestions_multiple_roots` in `tests/test_report_render.py`.

Tracking issue: #517
