### PR TITLE
Add CGNAT & zero-net constants, and IPv4-mapped unwrapping to context

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -40,6 +40,7 @@ from wptgen.context import (
     normalize_wpt_path,
     resolve_dependency_path,
     slug_for_spec_url,
+    validate_ip_against_ssrf,
     validate_wpt_paths,
 )
 
@@ -1101,3 +1102,26 @@ def test_slug_for_spec_url_fragments_distinguish() -> None:
     a = slug_for_spec_url("https://example.com/spec/#video")
     b = slug_for_spec_url("https://example.com/spec/#audio")
     assert a != b
+
+
+# ---------------------------------------------------------------------------
+# SSRF Protection & IP Hardening
+# ---------------------------------------------------------------------------
+
+
+def test_validate_ip_against_ssrf() -> None:
+    """Verifies restricted IP ranges raise ValueError."""
+    with pytest.raises(ValueError, match="restricted IP address"):
+        validate_ip_against_ssrf("127.0.0.1")
+    with pytest.raises(ValueError, match="restricted IP address"):
+        validate_ip_against_ssrf("10.0.0.1")
+    with pytest.raises(ValueError, match="restricted IP address"):
+        validate_ip_against_ssrf("169.254.169.254")
+    with pytest.raises(ValueError, match="restricted IP address"):
+        validate_ip_against_ssrf("100.64.0.1")
+    with pytest.raises(ValueError, match="restricted IP address"):
+        validate_ip_against_ssrf("0.0.0.0")
+    with pytest.raises(ValueError, match="restricted IP address"):
+        validate_ip_against_ssrf("::ffff:127.0.0.1")
+    validate_ip_against_ssrf("8.8.8.8")
+    validate_ip_against_ssrf("93.184.216.34")

--- a/wptgen/context.py
+++ b/wptgen/context.py
@@ -57,6 +57,16 @@ IGNORED_DEPENDENCIES = {
 MAXIMUM_TEST_SUITE_SIZE = 50
 MAXIMUM_FETCHED_DEPENDENCIES = 100
 
+# RFC 6598: Shared Address Space for Carrier-Grade NAT and cloud infrastructure.
+# https://datatracker.ietf.org/doc/html/rfc6598
+CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+
+# RFC 1122 & RFC 6890: "This network" / unspecified address block (`0.0.0.0/8`).
+# Prevents loopback bypasses where `0.x.y.z` routes to `127.0.0.1`
+# on local sockets.
+# https://datatracker.ietf.org/doc/html/rfc6890
+ZERO_NETWORK = ipaddress.ip_network("0.0.0.0/8")
+
 MDN_MAPPINGS_URL = (
     "https://raw.githubusercontent.com/web-platform-dx/"
     "web-features-mappings/main/mappings/mdn-docs.json"
@@ -212,15 +222,21 @@ def extract_feature_metadata(feature_data: dict[str, Any]) -> FeatureMetadata:
 def validate_ip_against_ssrf(ip: str) -> None:
     """Validates that an IP address is not a restricted internal address."""
     ip_obj = ipaddress.ip_address(ip)
+    if isinstance(ip_obj, ipaddress.IPv6Address) and ip_obj.ipv4_mapped:
+        ip_obj = ip_obj.ipv4_mapped
     if (
         ip_obj.is_loopback
         or ip_obj.is_private
         or ip_obj.is_link_local
         or ip_obj.is_multicast
         or ip_obj.is_reserved
+        or ip_obj.is_unspecified
         or ip == "0.0.0.0"
     ):
         raise ValueError(f"URL resolves to a restricted IP address: {ip}")
+    if isinstance(ip_obj, ipaddress.IPv4Address):
+        if ip_obj in CGNAT_NETWORK or ip_obj in ZERO_NETWORK:
+            raise ValueError(f"URL resolves to a restricted IP address: {ip}")
 
 
 class SafeHTTPConnection(http.client.HTTPConnection):


### PR DESCRIPTION
When `wptgen` is consumed by server-side web platforms like `chromestatus` (`chromium-dashboard`), those applications run in serverless environments where dynamic link checking and future AI features require socket-level IP pinning and URL syntax validation before opening connections. Enabling consuming platforms (`chromestatus`) to reuse `_ssrf_safe_opener` and `validate_url_against_ssrf` directly from `wptgen/context` prevents duplicating low-level socket interception or SSRF logic across projects.

This hardens existing socket-level IP validation across `wptgen` (`_ssrf_safe_opener` and `validate_ip_against_ssrf`):

- **RFC-Documented Network Constants**: Adds documented `CGNAT_NETWORK` (`100.64.0.0/10`, RFC 6598 Shared Address Space) and `ZERO_NETWORK` (`0.0.0.0/8`, RFC 1122/6890 unspecified address block) right at the module level so `validate_ip_against_ssrf` does not rely on magic strings when blocking cloud provider overlay routing or local socket loopback aliases (`0.x.y.z`).
- **Hardened `validate_ip_against_ssrf(ip)`**: Unwraps `.ipv4_mapped` IPv6 addresses (`::ffff:127.0.0.1` -> `127.0.0.1`) right before inspection so dual-stack sockets (`IPV6_V6ONLY=0`) cannot bypass loopback checks. Checks `.is_unspecified`, `CGNAT_NETWORK`, and `ZERO_NETWORK` alongside existing loopback, private, link-local, multicast, and reserved ranges.

This change is 100% additive and backwards-compatible (`16 lines of code in context.py`), leaving existing `__all__` exports and function signatures completely untouched.