### PR TITLE
Validate ChromeStatus feature ID format to consist digits only

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -554,6 +554,16 @@ def test_chromestatus_command(
     mock_engine_instance.run_workflow.assert_called_once_with("12345")
 
 
+def test_chromestatus_command_invalid_id() -> None:
+    """Test that invoking chromestatus with non-digit feature_id fails."""
+    result = runner.invoke(app, ["chromestatus", "5a4321"])
+    assert result.exit_code == 1
+    assert (
+        "ChromeStatus feature ID must consist digits only"
+        in result.stdout
+    )
+
+
 def test_audit_success(
     mock_load_config: Any, mock_engine_instance: Any
 ) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -558,10 +558,7 @@ def test_chromestatus_command_invalid_id() -> None:
     """Test that invoking chromestatus with non-digit feature_id fails."""
     result = runner.invoke(app, ["chromestatus", "5a4321"])
     assert result.exit_code == 1
-    assert (
-        "ChromeStatus feature ID must consist digits only"
-        in result.stdout
-    )
+    assert "ChromeStatus feature ID must consist digits only" in result.stdout
 
 
 def test_audit_success(

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -981,6 +981,10 @@ def chromestatus_command(
     """
     ui = ctx.obj["ui"]
 
+    if not feature_id.isdigit():
+        ui.error("ChromeStatus feature ID must consist digits only.")
+        raise typer.Exit(code=1)
+
     banner = Panel(
         Align.center(
             Text.from_markup(


### PR DESCRIPTION
## Description

This PR implements feature ID format validation for the `chromestatus` command to ensure that the provided `feature_id` consists entirely of digits. If it contains non-digit characters, the command aborts immediately with a clear error message and exit code `1` using `UIProvider`.

This prevents confusing downstream failures (network/metadata/parser errors) when users mistakenly pass a web-feature ID string (like `'popover'`) to the `chromestatus` command.

## Related Issues

Resolves #531
