### PR TITLE
chore: bump version to 0.6.0 for release

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wpt-gen-lib"
-version = "0.5.0"
+version = "0.6.0"
 description = "A Core Library for AI-Powered Web Platform Test Analysis"
 readme = "../README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wpt-gen"
-version = "0.5.0"
+version = "0.6.0"
 description = "A CLI Tool for AI-Powered Web Platform Test Generation"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/wptgen/__init__.py
+++ b/wptgen/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from wptgen.engine import WPTGenEngine
 from wptgen.ui import LoggingUIProvider
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 
 def generate_audit_report(


### PR DESCRIPTION
Bumps package version to `0.6.0` across root and library configurations for the upcoming release. All presubmit checks have passed successfully.
