### PR TITLE
chore: bump version to v0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ wpt-gen generate font-family
 
 | Option | Shorthand | Description |
 | :--- | :--- | :--- |
-| `web_feature_id` | (Arg) | **Required.** The ID of the feature (e.g., `font-family`, `popover`). |
+| `feature_id` | (Arg) | **Required.** The ID of the feature (e.g., `font-family`, `popover`). |
 | `--provider` | `-p` | Override the default LLM provider (`gemini`, `openai`, `anthropic`). |
 | `--wpt-dir` | `-w` | Override the path to the local web-platform-tests repository. |
 | `--draft` | | Enable fetching metadata from the draft features directory. |

--- a/docs/workflow-phases.md
+++ b/docs/workflow-phases.md
@@ -5,7 +5,7 @@ The `wpt-gen generate` command orchestrates a complex, multi-phase agentic workf
 ## Phase 1: Context Assembly (`context_assembly.py`)
 
 *   **Responsibility:** Aggregates the "Source of Truth" from external documentation (W3C Specs, MDN) and identifies existing test coverage in the local WPT repository.
-*   **Inputs:** `web_feature_id` (string), `Config` object, `UIProvider`.
+*   **Inputs:** `feature_id` (string), `Config` object, `UIProvider`.
 *   **Outputs:** A hydrated `WorkflowContext` object containing the web-features metadata, scraped specification context, and local WPT tree paths.
 *   **LLM Integration:** None. This phase is entirely focused on gathering local and remote factual data deterministically to feed the subsequent phases.
 

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wpt-gen-lib"
-version = "0.6.1"
+version = "0.6.2"
 description = "A Core Library for AI-Powered Web Platform Test Analysis"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wpt-gen"
