### PR TITLE
adds multi-spec support to conformance eval agent

### DIFF
--- a/tests/test_phase_evaluation.py
+++ b/tests/test_phase_evaluation.py
@@ -21,9 +21,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+from wptgen.agents.adk_conformance_evaluator import SpecRequirements
 from wptgen.agents.adk_evaluator import EvaluatorStrategy
 from wptgen.agents.streaming import TokenUsage
-from wptgen.config import Config
+from wptgen.config import DEFAULT_EVALUATOR_CACHE_DIR, Config
+from wptgen.context import slug_for_spec_url
 from wptgen.phases.evaluation import (
     ConformanceSection,
     EvaluationReportRenderer,
@@ -413,10 +415,14 @@ def test_render_conformance_with_findings() -> None:
     """A conformance section with findings renders them in their own block."""
     renderer = EvaluationReportRenderer()
     conformance = ConformanceSection(
-        spec_url="https://drafts.csswg.org/css-flexbox/",
+        specs=[
+            SpecRequirements(
+                spec_url="https://drafts.csswg.org/css-flexbox/",
+                requirements_xml="x" * 12_345,
+            )
+        ],
         findings=[_conformance_finding()],
         input_scope=InputScope(strategy=EvaluatorStrategy.DISTILLED),
-        requirements_xml_bytes=12_345,
     )
     report = renderer.render(
         test_path="wpt/foo/bar.html",
@@ -439,10 +445,14 @@ def test_render_conformance_empty_findings_fallback() -> None:
     """Empty conformance findings show the no-findings fallback in the section."""
     renderer = EvaluationReportRenderer()
     conformance = ConformanceSection(
-        spec_url="https://drafts.csswg.org/css-flexbox/",
+        specs=[
+            SpecRequirements(
+                spec_url="https://drafts.csswg.org/css-flexbox/",
+                requirements_xml="x" * 2_048,
+            )
+        ],
         findings=[],
         input_scope=InputScope(strategy=EvaluatorStrategy.DISTILLED),
-        requirements_xml_bytes=2_048,
     )
     report = renderer.render(
         test_path="wpt/foo/bar.html",
@@ -515,7 +525,7 @@ async def test_run_evaluation_with_spec_url_runs_conformance_pass(
         config=evaluation_config,
         jinja_env=MagicMock(),
         ui=mock_ui,
-        spec_url="https://drafts.csswg.org/css-flexbox/",
+        spec_urls=["https://drafts.csswg.org/css-flexbox/"],
     )
 
     assert report_path is not None
@@ -536,11 +546,217 @@ async def test_run_evaluation_with_spec_url_runs_conformance_pass(
     assert "Conformance check: skipped" not in contents
     # Phase headers and findings summary fired for both passes.
     mock_ui.on_phase_start.assert_any_call(1, "Documentation Evaluation")
-    mock_ui.on_phase_start.assert_any_call(3, "Spec Conformance Evaluation")
+    mock_ui.on_phase_start.assert_any_call(
+        3,
+        "Spec Conformance Evaluation "
+        "(https://drafts.csswg.org/css-flexbox/)",
+    )
     mock_ui.report_findings_summary.assert_called_once()
     # Per-pass input-scope and token-usage summaries fire twice (one per pass).
     assert mock_ui.report_input_scope_summary.call_count == 2
     assert mock_ui.report_token_usage_actual.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_evaluation_multiple_specs_judged_in_one_pass(
+    wpt_root_with_test: tuple[Path, Path],
+    evaluation_config: Config,
+    mock_ui: MagicMock,
+    tmp_path: Path,
+    mocker: MockerFixture,
+) -> None:
+    """Requirements are extracted per spec, but a single conformance pass
+    judges the test against every spec at once (both in the agent's
+    context), attributing findings back to each spec."""
+    _, test_path = wpt_root_with_test
+    output_dir = tmp_path / "out"
+
+    doc_inputs_payload = {
+        "findings": [],
+        "input_scope": {
+            "files": [],
+            "dependencies_not_read": [],
+            "strategy": "raw",
+        },
+    }
+
+    spec_a = "https://drafts.csswg.org/css-flexbox/"
+    spec_b = "https://drafts.csswg.org/css-grid/"
+
+    # One conformance pass returns findings attributed to both specs.
+    conformance_payload = {
+        "findings": [
+            {
+                "title": "contradicts flexbox",
+                "severity": "error",
+                "test_line": "Line 12",
+                "evidence": "assert_equals(x, 'wrong')",
+                "source": f"{spec_a}#R1",
+                "summary": "flexbox disagrees.",
+            },
+            {
+                "title": "contradicts grid",
+                "severity": "warn",
+                "test_line": "Line 20",
+                "evidence": "assert_true(y)",
+                "source": f"{spec_b}#R4",
+                "summary": "grid disagrees.",
+            },
+        ],
+        "input_scope": {
+            "files": [],
+            "dependencies_not_read": [],
+            "strategy": "distilled",
+        },
+    }
+
+    mock_doc_inputs = mocker.patch(
+        "wptgen.phases.evaluation.evaluate_test_with_adk",
+        new=AsyncMock(return_value=(doc_inputs_payload, TokenUsage())),
+    )
+    mock_conformance = mocker.patch(
+        "wptgen.phases.evaluation.evaluate_conformance_with_adk",
+        new=AsyncMock(return_value=(conformance_payload, TokenUsage())),
+    )
+    # Extraction still runs per spec, returning a distinct doc for each.
+    mock_extract = mocker.patch(
+        "wptgen.phases.evaluation._extract_requirements_for_spec",
+        new=AsyncMock(side_effect=["<requirements a/>", "<requirements b/>"]),
+    )
+
+    report_path = await run_evaluation(
+        test_path=test_path,
+        output_dir=output_dir,
+        config=evaluation_config,
+        jinja_env=MagicMock(),
+        ui=mock_ui,
+        spec_urls=[spec_a, spec_b],
+    )
+
+    assert report_path is not None
+    contents = report_path.read_text(encoding="utf-8")
+
+    # Extraction per spec, but only ONE conformance pass over both.
+    mock_doc_inputs.assert_awaited_once()
+    assert mock_extract.await_count == 2
+    mock_conformance.assert_awaited_once()
+
+    # The single conformance call received both specs, each with its own XML.
+    passed_specs = mock_conformance.await_args_list[0].kwargs["specs"]
+    assert [s.spec_url for s in passed_specs] == [spec_a, spec_b]
+    assert passed_specs[0].requirements_xml == "<requirements a/>"
+    assert passed_specs[1].requirements_xml == "<requirements b/>"
+
+    # One conformance section lists both specs and both attributed findings.
+    assert f"**Spec**: {spec_a}" in contents
+    assert f"**Spec**: {spec_b}" in contents
+    assert "contradicts flexbox" in contents
+    assert "contradicts grid" in contents
+    assert f"**Source**: `{spec_a}#R1`" in contents
+    assert f"**Source**: `{spec_b}#R4`" in contents
+    assert "Conformance check: skipped" not in contents
+
+    # A single conformance phase header fired, labeled with both specs.
+    mock_ui.on_phase_start.assert_any_call(
+        3, f"Spec Conformance Evaluation ({spec_a}, {spec_b})"
+    )
+    mock_ui.report_findings_summary.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_evaluation_multi_spec_pulls_each_spec_from_cache(
+    wpt_root_with_test: tuple[Path, Path],
+    evaluation_config: Config,
+    mock_ui: MagicMock,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    """With two specs cached, each conformance pass gets *its own* cached XML."""
+    _, test_path = wpt_root_with_test
+    output_dir = tmp_path / "out"
+
+    spec_a = "https://drafts.csswg.org/css-flexbox/"
+    spec_b = "https://drafts.csswg.org/css-grid/"
+    xml_a = '<requirements_list><requirement id="A1"/></requirements_list>'
+    xml_b = '<requirements_list><requirement id="B1"/></requirements_list>'
+
+    # run_evaluation resolves the cache dir relative to cwd; write the cache
+    # files there under the real spec-slug names so a slug change breaks this.
+    monkeypatch.chdir(tmp_path)
+    cache_dir = tmp_path / DEFAULT_EVALUATOR_CACHE_DIR
+    cache_dir.mkdir(parents=True)
+    for url, xml in ((spec_a, xml_a), (spec_b, xml_b)):
+        cache_file = cache_dir / f"{slug_for_spec_url(url)}__requirements.xml"
+        cache_file.write_text(xml, encoding="utf-8")
+
+    # Auto-accept the cache so no UI prompt is needed for the hit.
+    evaluation_config.yes_cache = True
+
+    mocker.patch(
+        "wptgen.phases.evaluation.evaluate_test_with_adk",
+        new=AsyncMock(
+            return_value=(
+                {
+                    "findings": [],
+                    "input_scope": {
+                        "files": [],
+                        "dependencies_not_read": [],
+                        "strategy": "raw",
+                    },
+                },
+                TokenUsage(),
+            )
+        ),
+    )
+    # Spec text is per-URL, but it must never reach the LLM: the cache hits.
+    mocker.patch(
+        "wptgen.phases.evaluation.fetch_and_slice_spec",
+        return_value="spec text",
+    )
+    mocker.patch(
+        "wptgen.phases.evaluation.get_llm_client",
+        return_value=MagicMock(),
+    )
+    # The extractor LLM. If a cache lookup misses, this fires — and we assert
+    # it does not.
+    mock_generate = mocker.patch(
+        "wptgen.phases.utils.generate_safe",
+        new=AsyncMock(return_value="<should-not-be-used/>"),
+    )
+
+    conformance_payload = {
+        "findings": [],
+        "input_scope": {
+            "files": [],
+            "dependencies_not_read": [],
+            "strategy": "distilled",
+        },
+    }
+    mock_conformance = mocker.patch(
+        "wptgen.phases.evaluation.evaluate_conformance_with_adk",
+        new=AsyncMock(return_value=(conformance_payload, TokenUsage())),
+    )
+
+    report_path = await run_evaluation(
+        test_path=test_path,
+        output_dir=output_dir,
+        config=evaluation_config,
+        jinja_env=MagicMock(),
+        ui=mock_ui,
+        spec_urls=[spec_a, spec_b],
+    )
+
+    assert report_path is not None
+    # The cache satisfied both extractions — the extractor LLM never ran.
+    mock_generate.assert_not_awaited()
+
+    # The single conformance pass received each spec's own cached XML, keyed
+    # to the right spec (a cross-spec cache collision would swap these).
+    mock_conformance.assert_awaited_once()
+    passed_specs = mock_conformance.await_args_list[0].kwargs["specs"]
+    by_url = {s.spec_url: s.requirements_xml for s in passed_specs}
+    assert by_url == {spec_a: xml_a, spec_b: xml_b}
 
 
 @pytest.mark.asyncio
@@ -551,7 +767,7 @@ async def test_run_evaluation_without_spec_skips_conformance(
     tmp_path: Path,
     mocker: MockerFixture,
 ) -> None:
-    """Without spec_url, neither extraction nor conformance agent runs."""
+    """Without spec_urls, neither extraction nor conformance agent runs."""
     _, test_path = wpt_root_with_test
     output_dir = tmp_path / "out"
 
@@ -586,7 +802,7 @@ async def test_run_evaluation_without_spec_skips_conformance(
         config=evaluation_config,
         jinja_env=MagicMock(),
         ui=mock_ui,
-        spec_url=None,
+        spec_urls=None,
     )
 
     assert report_path is not None
@@ -640,7 +856,7 @@ async def test_run_evaluation_with_spec_renders_skipped_when_extraction_fails(
         config=evaluation_config,
         jinja_env=MagicMock(),
         ui=mock_ui,
-        spec_url="https://drafts.csswg.org/css-flexbox/",
+        spec_urls=["https://drafts.csswg.org/css-flexbox/"],
     )
 
     assert report_path is not None

--- a/wptgen/agents/adk_conformance_evaluator.py
+++ b/wptgen/agents/adk_conformance_evaluator.py
@@ -14,6 +14,7 @@
 """Agentic spec-conformance evaluation using the Google ADK framework."""
 
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -34,22 +35,39 @@ from wptgen.config import SKILLS_DIR, Config
 from wptgen.ui import UIProvider
 
 # Re-exported so both evaluators share one read-only allowlist
-__all__ = ["EVALUATOR_TOOL_ALLOWLIST", "evaluate_conformance_with_adk"]
+__all__ = [
+    "EVALUATOR_TOOL_ALLOWLIST",
+    "SpecRequirements",
+    "evaluate_conformance_with_adk",
+]
+
+
+@dataclass
+class SpecRequirements:
+    """One spec's extracted requirements, kept separate but attributed."""
+
+    spec_url: str
+    requirements_xml: str
+
+    @property
+    def requirements_xml_bytes(self) -> int:
+        return len(self.requirements_xml.encode("utf-8"))
 
 
 async def evaluate_conformance_with_adk(
     test_path: Path,
-    requirements_xml: str,
+    specs: list[SpecRequirements],
     config: Config,
     jinja_env: Environment,
     ui: UIProvider,
 ) -> tuple[dict[str, Any], TokenUsage] | None:
-    """Runs the ADK Agent to judge a test file against a requirements XML.
+    """Runs the ADK Agent to judge a test file against one or more specs.
 
     Args:
         test_path: Path to the test file under evaluation.
-        requirements_xml: The <requirements_list> XML produced by the
-            requirements extraction phase.
+        specs: The governing specs to judge against, each carrying its own
+            <requirements_list> XML (produced by the requirements
+            extraction phase) and its source URL.
         config: The configuration object.
         jinja_env: The Jinja2 environment for loading templates.
         ui: The UI provider for logging output.
@@ -91,9 +109,11 @@ async def evaluate_conformance_with_adk(
                 fields `title` (short description), `severity` (one of
                 "error" or "warn"), `test_line` (a line reference into
                 the test file), `evidence` (the assertion in question),
-                `source` (e.g. `requirements.xml#R3` or
-                `requirements.xml#none-matched`), and `summary` (a
-                one-sentence paraphrase of the contradiction or gap).
+                `source` (the concerned spec's URL plus the requirement
+                id, e.g. `https://drafts.csswg.org/css-flexbox/#R3`, so
+                each finding is attributed to the spec it came from), and
+                `summary` (a one-sentence paraphrase of the contradiction
+                or gap).
             input_scope: An object describing what was loaded, with the
                 fields `files` (a list of `{path, bytes, role}` rows
                 where `role` is one of "skill", "test", "requirements",
@@ -183,7 +203,7 @@ async def evaluate_conformance_with_adk(
     prompt_template = jinja_env.get_template("adk_conformance_evaluator.jinja")
     prompt = prompt_template.render(
         test_path=str(test_path),
-        requirements_xml=requirements_xml,
+        specs=specs,
     )
     content = types.Content(role="user", parts=[types.Part(text=prompt)])
 

--- a/wptgen/main.py
+++ b/wptgen/main.py
@@ -887,16 +887,25 @@ def evaluate(
             resolve_path=True,
         ),
     ] = None,
+    spec_urls: Annotated[
+        str | None,
+        typer.Option(
+            "--spec-urls",
+            "-u",
+            help=(
+                "Comma-separated list of governing specification URLs. When "
+                "provided, a conformance pass runs per spec: it extracts "
+                "normative requirements and judges the test's assertions "
+                "against them, producing one conformance section per spec."
+            ),
+        ),
+    ] = None,
     spec_url: Annotated[
         str | None,
         typer.Option(
-            "--spec",
+            "--spec-url",
             "-s",
-            help=(
-                "URL of the governing specification. When provided, a "
-                "conformance pass extracts normative requirements from "
-                "the spec and judges the test's assertions against them."
-            ),
+            help="A single specification URL for convenience.",
         ),
     ] = None,
     strategy: Annotated[
@@ -925,6 +934,20 @@ def evaluate(
     ui = ctx.obj["ui"]
 
     with _workflow_error_handler(ui):
+        if spec_urls and spec_url:
+            ui.print(
+                "[red]Error: Cannot provide both --spec-urls and --spec-url. "
+                "Please use only one.[/red]"
+            )
+            raise typer.Exit(code=1)
+
+        # Parse spec_urls if provided
+        spec_urls_list = None
+        if spec_url:
+            spec_urls_list = [spec_url.strip()]
+        elif spec_urls:
+            spec_urls_list = [u.strip() for u in spec_urls.split(",")]
+
         config = load_config(
             config_path=config_path,
             provider_override=provider,
@@ -943,7 +966,7 @@ def evaluate(
                 config=config,
                 jinja_env=engine.jinja_env,
                 ui=engine.ui,
-                spec_url=spec_url,
+                spec_urls=spec_urls_list,
                 strategy=strategy,
             )
         )

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -21,6 +21,7 @@ from typing import Any
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 from wptgen.agents.adk_conformance_evaluator import (
+    SpecRequirements,
     evaluate_conformance_with_adk,
 )
 from wptgen.agents.adk_evaluator import (
@@ -89,12 +90,16 @@ class InputScope:
 
 @dataclass
 class ConformanceSection:
-    """Conformance pass results, rendered as a distinct section."""
+    """Conformance pass results, rendered as a distinct section.
 
-    spec_url: str
+    A single judging pass covers every governing spec at once, so `specs`
+    lists each spec that was judged and `findings` are attributed back to a
+    spec via each finding's `source`.
+    """
+
+    specs: list[SpecRequirements]
     findings: list[Finding]
     input_scope: InputScope
-    requirements_xml_bytes: int
 
 
 class EvaluationReportRenderer:
@@ -192,13 +197,84 @@ async def _extract_requirements_for_spec(
     )
 
 
+async def _gather_spec_requirements(
+    spec_urls: list[str],
+    config: Config,
+    jinja_env: Environment,
+    ui: UIProvider,
+) -> list[SpecRequirements]:
+    """Extracts (and caches) requirements for each spec, one at a time.
+
+    Extraction stays per-spec so each spec keeps its own cached requirements
+    XML. A spec that cannot be fetched or extracted is skipped (one bad spec
+    does not sink the rest).
+    """
+    gathered: list[SpecRequirements] = []
+    for spec_url in spec_urls:
+        requirements_xml = await _extract_requirements_for_spec(
+            spec_url=spec_url,
+            config=config,
+            jinja_env=jinja_env,
+            ui=ui,
+        )
+        if requirements_xml:
+            gathered.append(
+                SpecRequirements(
+                    spec_url=spec_url, requirements_xml=requirements_xml
+                )
+            )
+    return gathered
+
+
+async def _run_conformance(
+    specs: list[SpecRequirements],
+    test_path: Path,
+    config: Config,
+    jinja_env: Environment,
+    ui: UIProvider,
+) -> ConformanceSection | None:
+    """Judges the test against every spec in a single conformance pass."""
+    if not specs:
+        return None
+
+    label = ", ".join(s.spec_url for s in specs)
+    ui.on_phase_start(3, f"Spec Conformance Evaluation ({label})")
+    conformance_result = await evaluate_conformance_with_adk(
+        test_path=test_path,
+        specs=specs,
+        config=config,
+        jinja_env=jinja_env,
+        ui=ui,
+    )
+    if not conformance_result:
+        return None
+
+    conformance_payload, conformance_tokens = conformance_result
+    conformance_scope = _payload_to_input_scope(
+        conformance_payload.get("input_scope", {}) or {}
+    )
+    _report_pass_summaries(
+        ui,
+        "Spec conformance",
+        conformance_scope,
+        conformance_tokens,
+    )
+    return ConformanceSection(
+        specs=specs,
+        findings=_payload_to_findings(
+            conformance_payload.get("findings", []) or []
+        ),
+        input_scope=conformance_scope,
+    )
+
+
 async def run_evaluation(
     test_path: Path,
     output_dir: Path | None,
     config: Config,
     jinja_env: Environment,
     ui: UIProvider,
-    spec_url: str | None = None,
+    spec_urls: list[str] | None = None,
     strategy: EvaluatorStrategy = DEFAULT_EVALUATOR_STRATEGY,
 ) -> Path | None:
     """Evaluates a single WPT test file.
@@ -212,10 +288,11 @@ async def run_evaluation(
         jinja_env: The Jinja2 environment (used for agent prompt rendering;
             the report renderer instantiates its own environment).
         ui: The UI provider.
-        spec_url: Optional URL of the governing specification. When
-            provided, a second conformance pass extracts requirements
-            from the spec and judges the test's assertions against
-            them. When None, only the documentation pass runs.
+        spec_urls: Optional URLs of the governing specification(s). When
+            provided, a conformance pass runs per spec: each spec's
+            normative requirements are extracted and the test's assertions
+            judged against them, producing one conformance section per
+            spec. When None or empty, only the documentation pass runs.
         strategy: Which evaluator strategy to use for the documentation
             pass — `"distilled"` (default; judges against the distilled
             rules corpus) or `"raw"` (reads the curated upstream docs
@@ -253,43 +330,17 @@ async def run_evaluation(
     _report_pass_summaries(ui, "Documentation", input_scope, doc_inputs_tokens)
 
     conformance: ConformanceSection | None = None
-    if spec_url:
-        requirements_xml = await _extract_requirements_for_spec(
-            spec_url=spec_url,
+    specs = await _gather_spec_requirements(
+        spec_urls or [], config, jinja_env, ui
+    )
+    if specs:
+        conformance = await _run_conformance(
+            specs=specs,
+            test_path=test_path,
             config=config,
             jinja_env=jinja_env,
             ui=ui,
         )
-        if requirements_xml:
-            ui.on_phase_start(3, "Spec Conformance Evaluation")
-            conformance_result = await evaluate_conformance_with_adk(
-                test_path=test_path,
-                requirements_xml=requirements_xml,
-                config=config,
-                jinja_env=jinja_env,
-                ui=ui,
-            )
-            if conformance_result:
-                conformance_payload, conformance_tokens = conformance_result
-                conformance_scope = _payload_to_input_scope(
-                    conformance_payload.get("input_scope", {}) or {}
-                )
-                conformance = ConformanceSection(
-                    spec_url=spec_url,
-                    findings=_payload_to_findings(
-                        conformance_payload.get("findings", []) or []
-                    ),
-                    input_scope=conformance_scope,
-                    requirements_xml_bytes=len(
-                        requirements_xml.encode("utf-8")
-                    ),
-                )
-                _report_pass_summaries(
-                    ui,
-                    "Spec conformance",
-                    conformance_scope,
-                    conformance_tokens,
-                )
 
     ui.report_findings_summary(
         doc_inputs_counts=_count_findings(findings),

--- a/wptgen/templates/adk_conformance_evaluator.jinja
+++ b/wptgen/templates/adk_conformance_evaluator.jinja
@@ -1,14 +1,20 @@
-Evaluate the WPT test file at the path below for conformance against the normative requirements provided. Rigorously follow all instructions in the wpt-evaluator-conformance skill.
+Evaluate the WPT test file at the path below for conformance against the normative requirements of every governing specification provided. Rigorously follow all instructions in the wpt-evaluator-conformance skill.
+
+Consider the specifications together: an assertion may satisfy one spec while diverging from another, and requirements from different specs may overlap or interact. Judge the test holistically rather than one spec at a time.
 
 <test_file>{{ test_path }}</test_file>
 
+{% for spec in specs %}
+<spec url="{{ spec.spec_url }}">
 <requirements_list>
-{{ requirements_xml }}
+{{ spec.requirements_xml }}
 </requirements_list>
+</spec>
+{% endfor %}
 
 When the evaluation is complete, submit your findings via the `report_conformance_complete` tool. Pass:
 
-- `findings`: a list of finding objects (one per issue raised). Each finding must include the fields `title`, `severity`, `test_line`, `evidence`, `source`, and `summary` as described in the tool's parameter spec. Use only the severities `error` (contradicts a requirement) and `warn` (assertion on behavior not in the requirements). If you found no issues, pass an empty list.
+- `findings`: a list of finding objects (one per issue raised). Each finding must include the fields `title`, `severity`, `test_line`, `evidence`, `source`, and `summary` as described in the tool's parameter spec. Use only the severities `error` (contradicts a requirement) and `warn` (assertion on behavior not in the requirements). Attribute each finding to the spec it concerns: set `source` to that spec's URL followed by the requirement id, e.g. `https://drafts.csswg.org/css-flexbox/#R3`. If you found no issues, pass an empty list.
 - `input_scope`: an object describing every file you opened during the evaluation. Include `files` (a list of `{path, bytes, role}` rows; roles are `skill`, `test`, `requirements`, or `dependency`), `dependencies_not_read` (framework + external dependencies you detected but did not open), and `strategy` (set to `"distilled"` — conformance judges against the distilled requirements).
 
 Do NOT format the report yourself; the wpt-gen CLI renders the final Markdown from the data you submit. Do NOT write any file to disk.

--- a/wptgen/templates/evaluator_report.jinja
+++ b/wptgen/templates/evaluator_report.jinja
@@ -29,9 +29,10 @@ No findings raised.
 ## Spec conformance
 
 {% if conformance -%}
-- **Spec**: {{ conformance.spec_url }}
-- **Requirements XML**: {{ "{:,}".format(conformance.requirements_xml_bytes) }} bytes
-
+{% for spec in conformance.specs -%}
+- **Spec**: {{ spec.spec_url }}
+- **Requirements XML**: {{ "{:,}".format(spec.requirements_xml_bytes) }} bytes
+{% endfor %}
 {% if conformance.findings -%}
 {% for f in conformance.findings -%}
 ### Conformance finding {{ loop.index }} — {{ f.title }}


### PR DESCRIPTION
Extends `wpt-gen evaluate` to accept **multiple governing specs** for the conformance pass. A single conformance agent judges the test against **all specs at once** — each spec's requirements stay separate and attributed, but the agent sees them together so it can reason across them.

### CLI

Tweaks CLI to mirror the `generate` conventions:

- `--spec-urls` / `-u` — comma-separated list of spec URLs
- `--spec-url` / `-s` — single-URL convenience (mutually exclusive with `--spec-urls`)

### Behavior

- **Requirements extraction stays per-spec**: each spec's normative requirements are extracted and cached separately (keyed by spec-URL slug).
- One failing spec (fetch/extraction error) is skipped rather than aborting the others.
- The report has a single conformance section listing every spec judged, with the attributed findings.
