### PR TITLE
updates CLI reporting for eval agents

### DIFF
--- a/tests/test_phase_evaluation.py
+++ b/tests/test_phase_evaluation.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+from wptgen.agents.streaming import TokenUsage
 from wptgen.config import Config
 from wptgen.phases.evaluation import (
     ConformanceSection,
@@ -378,7 +379,7 @@ async def test_run_evaluation_writes_report_when_agent_succeeds(
 
     mock_agent = mocker.patch(
         "wptgen.phases.evaluation.evaluate_test_with_adk",
-        new=AsyncMock(return_value=agent_payload),
+        new=AsyncMock(return_value=(agent_payload, TokenUsage())),
     )
 
     report_path = await run_evaluation(
@@ -398,6 +399,8 @@ async def test_run_evaluation_writes_report_when_agent_succeeds(
     mock_agent.assert_awaited_once()
     mock_ui.on_phase_start.assert_any_call(1, "Documentation Evaluation")
     mock_ui.report_findings_summary.assert_called_once()
+    mock_ui.report_input_scope_summary.assert_called_once()
+    mock_ui.report_token_usage_actual.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -551,11 +554,11 @@ async def test_run_evaluation_with_spec_url_runs_conformance_pass(
 
     mock_doc_inputs = mocker.patch(
         "wptgen.phases.evaluation.evaluate_test_with_adk",
-        new=AsyncMock(return_value=doc_inputs_payload),
+        new=AsyncMock(return_value=(doc_inputs_payload, TokenUsage())),
     )
     mock_conformance = mocker.patch(
         "wptgen.phases.evaluation.evaluate_conformance_with_adk",
-        new=AsyncMock(return_value=conformance_payload),
+        new=AsyncMock(return_value=(conformance_payload, TokenUsage())),
     )
     mock_extract = mocker.patch(
         "wptgen.phases.evaluation._extract_requirements_for_spec",
@@ -591,6 +594,9 @@ async def test_run_evaluation_with_spec_url_runs_conformance_pass(
     mock_ui.on_phase_start.assert_any_call(1, "Documentation Evaluation")
     mock_ui.on_phase_start.assert_any_call(3, "Spec Conformance Evaluation")
     mock_ui.report_findings_summary.assert_called_once()
+    # Per-pass input-scope and token-usage summaries fire twice (one per pass).
+    assert mock_ui.report_input_scope_summary.call_count == 2
+    assert mock_ui.report_token_usage_actual.call_count == 2
 
 
 @pytest.mark.asyncio
@@ -608,14 +614,17 @@ async def test_run_evaluation_without_spec_skips_conformance(
     mocker.patch(
         "wptgen.phases.evaluation.evaluate_test_with_adk",
         new=AsyncMock(
-            return_value={
-                "findings": [],
-                "input_scope": {
-                    "files": [],
-                    "dependencies_not_read": [],
-                    "approach": "doc-inputs",
+            return_value=(
+                {
+                    "findings": [],
+                    "input_scope": {
+                        "files": [],
+                        "dependencies_not_read": [],
+                        "approach": "doc-inputs",
+                    },
                 },
-            }
+                TokenUsage(),
+            )
         ),
     )
     mock_conformance = mocker.patch(
@@ -659,14 +668,17 @@ async def test_run_evaluation_with_spec_renders_skipped_when_extraction_fails(
     mocker.patch(
         "wptgen.phases.evaluation.evaluate_test_with_adk",
         new=AsyncMock(
-            return_value={
-                "findings": [],
-                "input_scope": {
-                    "files": [],
-                    "dependencies_not_read": [],
-                    "approach": "doc-inputs",
+            return_value=(
+                {
+                    "findings": [],
+                    "input_scope": {
+                        "files": [],
+                        "dependencies_not_read": [],
+                        "approach": "doc-inputs",
+                    },
                 },
-            }
+                TokenUsage(),
+            )
         ),
     )
     mock_conformance = mocker.patch(
@@ -725,5 +737,23 @@ def test_count_findings_ignores_unknown_severity() -> None:
     ]
     counts = _count_findings(findings)
     assert counts == {"error": 0, "warn": 1, "info": 0, "nit": 0}
+
+
+def test_files_by_role_groups_input_scope_files() -> None:
+    from wptgen.phases.evaluation import _files_by_role
+
+    scope = InputScope(
+        files=[
+            InputScopeFile(path="a.md", bytes=10, role="skill"),
+            InputScopeFile(path="b.md", bytes=20, role="reading-list"),
+            InputScopeFile(path="c.md", bytes=30, role="reading-list"),
+            InputScopeFile(path="d.html", bytes=40, role="test"),
+        ],
+    )
+    assert _files_by_role(scope) == {
+        "skill": 1,
+        "reading-list": 2,
+        "test": 1,
+    }
 
 

--- a/tests/test_phase_evaluation.py
+++ b/tests/test_phase_evaluation.py
@@ -755,5 +755,3 @@ def test_files_by_role_groups_input_scope_files() -> None:
         "reading-list": 2,
         "test": 1,
     }
-
-

--- a/tests/test_phase_evaluation.py
+++ b/tests/test_phase_evaluation.py
@@ -28,6 +28,7 @@ from wptgen.phases.evaluation import (
     Finding,
     InputScope,
     InputScopeFile,
+    _count_findings,
     _payload_to_findings,
     _payload_to_input_scope,
     run_evaluation,
@@ -395,6 +396,8 @@ async def test_run_evaluation_writes_report_when_agent_succeeds(
     assert "### Finding 1 — missing charset" in contents
     assert "Approach: doc-inputs" in contents
     mock_agent.assert_awaited_once()
+    mock_ui.on_phase_start.assert_any_call(1, "Documentation Evaluation")
+    mock_ui.report_findings_summary.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -584,6 +587,10 @@ async def test_run_evaluation_with_spec_url_runs_conformance_pass(
     assert "### Conformance finding 1 — contradicts requirement" in contents
     # Skipped message should not appear.
     assert "Conformance check: skipped" not in contents
+    # Phase headers and findings summary fired for both passes.
+    mock_ui.on_phase_start.assert_any_call(1, "Documentation Evaluation")
+    mock_ui.on_phase_start.assert_any_call(3, "Spec Conformance Evaluation")
+    mock_ui.report_findings_summary.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -686,3 +693,37 @@ async def test_run_evaluation_with_spec_renders_skipped_when_extraction_fails(
     mock_conformance.assert_not_awaited()
     # Report degrades gracefully: shows "skipped" rather than half-rendered.
     assert "Conformance check: skipped (no spec provided)." in contents
+
+
+# ---------------------------------------------------------------------------
+# Findings summary + phase boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_count_findings_tallies_by_severity() -> None:
+    findings = [
+        Finding("a", "error", "L1", "e", "s", "y"),
+        Finding("b", "error", "L2", "e", "s", "y"),
+        Finding("c", "warn", "L3", "e", "s", "y"),
+        Finding("d", "info", "L4", "e", "s", "y"),
+        Finding("e", "nit", "L5", "e", "s", "y"),
+    ]
+    counts = _count_findings(findings)
+    assert counts == {"error": 2, "warn": 1, "info": 1, "nit": 1}
+
+
+def test_count_findings_empty_list_zeroes_all_severities() -> None:
+    counts = _count_findings([])
+    assert counts == {"error": 0, "warn": 0, "info": 0, "nit": 0}
+
+
+def test_count_findings_ignores_unknown_severity() -> None:
+    """Defensive: an agent that emits a typo'd severity shouldn't crash."""
+    findings = [
+        Finding("a", "fatal", "L1", "e", "s", "y"),
+        Finding("b", "warn", "L2", "e", "s", "y"),
+    ]
+    counts = _count_findings(findings)
+    assert counts == {"error": 0, "warn": 1, "info": 0, "nit": 0}
+
+

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -244,6 +244,32 @@ def test_report_findings_summary(
     assert mock_console.print.call_count == 12
 
 
+def test_report_input_scope_summary(
+    ui: RichUIProvider, mock_console: MagicMock
+) -> None:
+    """Test report_input_scope_summary semantic method."""
+    ui.report_input_scope_summary(
+        label="Documentation",
+        files_by_role={"skill": 1, "reading-list": 5, "test": 1},
+        total_bytes=28_413,
+        approximate_tokens=7_103,
+    )
+    mock_console.print.assert_called_once()
+
+
+def test_report_token_usage_actual(
+    ui: RichUIProvider, mock_console: MagicMock
+) -> None:
+    """Test report_token_usage_actual semantic method."""
+    ui.report_token_usage_actual(
+        label="Documentation",
+        prompt_tokens=12_345,
+        candidates_tokens=2_108,
+        total_tokens=14_453,
+    )
+    mock_console.print.assert_called_once()
+
+
 def test_progress_indicator(mocker: MockerFixture, ui: RichUIProvider) -> None:
     """Test that progress_indicator correctly uses rich.progress.Progress."""
     mock_progress_class = mocker.patch("wptgen.ui.Progress")

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -232,6 +232,18 @@ def test_report_generation_summary(
     assert mock_console.print.call_count == 5
 
 
+def test_report_findings_summary(
+    ui: RichUIProvider, mock_console: MagicMock
+) -> None:
+    """Test report_findings_summary semantic method."""
+    ui.report_findings_summary(
+        doc_inputs_counts={"error": 1, "warn": 2, "info": 0, "nit": 0},
+        conformance_counts={"error": 0, "warn": 1, "info": 0, "nit": 0},
+    )
+    # 2 blank-line separators + 2 section headers + 4 severity rows × 2 sections
+    assert mock_console.print.call_count == 12
+
+
 def test_progress_indicator(mocker: MockerFixture, ui: RichUIProvider) -> None:
     """Test that progress_indicator correctly uses rich.progress.Progress."""
     mock_progress_class = mocker.patch("wptgen.ui.Progress")

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -240,8 +240,9 @@ def test_report_findings_summary(
         doc_inputs_counts={"error": 1, "warn": 2, "info": 0, "nit": 0},
         conformance_counts={"error": 0, "warn": 1, "info": 0, "nit": 0},
     )
-    # 2 blank-line separators + 2 section headers + 4 severity rows × 2 sections
-    assert mock_console.print.call_count == 12
+    # 2 blank-line separators + 2 section headers
+    # + 4 severity rows (doc-inputs) + 2 severity rows (conformance)
+    assert mock_console.print.call_count == 10
 
 
 def test_report_input_scope_summary(

--- a/wptgen/agents/adk_conformance_evaluator.py
+++ b/wptgen/agents/adk_conformance_evaluator.py
@@ -28,7 +28,7 @@ from jinja2 import Environment
 
 from wptgen.agents.adk_evaluator import EVALUATOR_TOOL_ALLOWLIST
 from wptgen.agents.provider import setup_adk_environment
-from wptgen.agents.streaming import ADKStreamManager, StreamConfig
+from wptgen.agents.streaming import ADKStreamManager, StreamConfig, TokenUsage
 from wptgen.agents.tools import create_agent_tools
 from wptgen.config import SKILLS_DIR, Config
 from wptgen.ui import UIProvider
@@ -43,7 +43,7 @@ async def evaluate_conformance_with_adk(
     config: Config,
     jinja_env: Environment,
     ui: UIProvider,
-) -> dict[str, Any] | None:
+) -> tuple[dict[str, Any], TokenUsage] | None:
     """Runs the ADK Agent to judge a test file against a requirements XML.
 
     Args:
@@ -55,10 +55,11 @@ async def evaluate_conformance_with_adk(
         ui: The UI provider for logging output.
 
     Returns:
-        A dict with two keys, `findings` (a list of per-finding dicts)
-        and `input_scope` (a dict describing what was read), or None
-        if the agent did not submit a report. The phase wrapper is
-        responsible for rendering the report Markdown.
+        A `(payload, token_usage)` tuple, or None if the agent did not
+        submit a report. The payload dict has two keys, `findings` (a
+        list of per-finding dicts) and `input_scope` (a dict describing
+        what was read). The phase wrapper is responsible for rendering
+        the report Markdown.
     """
     model_string = setup_adk_environment(config)
     if config.provider.lower() == "anthropic" and not model_string.startswith(
@@ -204,7 +205,7 @@ async def evaluate_conformance_with_adk(
             )
             return None
 
-        return reported_payload[-1]
+        return reported_payload[-1], stream_manager.token_usage
 
     finally:
         await runner.close()  # type: ignore[no-untyped-call]

--- a/wptgen/agents/adk_evaluator.py
+++ b/wptgen/agents/adk_evaluator.py
@@ -27,7 +27,7 @@ from google.genai import types
 from jinja2 import Environment
 
 from wptgen.agents.provider import setup_adk_environment
-from wptgen.agents.streaming import ADKStreamManager, StreamConfig
+from wptgen.agents.streaming import ADKStreamManager, StreamConfig, TokenUsage
 from wptgen.agents.tools import create_agent_tools
 from wptgen.config import SKILLS_DIR, Config
 from wptgen.ui import UIProvider
@@ -54,7 +54,7 @@ async def evaluate_test_with_adk(
     config: Config,
     jinja_env: Environment,
     ui: UIProvider,
-) -> dict[str, Any] | None:
+) -> tuple[dict[str, Any], TokenUsage] | None:
     """Runs the ADK Agent to evaluate a single WPT test file.
 
     Args:
@@ -64,10 +64,11 @@ async def evaluate_test_with_adk(
         ui: The UI provider for logging output.
 
     Returns:
-        A dict with two keys, `findings` (a list of per-finding dicts)
-        and `input_scope` (a dict describing what was read), or None
-        if the agent did not submit a report. The phase wrapper is
-        responsible for rendering the report Markdown.
+        A `(payload, token_usage)` tuple, or None if the agent did not
+        submit a report. The payload dict has two keys, `findings` (a
+        list of per-finding dicts) and `input_scope` (a dict describing
+        what was read). The phase wrapper is responsible for rendering
+        the report Markdown.
     """
     model_string = setup_adk_environment(config)
     if config.provider.lower() == "anthropic" and not model_string.startswith(
@@ -214,7 +215,7 @@ async def evaluate_test_with_adk(
             ui.warning("Agent finished but did not submit a findings report.")
             return None
 
-        return reported_payload[-1]
+        return reported_payload[-1], stream_manager.token_usage
 
     finally:
         await runner.close()  # type: ignore[no-untyped-call]

--- a/wptgen/agents/streaming.py
+++ b/wptgen/agents/streaming.py
@@ -123,12 +123,22 @@ class StreamConfig:
     include_thoughts: bool = False
 
 
+@dataclass
+class TokenUsage:
+    """Cumulative token totals across an ADK run."""
+
+    prompt_tokens: int = 0
+    candidates_tokens: int = 0
+    total_tokens: int = 0
+
+
 class ADKStreamManager:
     """Manages the streaming of ADK events into the UI."""
 
     def __init__(self, ui: UIProvider, config: StreamConfig | None = None):
         self.ui = ui
         self.config = config or StreamConfig()
+        self.token_usage = TokenUsage()
 
     def __enter__(self) -> ADKStreamManager:
         return self
@@ -142,6 +152,18 @@ class ADKStreamManager:
         Args:
             event: The incoming ADK Event yielded by the Runner.
         """
+        usage = getattr(event, "usage_metadata", None)
+        if usage is not None:
+            self.token_usage.prompt_tokens += (
+                getattr(usage, "prompt_token_count", None) or 0
+            )
+            self.token_usage.candidates_tokens += (
+                getattr(usage, "candidates_token_count", None) or 0
+            )
+            self.token_usage.total_tokens += (
+                getattr(usage, "total_token_count", None) or 0
+            )
+
         if not event.content or not event.content.parts:
             return
 

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -24,6 +24,7 @@ from wptgen.agents.adk_conformance_evaluator import (
     evaluate_conformance_with_adk,
 )
 from wptgen.agents.adk_evaluator import evaluate_test_with_adk
+from wptgen.agents.streaming import TokenUsage
 from wptgen.agents.tools import _validate_safe_path
 from wptgen.config import (
     DEFAULT_EVALUATOR_CACHE_DIR,
@@ -225,10 +226,12 @@ async def run_evaluation(
     if not agent_result:
         return None
 
-    findings = _payload_to_findings(agent_result.get("findings", []) or [])
+    agent_payload, doc_inputs_tokens = agent_result
+    findings = _payload_to_findings(agent_payload.get("findings", []) or [])
     input_scope = _payload_to_input_scope(
-        agent_result.get("input_scope", {}) or {}
+        agent_payload.get("input_scope", {}) or {}
     )
+    _report_pass_summaries(ui, "Documentation", input_scope, doc_inputs_tokens)
 
     conformance: ConformanceSection | None = None
     if spec_url:
@@ -248,17 +251,25 @@ async def run_evaluation(
                 ui=ui,
             )
             if conformance_result:
+                conformance_payload, conformance_tokens = conformance_result
+                conformance_scope = _payload_to_input_scope(
+                    conformance_payload.get("input_scope", {}) or {}
+                )
                 conformance = ConformanceSection(
                     spec_url=spec_url,
                     findings=_payload_to_findings(
-                        conformance_result.get("findings", []) or []
+                        conformance_payload.get("findings", []) or []
                     ),
-                    input_scope=_payload_to_input_scope(
-                        conformance_result.get("input_scope", {}) or {}
-                    ),
+                    input_scope=conformance_scope,
                     requirements_xml_bytes=len(
                         requirements_xml.encode("utf-8")
                     ),
+                )
+                _report_pass_summaries(
+                    ui,
+                    "Spec conformance",
+                    conformance_scope,
+                    conformance_tokens,
                 )
 
     ui.report_findings_summary(
@@ -292,3 +303,32 @@ def _count_findings(findings: list[Finding]) -> dict[str, int]:
         if f.severity in counts:
             counts[f.severity] += 1
     return counts
+
+
+def _files_by_role(input_scope: InputScope) -> dict[str, int]:
+    """Tallies input-scope file counts grouped by role."""
+    counts: dict[str, int] = {}
+    for file in input_scope.files:
+        counts[file.role] = counts.get(file.role, 0) + 1
+    return counts
+
+
+def _report_pass_summaries(
+    ui: UIProvider,
+    label: str,
+    input_scope: InputScope,
+    tokens: TokenUsage,
+) -> None:
+    """Emits the input-scope and token-usage summaries for a finished pass."""
+    ui.report_input_scope_summary(
+        label=label,
+        files_by_role=_files_by_role(input_scope),
+        total_bytes=input_scope.total_bytes,
+        approximate_tokens=input_scope.approximate_input_tokens,
+    )
+    ui.report_token_usage_actual(
+        label=label,
+        prompt_tokens=tokens.prompt_tokens,
+        candidates_tokens=tokens.candidates_tokens,
+        total_tokens=tokens.total_tokens,
+    )

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -214,6 +214,7 @@ async def run_evaluation(
     if not test_path.is_file():
         raise FileNotFoundError(f"Test file not found: {test_path}")
 
+    ui.on_phase_start(1, "Documentation Evaluation")
     agent_result = await evaluate_test_with_adk(
         test_path=test_path,
         config=config,
@@ -238,6 +239,7 @@ async def run_evaluation(
             ui=ui,
         )
         if requirements_xml:
+            ui.on_phase_start(3, "Spec Conformance Evaluation")
             conformance_result = await evaluate_conformance_with_adk(
                 test_path=test_path,
                 requirements_xml=requirements_xml,
@@ -259,6 +261,13 @@ async def run_evaluation(
                     ),
                 )
 
+    ui.report_findings_summary(
+        doc_inputs_counts=_count_findings(findings),
+        conformance_counts=(
+            _count_findings(conformance.findings) if conformance else None
+        ),
+    )
+
     renderer = EvaluationReportRenderer()
     report_markdown = renderer.render(
         test_path=str(test_path),
@@ -274,3 +283,12 @@ async def run_evaluation(
     output_path = output_dir / f"{test_path.name}.md"
     output_path.write_text(report_markdown, encoding="utf-8")
     return output_path
+
+
+def _count_findings(findings: list[Finding]) -> dict[str, int]:
+    """Tallies findings by severity for the CLI summary."""
+    counts: dict[str, int] = {"error": 0, "warn": 0, "info": 0, "nit": 0}
+    for f in findings:
+        if f.severity in counts:
+            counts[f.severity] += 1
+    return counts

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -599,9 +599,7 @@ class RichUIProvider:
             for role, count in files_by_role.items()
             if count > 0
         ]
-        size_part = (
-            f"{total_bytes:,} bytes, ~{approximate_tokens:,} tokens"
-        )
+        size_part = f"{total_bytes:,} bytes, ~{approximate_tokens:,} tokens"
         body = ", ".join(role_parts) if role_parts else "no files read"
         self.success(f"{label} input scope: {body} ({size_part}).")
 

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -150,6 +150,22 @@ class UIProvider(Protocol):
         conformance_counts: dict[str, int] | None = None,
     ) -> None: ...
 
+    def report_input_scope_summary(
+        self,
+        label: str,
+        files_by_role: dict[str, int],
+        total_bytes: int,
+        approximate_tokens: int,
+    ) -> None: ...
+
+    def report_token_usage_actual(
+        self,
+        label: str,
+        prompt_tokens: int,
+        candidates_tokens: int,
+        total_tokens: int,
+    ) -> None: ...
+
 
 class RichUIProvider:
     """Rich-based implementation of the UIProvider protocol."""
@@ -570,6 +586,39 @@ class RichUIProvider:
             self.console.print()
             _print_section("Spec conformance findings", conformance_counts)
 
+    def report_input_scope_summary(
+        self,
+        label: str,
+        files_by_role: dict[str, int],
+        total_bytes: int,
+        approximate_tokens: int,
+    ) -> None:
+        """Displays a one-line summary of what the agent read for a pass."""
+        role_parts = [
+            f"{count} {role}{'s' if count != 1 else ''}"
+            for role, count in files_by_role.items()
+            if count > 0
+        ]
+        size_part = (
+            f"{total_bytes:,} bytes, ~{approximate_tokens:,} tokens"
+        )
+        body = ", ".join(role_parts) if role_parts else "no files read"
+        self.success(f"{label} input scope: {body} ({size_part}).")
+
+    def report_token_usage_actual(
+        self,
+        label: str,
+        prompt_tokens: int,
+        candidates_tokens: int,
+        total_tokens: int,
+    ) -> None:
+        """Displays a one-line summary of actual token spend for a pass."""
+        self.success(
+            f"{label} token usage: "
+            f"{prompt_tokens:,} input + {candidates_tokens:,} output "
+            f"= {total_tokens:,} total."
+        )
+
 
 logger = logging.getLogger("wptgen")
 
@@ -785,3 +834,36 @@ class LoggingUIProvider:
         _log_section("Findings", doc_inputs_counts)
         if conformance_counts is not None:
             _log_section("Spec conformance findings", conformance_counts)
+
+    def report_input_scope_summary(
+        self,
+        label: str,
+        files_by_role: dict[str, int],
+        total_bytes: int,
+        approximate_tokens: int,
+    ) -> None:
+        """Logs a one-line summary of what the agent read for a pass."""
+        role_parts = [
+            f"{count} {role}"
+            for role, count in files_by_role.items()
+            if count > 0
+        ]
+        body = ", ".join(role_parts) if role_parts else "no files read"
+        logger.info(
+            f"{label} input scope: {body} "
+            f"({total_bytes} bytes, ~{approximate_tokens} tokens)."
+        )
+
+    def report_token_usage_actual(
+        self,
+        label: str,
+        prompt_tokens: int,
+        candidates_tokens: int,
+        total_tokens: int,
+    ) -> None:
+        """Logs a one-line summary of actual token spend for a pass."""
+        logger.info(
+            f"{label} token usage: "
+            f"{prompt_tokens} input + {candidates_tokens} output "
+            f"= {total_tokens} total."
+        )

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -609,7 +609,7 @@ class RichUIProvider:
     ) -> None:
         """Displays a one-line summary of what the agent read for a pass."""
         role_parts = [
-            f"{count} {role}{'s' if count != 1 else ''}"
+            f'{count} {role}{"s" if count != 1 else ""}'
             for role, count in files_by_role.items()
             if count > 0
         ]
@@ -841,7 +841,7 @@ class LoggingUIProvider:
                 logger.info(f"{label}: no findings raised.")
                 return
             parts = [f"{counts.get(k, 0)} {k}" for k in severities]
-            logger.info(f"{label}: {', '.join(parts)}.")
+            logger.info(f'{label}: {", ".join(parts)}.')
 
         _log_section(
             "WPT Documentation Findings",

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -144,6 +144,12 @@ class UIProvider(Protocol):
         self, generated_tests: list[tuple[Path, str, str]]
     ) -> None: ...
 
+    def report_findings_summary(
+        self,
+        doc_inputs_counts: dict[str, int],
+        conformance_counts: dict[str, int] | None = None,
+    ) -> None: ...
+
 
 class RichUIProvider:
     """Rich-based implementation of the UIProvider protocol."""
@@ -532,6 +538,38 @@ class RichUIProvider:
         else:
             self.error("No files were successfully created.")
 
+    def report_findings_summary(
+        self,
+        doc_inputs_counts: dict[str, int],
+        conformance_counts: dict[str, int] | None = None,
+    ) -> None:
+        """Displays a summary count of evaluator findings by severity."""
+
+        def _print_section(label: str, counts: dict[str, int]) -> None:
+            self.console.print(f"[bold]{label}:[/bold]")
+            total = sum(counts.values())
+            if total == 0:
+                self.console.print("  [blue]ℹ No findings raised.[/blue]")
+                return
+            rows = [
+                ("error", "✘", "bold red"),
+                ("warn", "⚠", "yellow"),
+                ("info", "ℹ", "blue"),
+                ("nit", "•", "dim"),
+            ]
+            for key, glyph, style in rows:
+                n = counts.get(key, 0)
+                plural = "s" if n != 1 else ""
+                self.console.print(
+                    f"  [{style}]{glyph} {n} {key}{plural}[/{style}]"
+                )
+
+        self.console.print()
+        _print_section("Findings", doc_inputs_counts)
+        if conformance_counts is not None:
+            self.console.print()
+            _print_section("Spec conformance findings", conformance_counts)
+
 
 logger = logging.getLogger("wptgen")
 
@@ -725,3 +763,25 @@ class LoggingUIProvider:
     ) -> None:
         """Displays a summary table of all generated tests."""
         logger.info(f"Generated {len(generated_tests)} tests.")
+
+    def report_findings_summary(
+        self,
+        doc_inputs_counts: dict[str, int],
+        conformance_counts: dict[str, int] | None = None,
+    ) -> None:
+        """Logs a summary count of evaluator findings by severity."""
+
+        def _log_section(label: str, counts: dict[str, int]) -> None:
+            total = sum(counts.values())
+            if total == 0:
+                logger.info(f"{label}: no findings raised.")
+                return
+            parts = [
+                f"{counts.get(k, 0)} {k}"
+                for k in ("error", "warn", "info", "nit")
+            ]
+            logger.info(f"{label}: {', '.join(parts)}.")
+
+        _log_section("Findings", doc_inputs_counts)
+        if conformance_counts is not None:
+            _log_section("Spec conformance findings", conformance_counts)

--- a/wptgen/ui.py
+++ b/wptgen/ui.py
@@ -561,19 +561,25 @@ class RichUIProvider:
     ) -> None:
         """Displays a summary count of evaluator findings by severity."""
 
-        def _print_section(label: str, counts: dict[str, int]) -> None:
+        all_rows = [
+            ("error", "✘", "bold red"),
+            ("warn", "⚠", "yellow"),
+            ("info", "ℹ", "blue"),
+            ("nit", "•", "dim"),
+        ]
+
+        def _print_section(
+            label: str,
+            counts: dict[str, int],
+            severities: tuple[str, ...],
+        ) -> None:
             self.console.print(f"[bold]{label}:[/bold]")
-            total = sum(counts.values())
-            if total == 0:
+            if sum(counts.get(s, 0) for s in severities) == 0:
                 self.console.print("  [blue]ℹ No findings raised.[/blue]")
                 return
-            rows = [
-                ("error", "✘", "bold red"),
-                ("warn", "⚠", "yellow"),
-                ("info", "ℹ", "blue"),
-                ("nit", "•", "dim"),
-            ]
-            for key, glyph, style in rows:
+            for key, glyph, style in all_rows:
+                if key not in severities:
+                    continue
                 n = counts.get(key, 0)
                 plural = "s" if n != 1 else ""
                 self.console.print(
@@ -581,10 +587,18 @@ class RichUIProvider:
                 )
 
         self.console.print()
-        _print_section("Findings", doc_inputs_counts)
+        _print_section(
+            "WPT Documentation Findings",
+            doc_inputs_counts,
+            ("error", "warn", "info", "nit"),
+        )
         if conformance_counts is not None:
             self.console.print()
-            _print_section("Spec conformance findings", conformance_counts)
+            _print_section(
+                "Spec Conformance Findings",
+                conformance_counts,
+                ("error", "warn"),
+            )
 
     def report_input_scope_summary(
         self,
@@ -818,20 +832,28 @@ class LoggingUIProvider:
     ) -> None:
         """Logs a summary count of evaluator findings by severity."""
 
-        def _log_section(label: str, counts: dict[str, int]) -> None:
-            total = sum(counts.values())
-            if total == 0:
+        def _log_section(
+            label: str,
+            counts: dict[str, int],
+            severities: tuple[str, ...],
+        ) -> None:
+            if sum(counts.get(s, 0) for s in severities) == 0:
                 logger.info(f"{label}: no findings raised.")
                 return
-            parts = [
-                f"{counts.get(k, 0)} {k}"
-                for k in ("error", "warn", "info", "nit")
-            ]
+            parts = [f"{counts.get(k, 0)} {k}" for k in severities]
             logger.info(f"{label}: {', '.join(parts)}.")
 
-        _log_section("Findings", doc_inputs_counts)
+        _log_section(
+            "WPT Documentation Findings",
+            doc_inputs_counts,
+            ("error", "warn", "info", "nit"),
+        )
         if conformance_counts is not None:
-            _log_section("Spec conformance findings", conformance_counts)
+            _log_section(
+                "Spec Conformance Findings",
+                conformance_counts,
+                ("error", "warn"),
+            )
 
     def report_input_scope_summary(
         self,


### PR DESCRIPTION
Following some comments in #533, this updates the CLI output of the evaluator agents to better match the test generator's CLI UX. 

Sample output with a spec conformance check:
```
$ wpt-gen evaluate ../wpt/example-feature/my-test.html --spec https://example.spec.whatwg.org/#example-section

╭───────────────── Configuration ─────────────────╮
│ Provider:  gemini                            │
│ Model:     gemini-3.1-pro-preview                   │
│ WPT path:  ../wpt                               │
╰─────────────────────────────────────────────────╯

────────────────── Phase 1: Documentation Evaluation ──────────────────

[…agent stream output…]

✔ Documentation input scope: 1 skill, 5 reading-lists, 1 test (28,413 bytes, ~7,103 tokens).
✔ Documentation token usage: 35,210 input + 1,872 output = 37,082 total.

──────────────── Phase 2: Requirements Extraction ────────────────

ℹ Found cached requirements for spec-example-spec-whatwg-org-example-section.
✔ Using cached requirements.
✔ Extracted 18 test requirements.

────────────────── Phase 3: Spec Conformance Evaluation ──────────────────

[…agent stream output…]

✔ Spec conformance input scope: 1 skill, 1 test, 1 requirements (4,890 bytes, ~1,222 tokens).
✔ Spec conformance token usage: 8,114 input + 942 output = 9,056 total.

WPT Documentation Findings:
  ✘ 1 error
  ⚠ 2 warns
  ℹ 0 infos
  • 0 nits

Spec conformance findings:
  ✘ 0 errors
  ⚠ 1 warn

✔ Evaluation complete. Report written to: /Users/example/Dev/project/.wptgen/evaluator/outputs/my-test.html.
```
