### PR TITLE
[vendoring] dynamically group worksheet categories and render test suggestions as a flat list

### DIFF
--- a/tests/test_report_render.py
+++ b/tests/test_report_render.py
@@ -191,8 +191,8 @@ def test_render_basic() -> None:
     assert "### Test Suggestions" in report
 
     # Verify status mapping
-    assert "* **Status:** ✅ Covered" in report  # For Existence
-    assert "* **Status:** ❌ Not Covered" in report  # For Common Use Cases
+    assert "* **Status:** Covered" in report  # For Existence
+    assert "* **Status:** Not Covered" in report  # For Common Use Cases
 
     # Verify evidence and gaps
     assert "✅ Verified in `test1.html`" in report

--- a/tests/test_report_render.py
+++ b/tests/test_report_render.py
@@ -138,6 +138,22 @@ def test_parse_test_suggestions_invalid() -> None:
     assert len(results) == 0
 
 
+def test_parse_test_suggestions_multiple_roots() -> None:
+    """Test parsing multiple sibling test_suggestion tags without an enclosing root tag."""
+    xml = """
+    <test_suggestion>
+      <description>Desc 1</description>
+    </test_suggestion>
+    <test_suggestion>
+      <description>Desc 2</description>
+    </test_suggestion>
+    """
+    results = parse_test_suggestions(xml)
+    assert len(results) == 2
+    assert results[0].description == "Desc 1"
+    assert results[1].description == "Desc 2"
+
+
 def test_render_basic() -> None:
     """Test rendering with mixed coverage results."""
     renderer = MarkdownReportRenderer()

--- a/tests/test_report_render.py
+++ b/tests/test_report_render.py
@@ -191,12 +191,12 @@ def test_render_basic() -> None:
     assert "### Test Suggestions" in report
 
     # Verify status mapping
-    assert "* **Status:** Covered" in report  # For Existence
-    assert "* **Status:** Not Covered" in report  # For Common Use Cases
+    assert "* **Status:** ✅ Covered" in report  # For Existence
+    assert "* **Status:** ❌ Not Covered" in report  # For Common Use Cases
 
     # Verify evidence and gaps
-    assert "Verified in `test1.html`" in report
-    assert "Missing test coverage for: Basic behavior works" in report
+    assert "✅ Verified in `test1.html`" in report
+    assert "❌ Missing test coverage for: Basic behavior works" in report
 
     # Verify suggestions are listed
     assert "Add test for basic behavior" in report

--- a/tests/test_report_render.py
+++ b/tests/test_report_render.py
@@ -163,7 +163,7 @@ def test_render_basic() -> None:
     report = renderer.render(audit_rows, suggestions)
 
     # Verify headers are present
-    assert "#### 1. Feature Existence" in report
+    assert "#### 1. Existence" in report
     assert (
         "**Conclusion:** Some test suggestions are available. See below."
         in report

--- a/tests/test_report_render.py
+++ b/tests/test_report_render.py
@@ -191,8 +191,8 @@ def test_render_basic() -> None:
     assert "### Test Suggestions" in report
 
     # Verify status mapping
-    assert "* **Status:** Covered" in report  # For Existence
-    assert "* **Status:** Not Covered" in report  # For Common Use Cases
+    assert "**Status:** Covered" in report  # For Existence
+    assert "**Status:** Not Covered" in report  # For Common Use Cases
 
     # Verify evidence and gaps
     assert "✅ Verified in `test1.html`" in report

--- a/wptgen/phases/report_render.py
+++ b/wptgen/phases/report_render.py
@@ -98,7 +98,7 @@ def parse_audit_worksheet(worksheet_text: str) -> list[RequirementAudit]:
 def parse_test_suggestions(suggestions_xml: str) -> list[SuggestionData]:
     """Parses the structured XML test suggestions."""
     results = []
-    soup = BeautifulSoup(suggestions_xml, "xml")
+    soup = BeautifulSoup(f"<root>{suggestions_xml}</root>", "xml")
 
     for suggestion in soup.find_all("test_suggestion"):
         description = suggestion.find("description")

--- a/wptgen/phases/report_render.py
+++ b/wptgen/phases/report_render.py
@@ -179,30 +179,13 @@ class MarkdownReportRenderer:
         suggestions: list[SuggestionData],
     ) -> dict[str, Any]:
         """Groups and maps data into the structure expected by the template."""
