### PR TITLE
feat: always render all 5 requirement categories in coverage report

### DIFF
--- a/tests/test_report_render.py
+++ b/tests/test_report_render.py
@@ -224,3 +224,33 @@ def test_render_empty_suggestions() -> None:
         "No test suggestions found. This feature has great test coverage!"
         in report
     )
+
+
+def test_render_missing_categories_show_default_status() -> None:
+    """Test rendering when some standard categories are missing from audit_rows."""
+    renderer = MarkdownReportRenderer()
+
+    audit_rows = [
+        RequirementAudit(
+            id="R1",
+            category="Existence",
+            text="Interface must exist",
+            status="COVERED",
+            tests=["test1.html"],
+        )
+    ]
+
+    suggestions: list[SuggestionData] = []
+
+    report = renderer.render(audit_rows, suggestions)
+
+    # Verify all 5 categories are shown, even if they have no requirements
+    assert "#### 1. Existence" in report
+    assert "#### 2. Common Use Cases" in report
+    assert "#### 3. Error Scenarios" in report
+    assert "#### 4. Invalidation" in report
+    assert "#### 5. Integration" in report
+
+    # Verify that Existence has status "Covered"
+    # Wait, there's multiple status strings, so let's make sure the default status is rendered for the empty ones
+    assert "**Status:** No test suggestions applicable" in report

--- a/wptgen/phases/report_render.py
+++ b/wptgen/phases/report_render.py
@@ -20,6 +20,8 @@ from typing import Any
 from bs4 import BeautifulSoup
 from jinja2 import Environment, PackageLoader, select_autoescape
 
+from wptgen.models import REQUIREMENT_CATEGORIES
+
 
 @dataclass
 class RequirementAudit:
@@ -179,7 +181,14 @@ class MarkdownReportRenderer:
         suggestions: list[SuggestionData],
     ) -> dict[str, Any]:
         """Groups and maps data into the structure expected by the template."""
-        categories: dict[str, dict[str, Any]] = {}
+
+        categories: dict[str, dict[str, Any]] = {
+            cat_name: {
+                "status": "No test suggestions applicable",
+                "records": [],
+            }
+            for cat_name, _ in REQUIREMENT_CATEGORIES
+        }
 
         for row in audit_rows:
             cat_name = row.category or "Uncategorized"
@@ -203,7 +212,7 @@ class MarkdownReportRenderer:
 
         for _, cat_data in categories.items():
             if not cat_data["records"]:
-                cat_data["status"] = "N/A"
+                cat_data["status"] = "No test suggestions applicable"
                 continue
 
             all_covered = all(


### PR DESCRIPTION
## Background
Previously, in the Detailed Coverage Analysis report, requirement categories with no records (i.e., categories not present in `audit_rows` or categories where no test suggestions were applicable) were hidden entirely. This made it difficult for users to see the full landscape of expected testing categories.

## Proposed Changes
1. **Pre-populate Categories**: Initialized the `categories` dictionary in `wptgen/phases/report_render.py` with all 5 standard categories defined in `models.py` (`Existence`, `Common Use Cases`, `Error Scenarios`, `Invalidation`, `Integration`).
2. **Default Status**: Assigned the default status of `"No test suggestions applicable"` to categories that have no requirements/records.
3. **Dynamic Update**: Retained dynamic status updates (e.g., `"Covered"`, `"Not Covered"`, `"Partially Covered"`) for categories that *do* contain requirements.
4. **Unit Testing**: Added `test_render_missing_categories_show_default_status` in `tests/test_report_render.py` to cover this new behavior.

## Quality Checks
- `make presubmit` completed successfully.
- Code coverage remains at `89.99%`.

TESTED=https://screenshot.googleplex.com/3uohMFKP2zQZtdT