### PR TITLE
chore: bump release version to v0.6.3

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wpt-gen-lib"
-version = "0.6.1"
+version = "0.6.3"
 description = "A Core Library for AI-Powered Web Platform Test Analysis"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wpt-gen"
-version = "0.6.1"
+version = "0.6.3"
 description = "A CLI Tool for AI-Powered Web Platform Test Generation"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/wptgen/__init__.py
+++ b/wptgen/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from wptgen.engine import WPTGenEngine
 from wptgen.ui import LoggingUIProvider
 
-__version__ = "0.6.1"
+__version__ = "0.6.3"
 
 
 def generate_audit_report(


### PR DESCRIPTION
release: bump version to v0.6.3

Bumps the package and library release versions to `0.6.3` across the configuration and initialization modules.

- Updates `pyproject.toml` version to `0.6.3`.
- Updates `lib/pyproject.toml` version to `0.6.3`.
- Updates `__version__` inside `wptgen/__init__.py` to `0.6.3`.

Verified locally that all lints, types, and unit tests are passing on a clean main branch.