-        categories: dict[str, dict[str, Any]] = {
-            "existence": {"status": "Not Covered", "records": []},
-            "common_use_cases": {"status": "Not Covered", "records": []},
-            "error_scenarios": {"status": "Not Covered", "records": []},
-            "invalidation": {"status": "Not Covered", "records": []},
-            "integration": {"status": "Not Covered", "records": []},
-        }
-
-        def map_category(cat: str) -> str:
-            cat_lower = cat.lower()
-            if "existence" in cat_lower:
-                return "existence"
-            if "common" in cat_lower or "use case" in cat_lower:
-                return "common_use_cases"
-            if "error" in cat_lower or "exception" in cat_lower:
-                return "error_scenarios"
-            if "invalidation" in cat_lower or "dynamic" in cat_lower:
-                return "invalidation"
-            if "integration" in cat_lower or "interact" in cat_lower:
-                return "integration"
-            return "common_use_cases"
+        categories: dict[str, dict[str, Any]] = {}
 
         for row in audit_rows:
-            key = map_category(row.category)
+            cat_name = row.category or "Uncategorized"
+            if cat_name not in categories:
+                categories[cat_name] = {"status": "Not Covered", "records": []}
+
             evidence = "None"
             gaps = "None"
             if row.status == "COVERED":
@@ -214,7 +197,7 @@ class MarkdownReportRenderer:
             else:
                 gaps = f"Missing test coverage for: {row.text}"
 