-version = "0.6.1"
+version = "0.6.2"
 description = "A CLI Tool for AI-Powered Web Platform Test Generation"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -126,17 +126,17 @@ async def test_requirements_cache_hit_accept(
     """Verify that requirements extraction uses cached requirements when
     user accepts.
     """
-    web_feature_id = "cached-feat"
+    feature_id = "cached-feat"
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()
-    cache_file = cache_dir / f"{web_feature_id}__requirements.xml"
+    cache_file = cache_dir / f"{feature_id}__requirements.xml"
     cache_file.write_text(
         "<requirements_list>Cached Requirements</requirements_list>",
         encoding="utf-8",
     )
 
     context = WorkflowContext(
-        feature_id=web_feature_id,
+        feature_id=feature_id,
         metadata=MagicMock(),
     )
 
@@ -167,10 +167,10 @@ async def test_requirements_cache_hit_reject(
     """Verify that requirements extraction regenerates requirements when
     user rejects cache.
     """
-    web_feature_id = "rejected-cache-feat"
+    feature_id = "rejected-cache-feat"
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()
-    cache_file = cache_dir / f"{web_feature_id}__requirements.xml"
+    cache_file = cache_dir / f"{feature_id}__requirements.xml"
     cache_file.write_text(
         "<requirements_list>Old Cached Requirements</requirements_list>",
         encoding="utf-8",
@@ -180,7 +180,7 @@ async def test_requirements_cache_hit_reject(
         name="Feat", description="Desc", specs=["http://spec"]
     )
     context = WorkflowContext(
-        feature_id=web_feature_id,
+        feature_id=feature_id,
         metadata=metadata,
         spec_contents={"http://spec": "spec content"},
     )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -185,7 +185,7 @@ async def test_run_async_workflow_suggestions_only(
         "wptgen.engine.run_test_generation", return_value=[]
     )
 
-    await engine._run_async_workflow(web_feature_id="test-feat")
+    await engine._run_async_workflow(feature_id="test-feat")
 
     mock_provide.assert_called_once()
     mock_gen.assert_not_called()
@@ -495,7 +495,7 @@ async def test_run_async_workflow_brief_suggestions(
         "wptgen.engine.run_test_generation", return_value=[]
     )
 
-    await engine._run_async_workflow(web_feature_id="test-feat")
+    await engine._run_async_workflow(feature_id="test-feat")
 
     mock_provide.assert_called_once_with(context, engine.config, engine.ui)
     mock_gen.assert_not_called()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -682,7 +682,7 @@ def test_config_set_command_types() -> None:
 
 
 def test_generate_single_missing_spec_urls() -> None:
-    """Test that omitting both spec flags and --web-feature-id raises an error."""
+    """Test that omitting both spec flags and --feature-id raises an error."""
     result = runner.invoke(
         app,
         ["generate-single", "Test description"],
@@ -690,7 +690,7 @@ def test_generate_single_missing_spec_urls() -> None:
     )
     assert result.exit_code != 0
     assert (
-        "Either --spec-url, --spec-urls, or --web-feature-id must be provided."
+        "Either --spec-url, --spec-urls, or --feature-id must be provided."
         in result.output
     )
 
@@ -715,7 +715,7 @@ def test_generate_single_success(
             "This is a custom test",
             "--spec-urls",
             "https://example.com/spec",
-            "--web-feature-id",
+            "--feature-id",
             "popover",
             "--title",
             "My Custom Test",
@@ -735,7 +735,7 @@ def test_generate_single_success(
 
     mock_run_single.assert_called_once()
     kwargs = mock_run_single.call_args.kwargs
-    assert kwargs["web_feature_id"] == "popover"
+    assert kwargs["feature_id"] == "popover"
     assert kwargs["spec_urls"] == ["https://example.com/spec"]
     assert kwargs["description"] == "This is a custom test"
     assert kwargs["title"] == "My Custom Test"
@@ -767,7 +767,7 @@ def test_generate_single_no_feature_id(
 
     mock_run_single.assert_called_once()
     kwargs = mock_run_single.call_args.kwargs
-    assert kwargs["web_feature_id"] is None
+    assert kwargs["feature_id"] is None
 
 
 def test_generate_single_with_fetched_specs(
@@ -792,7 +792,7 @@ def test_generate_single_with_fetched_specs(
         [
             "generate-single",
             "This is a custom test",
-            "--web-feature-id",
+            "--feature-id",
             "popover",
         ],
     )
@@ -801,5 +801,5 @@ def test_generate_single_with_fetched_specs(
 
     mock_run_single.assert_called_once()
     kwargs = mock_run_single.call_args.kwargs
-    assert kwargs["web_feature_id"] == "popover"
+    assert kwargs["feature_id"] == "popover"
     assert kwargs["spec_urls"] == ["https://example.com/popover"]

--- a/tests/test_phase_generation.py
+++ b/tests/test_phase_generation.py
@@ -190,7 +190,7 @@ async def test_run_single_test_generation(
     jinja_env = MagicMock()
 
     result = await run_single_test_generation(
-        web_feature_id="custom-feat",
+        feature_id="custom-feat",
         spec_urls=["http://spec.com"],
         description="A cool feature",
         title="Cool Test",
@@ -220,7 +220,7 @@ async def test_run_single_test_generation(
 async def test_run_single_test_generation_no_feature_id(
     mock_config: Config, mock_ui: MagicMock, mocker: MockerFixture
 ) -> None:
-    """Test run_single_test_generation when web_feature_id is None."""
+    """Test run_single_test_generation when feature_id is None."""
     mock_generate_adk = mocker.patch(
         "wptgen.phases.generation._generate_adk_loop"
     )
@@ -228,7 +228,7 @@ async def test_run_single_test_generation_no_feature_id(
     jinja_env = MagicMock()
 
     await run_single_test_generation(
-        web_feature_id=None,
+        feature_id=None,
         spec_urls=["http://spec.com"],
         description="A cool feature",
         title=None,

--- a/wptgen/__init__.py
+++ b/wptgen/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from wptgen.engine import WPTGenEngine
 from wptgen.ui import LoggingUIProvider
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 
 def generate_audit_report(

--- a/wptgen/agents/adk_test_generator.py
+++ b/wptgen/agents/adk_test_generator.py
@@ -103,14 +103,12 @@ async def generate_test_with_adk(
         try:
             wpt_generator_skill = load_skill_from_dir(skill_dir)
 
-            # Conditionally template the skill instructions to avoid confusing
-            # the agent when no web_feature_id is provided.
             has_feature_id = bool(
-                re.search(r"<web_feature_id>\s*[^<\s]", suggestion_xml)
+                re.search(r"<feature_id>\s*[^<\s]", suggestion_xml)
             )
             template = jinja_env.from_string(wpt_generator_skill.instructions)
             wpt_generator_skill.instructions = template.render(
-                has_web_feature_id=has_feature_id
+                has_feature_id=has_feature_id
             )
 
             skill_toolset = SkillToolset(skills=[wpt_generator_skill])

--- a/wptgen/agents/tools.py
+++ b/wptgen/agents/tools.py
@@ -589,17 +589,17 @@ def create_agent_tools(
         except (OSError, ValueError, subprocess.SubprocessError) as e:
             return {"status": "error", "error": str(e)}
 
-    def search_feature_tests(web_feature_id: str) -> dict[str, Any]:
+    def search_feature_tests(feature_id: str) -> dict[str, Any]:
         """Searches WPT for test files associated with a specific feature.
 
         Args:
-            web_feature_id: The ID of the feature (e.g., 'popover').
+            feature_id: The ID of the feature (e.g., 'popover').
 
         Returns:
             A dictionary with 'status' and matching 'test_files'.
         """
         try:
-            matches = find_feature_tests(str(wpt_path), web_feature_id)
+            matches = find_feature_tests(str(wpt_path), feature_id)
             if matches:
                 # Clean up paths to be relative for the agent's consumption
                 rel_matches = [
@@ -610,7 +610,7 @@ def create_agent_tools(
             return {
                 "status": "success",
                 "test_files": [],
-                "message": f"No existing tests found for {web_feature_id}",
+                "message": f"No existing tests found for {feature_id}",
             }
         except (OSError, ValueError) as e:
             return {"status": "error", "error": str(e)}

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -64,7 +64,7 @@ MDN_MAPPINGS_URL = (
 
 
 def fetch_feature_yaml(
-    web_feature_id: str, draft: bool = False
+    feature_id: str, draft: bool = False
 ) -> dict[str, Any] | None:
     """
     Fetches the YAML definition for a given web feature ID from the
@@ -75,12 +75,12 @@ def fetch_feature_yaml(
     if draft:
         url = (
             "https://raw.githubusercontent.com/web-platform-dx/web-features/"
-            f"main/features/draft/spec/{web_feature_id}.yml"
+            f"main/features/draft/spec/{feature_id}.yml"
         )
     else:
         url = (
             "https://raw.githubusercontent.com/web-platform-dx/web-features/"
-            f"main/features/{web_feature_id}.yml"
+            f"main/features/{feature_id}.yml"
         )
 
     try:
@@ -166,7 +166,7 @@ def fetch_chromestatus_metadata(feature_id: str) -> FeatureMetadata | None:
         return None
 
 
-def fetch_mdn_urls(web_feature_id: str) -> list[str]:
+def fetch_mdn_urls(feature_id: str) -> list[str]:
     """
     Fetches the MDN mapping for a given web feature ID from the
     web-platform-dx/web-features-mappings repository.
@@ -181,7 +181,7 @@ def fetch_mdn_urls(web_feature_id: str) -> list[str]:
             json_content = response.read().decode("utf-8")
             data = json.loads(json_content)
 
-            feature_mappings = data.get(web_feature_id, [])
+            feature_mappings = data.get(feature_id, [])
             return [item["url"] for item in feature_mappings if "url" in item]
 
     except (urllib.error.HTTPError, json.JSONDecodeError, KeyError) as e:

--- a/wptgen/engine.py
+++ b/wptgen/engine.py
@@ -69,18 +69,16 @@ class WPTGenEngine:
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
     def run_workflow(
-        self, web_feature_id: str, disable_directory_inference: bool = False
+        self, feature_id: str, disable_directory_inference: bool = False
     ) -> WorkflowContext:
         """Entry point for the synchronous CLI to launch the async workflow."""
         return asyncio.run(
-            self._run_async_workflow(
-                web_feature_id, disable_directory_inference
-            )
+            self._run_async_workflow(feature_id, disable_directory_inference)
         )
 
-    def _get_resume_file_path(self, web_feature_id: str) -> Path:
+    def _get_resume_file_path(self, feature_id: str) -> Path:
         """Returns the path to the resume file for a given web feature ID."""
-        return self.cache_dir / f"resume_{web_feature_id}.json"
+        return self.cache_dir / f"resume_{feature_id}.json"
 
     def _save_resume_state(self, context: WorkflowContext) -> None:
         """Serializes and saves the current workflow context to the cache."""
@@ -89,9 +87,9 @@ class WPTGenEngine:
         with open(resume_file, "w", encoding="utf-8") as f:
             json.dump(context.to_dict(), f, indent=2)
 
-    def _load_resume_state(self, web_feature_id: str) -> WorkflowContext | None:
+    def _load_resume_state(self, feature_id: str) -> WorkflowContext | None:
         """Attempts to load a serialized workflow context from the cache."""
-        resume_file = self._get_resume_file_path(web_feature_id)
+        resume_file = self._get_resume_file_path(feature_id)
         if not resume_file.exists():
             return None
 
@@ -105,7 +103,7 @@ class WPTGenEngine:
             )
             return None
 
-    def _hydrate_context(self, web_feature_id: str) -> WorkflowContext:
+    def _hydrate_context(self, feature_id: str) -> WorkflowContext:
         """Hydrates context from explicitly provided state directory or
         default cache.
         """
@@ -114,11 +112,11 @@ class WPTGenEngine:
             if self.config.state_dir
             else self.cache_dir
         )
-        resume_file = state_dir / f"resume_{web_feature_id}.json"
+        resume_file = state_dir / f"resume_{feature_id}.json"
         if not resume_file.exists():
-            resume_file = self._get_resume_file_path(web_feature_id)
+            resume_file = self._get_resume_file_path(feature_id)
 
-        context = WorkflowContext(feature_id=web_feature_id)
+        context = WorkflowContext(feature_id=feature_id)
         if resume_file.exists():
             try:
                 with open(resume_file, encoding="utf-8") as f:
@@ -225,7 +223,7 @@ class WPTGenEngine:
                 json.dump(tests_data, f, indent=2)
 
     async def _run_async_workflow(
-        self, web_feature_id: str, disable_directory_inference: bool = False
+        self, feature_id: str, disable_directory_inference: bool = False
     ) -> WorkflowContext:
         """Orchestrates the end-to-end WPT generation workflow."""
         context = None
@@ -235,14 +233,14 @@ class WPTGenEngine:
                 f"Explicitly resuming workflow from: "
                 f"{self.config.resume_from.value}"
             )
-            context = self._hydrate_context(web_feature_id)
+            context = self._hydrate_context(feature_id)
         elif self.config.resume:
-            context = self._load_resume_state(web_feature_id)
+            context = self._load_resume_state(feature_id)
             if context:
-                self.ui.success(f"Resuming workflow for {web_feature_id}")
+                self.ui.success(f"Resuming workflow for {feature_id}")
 
         if not context:
-            context = WorkflowContext(feature_id=web_feature_id)
+            context = WorkflowContext(feature_id=feature_id)
 
         phases_order = [
             WorkflowPhase.REQUIREMENTS_EXTRACTION,
@@ -260,7 +258,7 @@ class WPTGenEngine:
         # Phase 1: Context Assembly
         if should_run(None, bool(context.wpt_context)):
             context = await run_context_assembly(
-                web_feature_id, self.config, self.ui
+                feature_id, self.config, self.ui
             )
             if not context:
                 raise WorkflowError("Phase 1: Context Assembly failed.")
@@ -368,7 +366,7 @@ class WPTGenEngine:
             await provide_coverage_report(context, self.config, self.ui)
             # Cleanup resume file if it exists, as this is a terminal
             # state for suggestions-only
-            self._get_resume_file_path(web_feature_id).unlink(missing_ok=True)
+            self._get_resume_file_path(feature_id).unlink(missing_ok=True)
             return context
 
         # Phase 4: User Selection & Generation
@@ -392,6 +390,6 @@ class WPTGenEngine:
             self.ui.success("Skipping Phase 4: Tests already generated.")
 
         # Final cleanup of resume file on success
-        self._get_resume_file_path(web_feature_id).unlink(missing_ok=True)
+        self._get_resume_file_path(feature_id).unlink(missing_ok=True)
 
         return context

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -174,12 +174,12 @@ def _check_workflow_flags(
         raise typer.Exit(code=1)
 
 
-def _print_workflow_banner(ui: UIProvider, web_feature_id: str) -> None:
+def _print_workflow_banner(ui: UIProvider, feature_id: str) -> None:
     """Prints a stylized banner and target feature info to the console.
 
     Args:
         ui: The UI provider for the workflow.
-        web_feature_id: The ID of the feature being processed.
+        feature_id: The ID of the feature being processed.
     """
     banner = Panel(
         Align.center(
@@ -193,7 +193,7 @@ def _print_workflow_banner(ui: UIProvider, web_feature_id: str) -> None:
         border_style="bright_blue",
     )
     ui.print(banner)
-    ui.print(f"\n[bold]Target Feature:[/bold] [cyan]{web_feature_id}[/cyan]\n")
+    ui.print(f"\n[bold]Target Feature:[/bold] [cyan]{feature_id}[/cyan]\\n")
 
 
 def _print_run_config(ui: UIProvider, config: Any) -> None:
@@ -238,7 +238,7 @@ def _workflow_error_handler(ui: UIProvider) -> Generator[None, None, None]:
 
 def _execute_workflow(
     ui: UIProvider,
-    web_feature_id: str,
+    feature_id: str,
     config: Any,
     wf_yml_update: bool,
     output_dir: Path | None,
@@ -249,7 +249,7 @@ def _execute_workflow(
 
     Args:
         ui: The UI provider for the workflow.
-        web_feature_id: The ID of the web feature.
+        feature_id: The ID of the web feature.
         config: Resolved configuration object.
         wf_yml_update: Whether to update WEB_FEATURES.yml.
         output_dir: Directory to save tests.
@@ -265,7 +265,7 @@ def _execute_workflow(
     # Execute the workflow
     try:
         context = engine.run_workflow(
-            web_feature_id,
+            feature_id,
             disable_directory_inference=disable_directory_inference,
         )
     except WorkflowAborted:
@@ -281,8 +281,8 @@ def _execute_workflow(
         )
         if wf_yml_update and target_dir and context and context.generated_tests:
             generated_paths = [path for path, _, _ in context.generated_tests]
-            update_web_features_yml(target_dir, web_feature_id, generated_paths)
-            ui.success(f"Updated WEB_FEATURES.yml for {web_feature_id}")
+            update_web_features_yml(target_dir, feature_id, generated_paths)
+            ui.success(f"Updated WEB_FEATURES.yml for {feature_id}")
 
         ui.print()
         ui.success("Workflow completed successfully!")
@@ -291,7 +291,7 @@ def _execute_workflow(
 @app.command()
 def generate(
     ctx: typer.Context,
-    web_feature_id: Annotated[
+    feature_id: Annotated[
         str,
         typer.Argument(
             help=(
@@ -600,7 +600,7 @@ def generate(
     """
     ui = ctx.obj["ui"]
 
-    _print_workflow_banner(ui, web_feature_id)
+    _print_workflow_banner(ui, feature_id)
     _check_workflow_flags(
         ui=ui,
         wf_yml_update=wf_yml_update,
@@ -670,7 +670,7 @@ def generate(
 
         _execute_workflow(
             ui=ui,
-            web_feature_id=web_feature_id,
+            feature_id=feature_id,
             config=config,
             wf_yml_update=wf_yml_update,
             output_dir=output_dir,
@@ -700,10 +700,10 @@ def generate_single(
             help="A single specification URL for convenience.",
         ),
     ] = None,
-    web_feature_id: Annotated[
+    feature_id: Annotated[
         str | None,
         typer.Option(
-            "--web-feature-id",
+            "--feature-id",
             "-f",
             help="Optional web feature ID (e.g., 'grid', 'popover').",
         ),
@@ -771,10 +771,10 @@ def generate_single(
         )
         raise typer.Exit(code=1)
 
-    if not spec_urls and not spec_url and not web_feature_id:
+    if not spec_urls and not spec_url and not feature_id:
         ui.error(
             "Error: Either --spec-url, --spec-urls, or "
-            "--web-feature-id must be provided."
+            "--feature-id must be provided."
         )
         raise typer.Exit(code=1)
 
@@ -786,8 +786,8 @@ def generate_single(
                 [u.strip() for u in spec_urls.split(",")] if spec_urls else []
             )
 
-        if not spec_urls_list and web_feature_id:
-            feature_data = fetch_feature_yaml(web_feature_id)
+        if not spec_urls_list and feature_id:
+            feature_data = fetch_feature_yaml(feature_id)
             if feature_data:
                 metadata = extract_feature_metadata(feature_data)
                 if metadata.specs:
@@ -817,7 +817,7 @@ def generate_single(
 
         generated_tests = asyncio.run(
             run_single_test_generation(
-                web_feature_id=web_feature_id,
+                feature_id=feature_id,
                 spec_urls=spec_urls_list,
                 description=description,
                 title=title,
@@ -1384,7 +1384,7 @@ def list_models(
 @app.command(name="audit")
 def audit(
     ctx: typer.Context,
-    web_feature_id: Annotated[
+    feature_id: Annotated[
         str,
         typer.Argument(
             help=(
@@ -1667,7 +1667,7 @@ def audit(
     """
     ui = ctx.obj["ui"]
 
-    _print_workflow_banner(ui, web_feature_id)
+    _print_workflow_banner(ui, feature_id)
     _check_workflow_flags(
         ui=ui,
         wf_yml_update=wf_yml_update,
@@ -1737,7 +1737,7 @@ def audit(
 
         _execute_workflow(
             ui=ui,
-            web_feature_id=web_feature_id,
+            feature_id=feature_id,
             config=config,
             wf_yml_update=wf_yml_update,
             output_dir=output_dir,

--- a/wptgen/metadata.py
+++ b/wptgen/metadata.py
@@ -38,12 +38,12 @@ def is_path_covered(rel_path: Path, patterns: list[str]) -> bool:
 
 
 def update_web_features_yml(
-    output_dir: Path, web_feature_id: str, generated_paths: list[Path]
+    output_dir: Path, feature_id: str, generated_paths: list[Path]
 ) -> None:
     """Updates or creates a WEB_FEATURES.yml file linking tests to a feature.
 
     Updates or creates a WEB_FEATURES.yml file at the root of output_dir,
-    linking generated tests to the given web_feature_id.
+    linking generated tests to the given feature_id.
     """
     yml_path = output_dir / "WEB_FEATURES.yml"
     yaml_data: dict[str, Any] = {}
@@ -61,11 +61,11 @@ def update_web_features_yml(
     features_list: list[dict[str, Any]] = yaml_data["features"]
 
     feature_block = next(
-        (f for f in features_list if f.get("name") == web_feature_id), None
+        (f for f in features_list if f.get("name") == feature_id), None
     )
 
     if feature_block is None:
-        feature_block = {"name": web_feature_id, "files": []}
+        feature_block = {"name": feature_id, "files": []}
         features_list.append(feature_block)
 
     elif "files" not in feature_block:

--- a/wptgen/phases/context_assembly.py
+++ b/wptgen/phases/context_assembly.py
@@ -35,7 +35,7 @@ from wptgen.ui import UIProvider
 
 
 async def run_context_assembly(
-    web_feature_id: str, config: Config, ui: UIProvider
+    feature_id: str, config: Config, ui: UIProvider
 ) -> WorkflowContext | None:
     """Executes the Context Assembly phase.
 
@@ -44,7 +44,7 @@ async def run_context_assembly(
     phases.
 
     Args:
-      web_feature_id: The ID of the feature to gather context for.
+      feature_id: The ID of the feature to gather context for.
       config: The tool configuration.
       ui: The UI provider for reporting progress.
 
@@ -55,26 +55,26 @@ async def run_context_assembly(
 
     if config.chromestatus:
         metadata = await asyncio.to_thread(
-            fetch_chromestatus_metadata, web_feature_id
+            fetch_chromestatus_metadata, feature_id
         )
         if not metadata:
-            ui.error(f"Feature {web_feature_id} not found on ChromeStatus.")
+            ui.error(f"Feature {feature_id} not found on ChromeStatus.")
             return None
     else:
-        feature_data = fetch_feature_yaml(web_feature_id, draft=config.draft)
+        feature_data = fetch_feature_yaml(feature_id, draft=config.draft)
         if not feature_data:
             if config.spec_urls and config.feature_description:
                 ui.warning(
-                    f"Feature {web_feature_id} not found in the "
+                    f"Feature {feature_id} not found in the "
                     "web-features repository."
                 )
                 metadata = FeatureMetadata(
-                    name=web_feature_id,
+                    name=feature_id,
                     description=config.feature_description,
                     specs=config.spec_urls,
                 )
             else:
-                ui.error(f"Feature {web_feature_id} not found.")
+                ui.error(f"Feature {feature_id} not found.")
                 ui.print(
                     "To generate tests for an unregistered feature, please "
                     "provide both a spec URL using --spec-urls and a "
@@ -150,7 +150,7 @@ async def run_context_assembly(
             "Scanning local WPT repository for existing tests and "
             "dependencies..."
         )
-        test_paths = find_feature_tests(config.wpt_path, web_feature_id)
+        test_paths = find_feature_tests(config.wpt_path, feature_id)
 
         # If ChromeStatus is enabled, extract and validate tests from wpt_descr
         if config.chromestatus and metadata.wpt_descr:
@@ -197,7 +197,7 @@ async def run_context_assembly(
     mdn_contents: list[str] | None = None
     if config.include_mdn_docs and not config.chromestatus:
         ui.print("Fetching MDN documentation...")
-        mdn_urls = fetch_mdn_urls(web_feature_id)
+        mdn_urls = fetch_mdn_urls(feature_id)
         if mdn_urls:
             with ui.status(f"Fetching {len(mdn_urls)} MDN pages..."):
                 # Fetch all MDN pages asynchronously using to_thread
@@ -238,7 +238,7 @@ async def run_context_assembly(
         )
 
     return WorkflowContext(
-        feature_id=web_feature_id,
+        feature_id=feature_id,
         metadata=metadata,
         spec_contents=spec_contents,
         explainer_contents=explainer_contents,

--- a/wptgen/phases/generation.py
+++ b/wptgen/phases/generation.py
@@ -114,7 +114,7 @@ async def run_test_generation(
 
 
 async def run_single_test_generation(
-    web_feature_id: str | None,
+    feature_id: str | None,
     spec_urls: list[str],
     description: str,
     title: str | None,
@@ -126,9 +126,9 @@ async def run_single_test_generation(
     """Generates a single test directly from a user description."""
     ui.on_phase_start(4, "Single Test Generation")
 
-    context = WorkflowContext(feature_id=web_feature_id)
+    context = WorkflowContext(feature_id=feature_id)
     context.metadata = FeatureMetadata(
-        name=web_feature_id or "custom_feature", description="", specs=spec_urls
+        name=feature_id or "custom_feature", description="", specs=spec_urls
     )
 
     title_xml = f"  <title>{title}</title>\n" if title else ""
@@ -170,16 +170,16 @@ def _format_test_suggestion(
         for url in spec_urls:
             lines.append(f"  <spec_url>{url}</spec_url>")
         if feature_id:
-            lines.append(f"  <web_feature_id>{feature_id}</web_feature_id>")
+            lines.append(f"  <feature_id>{feature_id}</feature_id>")
         lines.append("</test_suggestion>")
         return "\n".join(lines)
     else:
-        # Just inject spec_urls and web_feature_id into the existing XML
+        # Just inject spec_urls and feature_id into the existing XML
         lines = []
         for url in spec_urls:
             lines.append(f"  <spec_url>{url}</spec_url>")
         if feature_id:
-            lines.append(f"  <web_feature_id>{feature_id}</web_feature_id>")
+            lines.append(f"  <feature_id>{feature_id}</feature_id>")
         additions = "\n".join(lines)
         if additions:
             return suggestion_xml.replace(

--- a/wptgen/phases/requirements_extraction.py
+++ b/wptgen/phases/requirements_extraction.py
@@ -28,7 +28,7 @@ from wptgen.ui import UIProvider
 
 
 def _load_cached_requirements(
-    web_feature_id: str,
+    feature_id: str,
     cache_file: Path,
     config: Config,
     ui: UIProvider,
@@ -36,7 +36,7 @@ def _load_cached_requirements(
     """Helper to check for and load cached requirements if requested.
 
     Args:
-      web_feature_id: The ID of the feature.
+      feature_id: The ID of the feature.
       cache_file: The path to the potential cache file.
       config: The tool configuration.
       ui: The UI provider.
@@ -47,7 +47,7 @@ def _load_cached_requirements(
     if not cache_file.exists():
         return None
 
-    ui.info(f"Found cached requirements for {web_feature_id}.")
+    ui.info(f"Found cached requirements for {feature_id}.")
     use_cache = False
     if config.yes_cache:
         use_cache = True
@@ -95,11 +95,11 @@ async def run_requirements_extraction(
     assert context.metadata is not None
     assert context.feature_id is not None
 
-    web_feature_id = context.feature_id
-    cache_file = cache_dir / f"{web_feature_id}__requirements.xml"
+    feature_id = context.feature_id
+    cache_file = cache_dir / f"{feature_id}__requirements.xml"
 
     requirements_xml = _load_cached_requirements(
-        web_feature_id, cache_file, config, ui
+        feature_id, cache_file, config, ui
     )
 
     if not requirements_xml:
@@ -185,11 +185,11 @@ async def run_requirements_extraction_categorized(
     assert context.metadata is not None
     assert context.feature_id is not None
 
-    web_feature_id = context.feature_id
-    cache_file = cache_dir / f"{web_feature_id}__requirements.xml"
+    feature_id = context.feature_id
+    cache_file = cache_dir / f"{feature_id}__requirements.xml"
 
     requirements_xml = _load_cached_requirements(
-        web_feature_id, cache_file, config, ui
+        feature_id, cache_file, config, ui
     )
 
     if not requirements_xml:
@@ -379,11 +379,11 @@ async def run_requirements_extraction_iterative(
     assert context.metadata is not None
     assert context.feature_id is not None
 
-    web_feature_id = context.feature_id
-    cache_file = cache_dir / f"{web_feature_id}__requirements.xml"
+    feature_id = context.feature_id
+    cache_file = cache_dir / f"{feature_id}__requirements.xml"
 
     requirements_xml = _load_cached_requirements(
-        web_feature_id, cache_file, config, ui
+        feature_id, cache_file, config, ui
     )
 
     if not requirements_xml:

--- a/wptgen/skills/wpt-generator/SKILL.md
+++ b/wptgen/skills/wpt-generator/SKILL.md
@@ -14,16 +14,16 @@ When asked to generate a WPT from an XML test suggestion, follow these steps:
 
 ### 1. Parse the test suggestion
 Extract the following elements from the `<test_suggestion>` XML snippet provided by the user:
-{% if has_web_feature_id %}
-- `<web_feature_id>`: Used to find where the test should live.
+{% if has_feature_id %}
+- `<feature_id>`: Used to find where the test should live.
 {% endif %}
 - `<description>`: The underlying requirement or specification behavior to test.
 - `<spec_url>` (can be multiple): A link to the specification. You MUST include these exact URLs in the generated test (using `<link rel="help" href="...">` for HTML tests, or as a single-line comment for `.js` tests).
 
 ### 2. Locate the Test Directory
-{% if has_web_feature_id %}
+{% if has_feature_id %}
 Determine where this test belongs in the repository by finding the corresponding `WEB_FEATURES.yml` file.
-1. Use the `search_feature_tests` tool with the `<web_feature_id>` to find existing tests for this feature.
+1. Use the `search_feature_tests` tool with the `<feature_id>` to find existing tests for this feature.
 2. Review the output to determine the target directory.
 {% else %}
 Determine where this test belongs in the repository based on the specification URL and the feature description.
@@ -32,7 +32,7 @@ Determine where this test belongs in the repository based on the specification U
 {% endif %}
 
 ### 3. Research Existing Paradigms & Determine Test Type
-Since you are not provided with explicit steps or a test type, you MUST research how similar tests are written for this feature, both in the target directory and across the broader codebase. {% if has_web_feature_id %}**Avoid "Tunnel Vision":** Do not restrict your research solely to the output of `search_feature_tests`.
+Since you are not provided with explicit steps or a test type, you MUST research how similar tests are written for this feature, both in the target directory and across the broader codebase. {% if has_feature_id %}**Avoid "Tunnel Vision":** Do not restrict your research solely to the output of `search_feature_tests`.
 {% endif %}1. Use the `list_directory` and `search_files` tools to explore existing tests in the target directory.
 2. Broaden your search: Search the broader repository (or related parent directories) for the API name or feature (e.g., `fetchLater`) to find existing test ecosystems, helper files (`resources/`), or data-driven testing paradigms that might live in adjacent directories.
 3. **IDL Check:** If the `<description>` involves testing interface exposure, attributes, or methods, you MUST check the repository's `interfaces/` directory for a corresponding `.idl` file (e.g., `interfaces/crash-reporting.idl`). If it exists, this strongly indicates you should use `idlharness.js` instead of manual boolean assertions.
@@ -49,7 +49,7 @@ Before creating a new file, rigorously check if the test logic belongs in existi
 1. **Analyze Directory Paradigms:** Check if the target directory splits tests by category (e.g., separating valid vs. invalid values, or computed vs. parsing behavior).
 2. **Split the test suggestion if Necessary:** A single XML test suggestion might encompass multiple test categories. If the directory separates testing into distinct files (e.g., `feature-valid.html` and `feature-invalid.html`), **you MUST split the test logic across the respective existing files** rather than creating a single, monolithic new file.
 3. **Reftest Reference Search:** If you selected **Reftest**, you MUST search the target directory (and any `reference/` subdirectories) for existing reusable reference files (e.g., `ref-filled-green-100px-square.xht`) before deciding to create a new one. Do NOT generate a duplicate reference file if a suitable one exists.
-4. **Create New Only When Necessary:** Only if no logical match is found (even after considering splitting and manual consolidation), plan to create a new file. **Consult `references/wpt_style_guide.md` to determine the correct filename extension and suffixes** (e.g., `.html`, `.window.js`, `.any.js`) based on your chosen test type. Name the file logically based on the {% if has_web_feature_id %}`<web_feature_id>`{% else %}feature description{% endif %}.
+4. **Create New Only When Necessary:** Only if no logical match is found (even after considering splitting and manual consolidation), plan to create a new file. **Consult `references/wpt_style_guide.md` to determine the correct filename extension and suffixes** (e.g., `.html`, `.window.js`, `.any.js`) based on your chosen test type. Name the file logically based on the {% if has_feature_id %}`<feature_id>`{% else %}feature description{% endif %}.
 5. **File Existence Check:** Before using `write_file` to create a new test file, you MUST verify that the proposed filename does not already exist in the target directory (e.g., by using the `list_directory` tool).
 6. **Naming Conflicts:** If a file with the proposed name already exists, you MUST either append the new test logic to the existing file (if logically appropriate) or generate a new unique filename by incrementing a numerical suffix (e.g., changing `-001.html` to `-002.html`) to prevent overwriting existing work.
 7. **Existing Test Expansion:** If you detect that the core assertion of the WPT test suggestion is already present in an existing test (i.e. a test perfectly matching the test suggestion exists), you MUST ensure all specification edge cases, permutations, or multi-level DOM configurations are thoroughly exercised, and expand the existing test file as necessary instead of creating a redundant new test.
@@ -92,24 +92,24 @@ Before completing the task, you MUST validate that the code you generated is syn
    - **Self-Correct:** If the runner reports a `Harness Error`, `SyntaxError`, a timeout, or a failure that indicates a flaw in your test logic (e.g., calling an undefined helper function or making an incorrect assertion), you MUST use the `replace_in_file` or `write_file` tools to fix the bug, and re-run the test. Use `replace_in_file` whenever possible.
    - Repeat this execute-and-fix loop until the test executes successfully without syntax or harness errors. **Maximum 3 attempts.** If the test still fails after 3 correction attempts, stop debugging and proceed to finalize. *(Note: If the test fails because the browser genuinely does not support the feature, that is acceptable—your goal is to ensure the **test code** itself is valid.)*
 
-{% if has_web_feature_id %}
+{% if has_feature_id %}
 ### 7. Map the Test in WEB_FEATURES.yml
-Every generated test file MUST be explicitly mapped to the target `<web_feature_id>` (from Step 1) in the directory's `WEB_FEATURES.yml` file.
+Every generated test file MUST be explicitly mapped to the target `<feature_id>` (from Step 1) in the directory's `WEB_FEATURES.yml` file.
 1. **Check for File:** Look for `WEB_FEATURES.yml` in the directory where you created or modified the test using the `list_directory` tool.
 2. **Create if Missing:** If the file does not exist, create it using the `write_file` tool with the following structure:
    ```yaml
    features:
-   - name: <web_feature_id>
+   - name: <feature_id>
      files:
      - <new_test_file_name>
    ```
-3. **Update if Existing:** If it exists, read it using `read_file` and update it using `write_file` to append your new test file name to the `files:` list under the matching `<web_feature_id>`. (If the test is already covered by an existing wildcard pattern belonging to the correct feature, you don't need to list it individually).
+3. **Update if Existing:** If it exists, read it using `read_file` and update it using `write_file` to append your new test file name to the `files:` list under the matching `<feature_id>`. (If the test is already covered by an existing wildcard pattern belonging to the correct feature, you don't need to list it individually).
 4. **Prevent Collisions (CRITICAL):** Carefully review the other web feature IDs defined in the same `WEB_FEATURES.yml` file. If another feature uses a wildcard (like `- "**"` or `- "*.html"`) that would accidentally match your newly created test file, you MUST explicitly exclude your test from that feature by adding a negation line (e.g., `- "!<new_test_file_name>"`) to its `files:` list.
 
 {% endif %}
 
-### {% if has_web_feature_id %}8{% else %}7{% endif %}. Finalizing
+### {% if has_feature_id %}8{% else %}7{% endif %}. Finalizing
 - Ensure standard WPT scripts are included properly (if applicable) using absolute paths from the root server.
 - Ensure crashtests end with `-crash.html` if creating a new crashtest file.
 - **Clean Up:** You MUST explicitly delete any temporary files you created in `.wpt-generator-tmp/` using the `delete_file` tool to ensure no temporary prototypes, scripts, or intermediate files are left behind in the repository.
-- Once the test is validated{% if has_web_feature_id %} and the `WEB_FEATURES.yml` file is mapped{% endif %}, your task is complete.
+- Once the test is validated{% if has_feature_id %} and the `WEB_FEATURES.yml` file is mapped{% endif %}, your task is complete.


### PR DESCRIPTION
release: bump version to v0.6.2

Bumps the package and library release versions to `0.6.2` across the configuration and initialization modules.

- Updates `pyproject.toml` version to `0.6.2`.
- Updates `lib/pyproject.toml` version to `0.6.2`.
- Updates `__version__` inside `wptgen/__init__.py` to `0.6.2`.

Verified locally that all lints, types, and unit tests are passing.
