### PR TITLE
fix(packaging): include templates and skills in wpt-gen-lib package data

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -63,3 +63,11 @@ packages = ["wptgen"]
 
 [tool.setuptools.package-dir]
 "wptgen" = "../wptgen"
+
+[tool.setuptools.package-data]
+wptgen = [
+    "templates/*.jinja",
+    "templates/*.xml",
+    "templates/*.txt",
+    "skills/**/*"
+]

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -58,11 +58,9 @@ dependencies = [
     "pyyaml>=6.0.3",
 ]
 
-[tool.setuptools]
-packages = ["wptgen"]
-
-[tool.setuptools.package-dir]
-"wptgen" = "../wptgen"
+[tool.setuptools.packages.find]
+where = [".."]
+include = ["wptgen*"]
 
 [tool.setuptools.package-data]
 wptgen = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ wptgen = [
     "templates/*.jinja",
     "templates/*.xml",
     "templates/*.txt",
-    "skills/wpt-generator/**/*"
+    "skills/**/*"
 ]
 
 [tool.black]

--- a/scripts/check_pyproject.py
+++ b/scripts/check_pyproject.py
@@ -87,6 +87,19 @@ def main():
 
         sys.exit(1)
 
+    # Compare setuptools package-data
+    root_pkg_data = (
+        root_data.get("tool", {}).get("setuptools", {}).get("package-data", {})
+    )
+    lib_pkg_data = (
+        lib_data.get("tool", {}).get("setuptools", {}).get("package-data", {})
+    )
+    if root_pkg_data != lib_pkg_data:
+        print("Error: package-data in pyproject.toml files is out of sync!")
+        print(f"Root package-data: {root_pkg_data}")
+        print(f"Lib package-data: {lib_pkg_data}")
+        sys.exit(1)
+
     print(
         "Success: pyproject.toml files are in sync (apart from expected differences)."
     )

--- a/scripts/check_pyproject.py
+++ b/scripts/check_pyproject.py
@@ -87,6 +87,29 @@ def main():
 
         sys.exit(1)
 
+    # Compare setuptools packages.find include
+    root_pkg_find = (
+        root_data.get("tool", {})
+        .get("setuptools", {})
+        .get("packages", {})
+        .get("find", {})
+        .get("include", [])
+    )
+    lib_pkg_find = (
+        lib_data.get("tool", {})
+        .get("setuptools", {})
+        .get("packages", {})
+        .get("find", {})
+        .get("include", [])
+    )
+    if root_pkg_find != lib_pkg_find:
+        print(
+            "Error: packages.find.include in pyproject.toml files is out of sync!"
+        )
+        print(f"Root packages.find.include: {root_pkg_find}")
+        print(f"Lib packages.find.include: {lib_pkg_find}")
+        sys.exit(1)
+
     # Compare setuptools package-data
     root_pkg_data = (
         root_data.get("tool", {}).get("setuptools", {}).get("package-data", {})


### PR DESCRIPTION
### Summary
Fixes two packaging bugs in `wpt-gen-lib` where Jinja templates, skills, and Python subpackages were omitted from distribution packages, leading to runtime errors when `wpt-gen-lib` is used (e.g. in Chromestatus).

### Issues Fixed
1. **Missing Jinja Templates & Skills**: `'requirements_extraction_categorized.jinja' not found in search path: '/.../site-packages/wptgen/templates'`
2. **Missing Python Subpackages**: `ModuleNotFoundError: No module named 'wptgen.phases'`

### Changes
1. **`lib/pyproject.toml`**:
   - Added `[tool.setuptools.package-data]` so setuptools includes all template files (`*.jinja`, `*.xml`, `*.txt`) and skill assets (`skills/**/*`) in `wpt-gen-lib` wheel distributions.
   - Replaced static `packages = ["wptgen"]` with `[tool.setuptools.packages.find]` (`where = [".."]`, `include = ["wptgen*"]`) so subpackages (`wptgen.phases`, `wptgen.agents`) are included in wheels.
2. **`pyproject.toml`**: Updated package data pattern from `skills/wpt-generator/**/*` to `skills/**/*` to ensure all skills (including evaluator skills) are included recursively.
3. **`scripts/check_pyproject.py`**: Added verification for `tool.setuptools.package-data` and `tool.setuptools.packages.find.include` synchronization between `pyproject.toml` and `lib/pyproject.toml` during `make check`.