-            categories[key]["records"].append(
+            categories[cat_name]["records"].append(
                 {"requirement": row.text, "evidence": evidence, "gaps": gaps}
             )
 
@@ -237,33 +220,7 @@ class MarkdownReportRenderer:
             else:
                 cat_data["status"] = "Partially Covered"
 
-        sug_data: dict[str, Any] = {
-            "status": "GAPS_FOUND" if suggestions else "SATISFIED",
-            "existence": [],
-            "common_use_cases": [],
-            "error_scenarios": [],
-            "invalidation": [],
-            "integration": [],
-        }
-
-        for sug in suggestions:
-            desc_lower = sug.description.lower()
-            if "existence" in desc_lower:
-                sug_data["existence"].append(sug.description)
-            elif "error" in desc_lower or "exception" in desc_lower:
-                sug_data["error_scenarios"].append(sug.description)
-            elif "invalidation" in desc_lower or "dynamic" in desc_lower:
-                sug_data["invalidation"].append(sug.description)
-            elif "integration" in desc_lower or "interact" in desc_lower:
-                sug_data["integration"].append(sug.description)
-            else:
-                sug_data["common_use_cases"].append(sug.description)
-
         return {
-            "existence": categories["existence"],
-            "common_use_cases": categories["common_use_cases"],
-            "error_scenarios": categories["error_scenarios"],
-            "invalidation": categories["invalidation"],
-            "integration": categories["integration"],
-            "suggestions": sug_data,
+            "categories": categories,
+            "suggestions": suggestions,
         }

--- a/wptgen/phases/report_render.py
+++ b/wptgen/phases/report_render.py
@@ -190,12 +190,12 @@ class MarkdownReportRenderer:
             gaps = "None"
             if row.status == "COVERED":
                 evidence = (
-                    f'Verified in `{", ".join(row.tests)}`'
+                    f'✅ Verified in `{", ".join(row.tests)}`'
                     if row.tests
-                    else "Verified"
+                    else "✅ Verified"
                 )
             else:
-                gaps = f"Missing test coverage for: {row.text}"
+                gaps = f"❌ Missing test coverage for: {row.text}"
 
             categories[cat_name]["records"].append(
                 {"requirement": row.text, "evidence": evidence, "gaps": gaps}
@@ -203,7 +203,7 @@ class MarkdownReportRenderer:
 
         for _, cat_data in categories.items():
             if not cat_data["records"]:
-                cat_data["status"] = "N/A"
+                cat_data["status"] = "⚪ N/A"
                 continue
 
             all_covered = all(
@@ -214,11 +214,11 @@ class MarkdownReportRenderer:
             )
 
             if all_covered:
-                cat_data["status"] = "Covered"
+                cat_data["status"] = "✅ Covered"
             elif all_uncovered:
-                cat_data["status"] = "Not Covered"
+                cat_data["status"] = "❌ Not Covered"
             else:
-                cat_data["status"] = "Partially Covered"
+                cat_data["status"] = "⚠️ Partially Covered"
 
         return {
             "categories": categories,

--- a/wptgen/phases/report_render.py
+++ b/wptgen/phases/report_render.py
@@ -203,7 +203,7 @@ class MarkdownReportRenderer:
 
         for _, cat_data in categories.items():
             if not cat_data["records"]:
-                cat_data["status"] = "⚪ N/A"
+                cat_data["status"] = "N/A"
                 continue
 
             all_covered = all(
@@ -214,11 +214,11 @@ class MarkdownReportRenderer:
             )
 
             if all_covered:
-                cat_data["status"] = "✅ Covered"
+                cat_data["status"] = "Covered"
             elif all_uncovered:
-                cat_data["status"] = "❌ Not Covered"
+                cat_data["status"] = "Not Covered"
             else:
-                cat_data["status"] = "⚠️ Partially Covered"
+                cat_data["status"] = "Partially Covered"
 
         return {
             "categories": categories,

--- a/wptgen/templates/report_render.jinja
+++ b/wptgen/templates/report_render.jinja
@@ -11,8 +11,8 @@
 * **Status:** {{ cat_data.status }}
 {% for item in cat_data.records %}
 * **Spec Requirement:** {{ item.requirement }}
-* **Evidence:** {{ item.evidence }}
-* **Gaps:** {{ item.gaps }}
+{% if item.evidence != "None" %}* {{ item.evidence }}{% endif %}
+{% if item.gaps != "None" %}* {{ item.gaps }}{% endif %}
 {% endfor %}
 {% if not loop.last %}
 
@@ -29,11 +29,8 @@ No test suggestions found. This feature has great test coverage!
 {% else %}
 Found {{ suggestions | length }} test suggestions:
 
-{% for sug in suggestions %}
-* **Suggestion #{{ loop.index }}**: {{ sug.title | default("Untitled") }}
-    * **Description:** {{ sug.description }}
-{% if sug.test_type %}    * **Test Type:** {{ sug.test_type }}{% endif %}
-{% if sug.expected_result %}    * **Expected Result:** {{ sug.expected_result }}{% endif %}
 
+{% for sug in suggestions %}
+* {{ sug.description }}
 {% endfor %}
 {% endif %}

--- a/wptgen/templates/report_render.jinja
+++ b/wptgen/templates/report_render.jinja
@@ -10,7 +10,7 @@
 #### {{ loop.index }}. {{ cat_name }}
 * **Status:** {{ cat_data.status }}
 {% for item in cat_data.records %}
-* **Spec Requirement:** {{ item.requirement }}
+**Spec Requirement:** {{ item.requirement }}
 {% if item.evidence != "None" %}* {{ item.evidence }}{% endif %}
 {% if item.gaps != "None" %}* {{ item.gaps }}{% endif %}
 {% endfor %}

--- a/wptgen/templates/report_render.jinja
+++ b/wptgen/templates/report_render.jinja
@@ -6,78 +6,34 @@
 
 ### Detailed Coverage Analysis
 
-#### 1. Feature Existence
-* **Status:** {{ existence.status }}
-{% for item in existence.records %}
+{% for cat_name, cat_data in categories.items() %}
+#### {{ loop.index }}. {{ cat_name }}
+* **Status:** {{ cat_data.status }}
+{% for item in cat_data.records %}
 * **Spec Requirement:** {{ item.requirement }}
 * **Evidence:** {{ item.evidence }}
 * **Gaps:** {{ item.gaps }}
 {% endfor %}
+{% if not loop.last %}
 
 -----
 
-#### 2. Common Use Cases
-* **Status:** {{ common_use_cases.status }}
-{% for item in common_use_cases.records %}
-* **Spec Requirement:** {{ item.requirement }}
-* **Evidence:** {{ item.evidence }}
-* **Gaps:** {{ item.gaps }}
-{% endfor %}
-
------
-
-#### 3. Likely Error Scenarios
-* **Status:** {{ error_scenarios.status }}
-{% for item in error_scenarios.records %}
-* **Spec Requirement:** {{ item.requirement }}
-* **Evidence:** {{ item.evidence }}
-* **Gaps:** {{ item.gaps }}
-{% endfor %}
-
------
-
-#### 4. Invalidation & Dynamic Behavior
-* **Status:** {{ invalidation.status }}
-{% for item in invalidation.records %}
-* **Spec Requirement:** {{ item.requirement }}
-* **Evidence:** {{ item.evidence }}
-* **Gaps:** {{ item.gaps }}
-{% endfor %}
-
------
-
-#### 5. Integration with Other Features
-* **Status:** {{ integration.status }}
-{% for item in integration.records %}
-* **Spec Requirement:** {{ item.requirement }}
-* **Evidence:** {{ item.evidence }}
-* **Gaps:** {{ item.gaps }}
+{% endif %}
 {% endfor %}
 
 -----
 
 ### Test Suggestions
-{% if suggestions.status == "SATISFIED" %}
+{% if not suggestions %}
 No test suggestions found. This feature has great test coverage!
 {% else %}
-* **Existence:** {{ suggestions.existence | length }} test suggestions.
-{% for sug in suggestions.existence %}
-    * {{ sug }}
-{% endfor %}
-* **Common Use Cases:** {{ suggestions.common_use_cases | length }} test suggestions.
-{% for sug in suggestions.common_use_cases %}
-    * {{ sug }}
-{% endfor %}
-* **Error Scenarios:** {{ suggestions.error_scenarios | length }} test suggestions.
-{% for sug in suggestions.error_scenarios %}
-    * {{ sug }}
-{% endfor %}
-* **Invalidation:** {{ suggestions.invalidation | length }} test suggestions.
-{% for sug in suggestions.invalidation %}
-    * {{ sug }}
-{% endfor %}
-* **Integration:** {{ suggestions.integration | length }} test suggestions.
-{% for sug in suggestions.integration %}
-    * {{ sug }}
+Found {{ suggestions | length }} test suggestions:
+
+{% for sug in suggestions %}
+* **Suggestion #{{ loop.index }}**: {{ sug.title | default("Untitled") }}
+    * **Description:** {{ sug.description }}
+{% if sug.test_type %}    * **Test Type:** {{ sug.test_type }}{% endif %}
+{% if sug.expected_result %}    * **Expected Result:** {{ sug.expected_result }}{% endif %}
+
 {% endfor %}
 {% endif %}

--- a/wptgen/templates/report_render.jinja
+++ b/wptgen/templates/report_render.jinja
@@ -8,11 +8,17 @@
 
 {% for cat_name, cat_data in categories.items() %}
 #### {{ loop.index }}. {{ cat_name }}
-* **Status:** {{ cat_data.status }}
+**Status:** {{ cat_data.status }}
 {% for item in cat_data.records %}
-**Spec Requirement:** {{ item.requirement }}
-{% if item.evidence != "None" %}* {{ item.evidence }}{% endif %}
-{% if item.gaps != "None" %}* {{ item.gaps }}{% endif %}
+* **Spec Requirement:** {{ item.requirement }}
+{% if item.evidence != "None" %}
+  
+  {{ item.evidence }}
+{% endif %}
+{% if item.gaps != "None" %}
+  
+  {{ item.gaps }}
+{% endif %}
 {% endfor %}
 {% if not loop.last %}
 


### PR DESCRIPTION
This stacked PR dynamically groups worksheet categories and renders test suggestions as a flat list.

### Proposed Changes
- Removes `map_category()` from `_prepare_data()` in `wptgen/phases/report_render.py`, allowing WPT-Gen to dynamically group worksheet rows by their exact category titles derived from the specification.
- Updates `report_render.jinja` in `wptgen/templates/` to render dynamic worksheet categories and display test suggestions as a clean, flat list.
- Updates `test_render_basic()` in `tests/test_report_render.py`.

Tracking issue: #517
