### PR TITLE
Adds a helper script and initial set of "consistency corpus" of WPT's for benchmarking

### DIFF
--- a/benchmarks/manifest.yaml
+++ b/benchmarks/manifest.yaml
@@ -22,25 +22,111 @@ wpt_upstream_commit: f5a7deaba2bffac7a534dfafaa3baf14b9a253cf
 
 # --- Consistency corpus ---------------------------------------------------
 # Real merged wpt files, referenced by path inside the checkout. No gold
-# labels: these measure run-to-run variance only. Deliberately a mix of tidy
-# and messy files — judge variance on messy files is the signal.
+# labels: these measure run-to-run variance only.
 #
-# NOTE: this is a proof-of-concept slice, not a stratified 20-40 file
-# corpus. The full set will get selected by a script
-# (maintainer-reviewed, then pinned here).
+# Provenance: suggested by scripts/benchmark/select_corpus.py (stratified by
+# kind), then maintainer-reviewed.
 corpus:
-  - id: corpus-layout-instability-clipped-rect
-    path: layout-instability/partially-clipped-visual-rect.html
-    # Ambiguous between testharness and visual — deliberately included so the
-    # corpus exercises the evaluator's own kind detection (the `kind` field
-    # here is only metadata for filtering, not a hint to the agent).
+  # -- testharness (8) --
+  - id: corpus-css-cssom-insertRule-import-no-index
+    path: css/cssom/insertRule-import-no-index.html
+    kind: testharness
+  - id: corpus-device-bound-session-credentials-multiple-registrations
+    path: device-bound-session-credentials/multiple-registrations.https.html
+    kind: testharness
+  - id: corpus-api-headers-headers-errors
+    path: fetch/api/headers/headers-errors.any.js
+    kind: testharness
+  - id: corpus-tentative-descendant-navigation-simple-descendant-test
+    path: html/interaction/focus/focusgroup/tentative/descendant-navigation/simple-descendant-test.html
+    kind: testharness
+  - id: corpus-html-elements-in-shadow-trees-html-forms-test-002
+    path: shadow-dom/untriaged/html-elements-in-shadow-trees/html-forms/test-002.html
+    kind: testharness
+  - id: corpus-trusted-types-trusted-types-from-literal
+    path: trusted-types/trusted-types-from-literal.tentative.html
+    kind: testharness
+  - id: corpus-url-data-uri-fragment
+    path: url/data-uri-fragment.html
+    kind: testharness
+  - id: corpus-web-share-share-file-url-with-base-tag
+    path: web-share/share-file-url-with-base-tag.https.html
     kind: testharness
 
-  - id: corpus-background-sync-idlharness
-    path: background-sync/idlharness.https.any.js
-    # idlharness `.https.any.js` — exercises idl detection plus the
-    # `.any.js` / `.https` filename-flag parsing that no other entry hits.
+  # -- reftest (6) --
+  - id: corpus-CSS2-tables-table-anonymous-objects-110
+    path: css/CSS2/tables/table-anonymous-objects-110.xht
+    kind: reftest
+  - id: corpus-html-ruby-extensions-html-ruby-016
+    path: html-ruby-extensions/html-ruby-016.html
+    kind: reftest
+  - id: corpus-the-select-element-customizable-select-select-picker-pseudo-selection
+    path: html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-selection.html
+    kind: reftest
+  - id: corpus-png-apng-fcTL-dispose-background-final
+    path: png/apng/fcTL-dispose-background-final.html
+    kind: reftest
+  - id: corpus-shadow-dom-slot-fallback-content-006
+    path: shadow-dom/slot-fallback-content-006.html
+    kind: reftest
+  - id: corpus-cues-with-video-processing-model-navigate-cue-position
+    path: webvtt/rendering/cues-with-video/processing-model/navigate_cue_position.html
+    kind: reftest
+
+  # -- visual (4) --
+  - id: corpus-CSS2-borders-border-left-style-applies-to-015
+    path: css/CSS2/borders/border-left-style-applies-to-015.xht
+    kind: visual
+  - id: corpus-submissions-Microsoft-focusin
+    path: uievents/legacy-domevents-tests/submissions/Microsoft/focusin.html
+    kind: visual
+  # Hand-picked replacements (selector had chosen a gentest -expected.html
+  # reference and a navigation-target fragment, neither a standalone test):
+  - id: corpus-CSS2-normal-flow-block-non-replaced-height-002
+    path: css/CSS2/normal-flow/block-non-replaced-height-002.xht
+    kind: visual
+  - id: corpus-css-backgrounds-background-size-024
+    path: css/css-backgrounds/background-size-024.html
+    kind: visual
+
+  # -- manual (4) --
+  - id: corpus-css-css-text-decor-text-underline-position-073-manual
+    path: css/css-text-decor/text-underline-position-073-manual.html
+    kind: manual
+  - id: corpus-dpub-aam-manual-doc-conclusion-manual
+    path: dpub-aam/manual/doc-conclusion-manual.html
+    kind: manual
+  - id: corpus-serial-serialPort-readable-manual
+    path: serial/serialPort_readable-manual.https.html
+    kind: manual
+  - id: corpus-wai-aria-manual-button-roledescription-valid-manual
+    path: wai-aria/manual/button_roledescription_valid-manual.html
+    kind: manual
+
+  # -- idl (4) --
+  - id: corpus-css-css-anchor-position-idlharness
+    path: css/css-anchor-position/idlharness.html
     kind: idl
+  - id: corpus-mediacapture-streams-idlharness
+    path: mediacapture-streams/idlharness.https.window.js
+    kind: idl
+  - id: corpus-notifications-idlharness
+    path: notifications/idlharness.https.any.js
+    kind: idl
+  - id: corpus-presentation-api-controlling-ua-idlharness
+    path: presentation-api/controlling-ua/idlharness.https.html
+    kind: idl
+
+  # -- crashtest (3) --
+  - id: corpus-css-css-sizing-min-content-negative-margin-inline-crash
+    path: css/css-sizing/min-content-negative-margin-inline-crash.html
+    kind: crashtest
+  - id: corpus-scroll-animations-crashtests-scroll-timeline-completion-crash
+    path: scroll-animations/crashtests/scroll-timeline-completion-crash.html
+    kind: crashtest
+  - id: corpus-web-animations-crashtests-iteration-composite-non-additive-crash
+    path: web-animations/crashtests/iteration-composite-non-additive-crash.html
+    kind: crashtest
 
 # --- Seeded-defect set ----------------------------------------------------
 # Files under benchmarks/seeds/, copied into <wpt_dir>/wpt-gen-bench/ by the

--- a/scripts/benchmark/select_corpus.py
+++ b/scripts/benchmark/select_corpus.py
@@ -34,12 +34,14 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+# Puts scripts/ on the path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from wptgen.context import is_wpt_test_file
-from wptgen.lint_ext import (
+from wpt_utils import (  # noqa: E402
     EXTENSIONS,
     is_manual_test,
     is_worker_js,
+    is_wpt_test_file,
 )
 
 # --- Stratification target --------------------------------------------------

--- a/scripts/benchmark/select_corpus.py
+++ b/scripts/benchmark/select_corpus.py
@@ -104,6 +104,17 @@ def _base_stem(base: str) -> str:
     return base.split(".", 1)[0]
 
 
+def _pre_ext_stem(base: str) -> str:
+    """The filename with only its *final* extension stripped.
+
+    ``foo.pattern-expected.html`` -> ``foo.pattern-expected``. Catches markers
+    that sit on the last dot-segment (e.g. gentest ``…-expected.html`` canvas
+    references) which ``_base_stem`` (first-dot split) would miss.
+    """
+    dot = base.rfind(".")
+    return base[:dot] if dot != -1 else base
+
+
 def _has_reftest_link(head: bytes) -> bool:
     """True if the markup declares a reftest relationship near its top.
 
@@ -136,8 +147,12 @@ def classify(path: str, sniff: bytes | None = None) -> str | None:
     ext = "." + base.rsplit(".", 1)[-1] if "." in base else ""
     stem = _base_stem(base)
 
-    # References are never sampled as tests in their own right.
+    # References/expected files are never sampled as tests in their own right.
+    # ``-expected`` sits on the final dot-segment (gentest canvas refs), so it
+    # needs the pre-extension stem, not the first-dot ``stem``.
     if stem.endswith("-ref") or stem.endswith("-notref"):
+        return None
+    if _pre_ext_stem(base).endswith("-expected"):
         return None
 
     # JS globals (worker/any/window) and plain .js harness tests.

--- a/scripts/benchmark/select_corpus.py
+++ b/scripts/benchmark/select_corpus.py
@@ -1,0 +1,416 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Consistency-corpus selector for the WPT evaluator benchmark.
+
+Emits a stratified random sample of *real* merged wpt files — the consistency
+corpus (no gold labels; it measures run-to-run judge variance). This is a
+one-time, reproducible procedure: the output is meant to be reviewed by a
+maintainer and then pinned verbatim into ``benchmarks/manifest.yaml`` under
+``corpus:``.
+
+    python scripts/benchmark/select_corpus.py \\
+      [--wpt-dir ../wpt] \\
+      [--rng-seed 1] \\
+      [--min-bytes 1024] [--max-bytes 15360] \\
+      [--out benchmarks/corpus.candidate.yaml]
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+from wptgen.context import is_wpt_test_file
+from wptgen.lint_ext import (
+    EXTENSIONS,
+    is_manual_test,
+    is_worker_js,
+)
+
+# --- Stratification target --------------------------------------------------
+# Per-kind quotas (20-40 files total). A kind that
+# cannot fill its quota from the checkout yields fewer; that shortfall is
+# surfaced in the summary rather than silently back-filled from another kind.
+QUOTAS: dict[str, int] = {
+    "testharness": 8,
+    "reftest": 6,
+    "visual": 4,
+    "manual": 4,
+    "idl": 4,
+    "crashtest": 3,
+}
+
+# Directories whose contents are tooling/resources/support, never tests.
+_EXCLUDED_TOPLEVEL = frozenset(
+    {
+        "tools",
+        "docs",
+        "resources",
+        "infrastructure",
+        "common",
+        "conformance-checkers",
+        "css/tools",
+        "fonts",
+        "images",
+        "media",
+        "support",
+    }
+)
+
+# Path segments that mark a file as generated/vendored/support rather than an
+# authored test. A file whose path contains any of these (as a segment) is
+# skipped.
+_SUPPORT_SEGMENTS = frozenset(
+    {"support", "resources", "reference", "references", "tentative-ref"}
+)
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A file that passed the mechanical filters, ready to be sampled."""
+
+    # wpt-root-relative POSIX path — exactly what goes in the manifest.
+    path: str
+    kind: str
+    size: int
+
+
+# --- Classification ---------------------------------------------------------
+
+
+def _base_stem(base: str) -> str:
+    """The filename with its *entire* extension chain stripped.
+
+    ``bar-crash.https.html`` -> ``bar-crash``. Unlike ``os.path.splitext``
+    (which strips only ``.html``), this handles wpt's compound extensions
+    (``.https.html``, ``.sub.html``, ``.any.js``) so that flag tokens like
+    ``-crash`` / ``-ref`` are found even when secondary flags follow them.
+    """
+    return base.split(".", 1)[0]
+
+
+def _has_reftest_link(head: bytes) -> bool:
+    """True if the markup declares a reftest relationship near its top.
+
+    Cheap sniff, not a parse: reftests put ``<link rel="match">`` /
+    ``rel="mismatch">`` in the head. We lowercase and look for the token pair;
+    attribute order/quoting varies, so match on ``rel`` + the value.
+    """
+    lowered = head.lower()
+    if b"rel=" not in lowered:
+        return False
+    return (
+        b'"match"' in lowered
+        or b"'match'" in lowered
+        or (b'"mismatch"' in lowered or b"'mismatch'" in lowered)
+    )
+
+
+def classify(path: str, sniff: bytes | None = None) -> str | None:
+    """Classifies a wpt-root-relative path into a benchmark test kind.
+
+    Returns one of the QUOTAS keys, or ``None`` for files that are not one of
+    the sampled kinds (helpers, ``-ref`` references, unsupported types).
+
+    ``sniff`` is the first chunk of the file's bytes, used only to split
+    markup into reftest vs. testharness/visual; pass ``None`` to skip the
+    content check (path-only classification, for tests).
+    """
+    base = path.rsplit("/", 1)[-1]
+    stem_lower = base.lower()
+    ext = "." + base.rsplit(".", 1)[-1] if "." in base else ""
+    stem = _base_stem(base)
+
+    # References are never sampled as tests in their own right.
+    if stem.endswith("-ref") or stem.endswith("-notref"):
+        return None
+
+    # JS globals (worker/any/window) and plain .js harness tests.
+    if is_worker_js(path) or base.endswith((".any.js", ".window.js")):
+        # idlharness helpers are conventionally named idlharness{,.*}.
+        if "idlharness" in stem_lower or "idl-harness" in stem_lower:
+            return "idl"
+        return "testharness"
+    if ext in EXTENSIONS["js"]:
+        return None
+
+    if ext in EXTENSIONS["markup"]:
+        if stem.endswith("-crash"):
+            return "crashtest"
+        if is_manual_test(path):
+            return "manual"
+        if "idlharness" in stem_lower:
+            return "idl"
+        if sniff is not None:
+            if _has_reftest_link(sniff):
+                return "reftest"
+            if b"testharness.js" in sniff:
+                return "testharness"
+            # Markup that imports neither harness nor a ref link: treat as a
+            # visual test (self-describing rendered page).
+            return "visual"
+        # Path-only mode (no sniff): cannot split markup further.
+        return None
+
+    return None
+
+
+# --- Enumeration + filtering ------------------------------------------------
+
+
+def _is_excluded_dir(rel_parts: tuple[str, ...]) -> bool:
+    """True if the file lives under an excluded top-level/support directory."""
+    if not rel_parts:
+        return True
+    top = rel_parts[0]
+    two = "/".join(rel_parts[:2])
+    if top in _EXCLUDED_TOPLEVEL or two in _EXCLUDED_TOPLEVEL:
+        return True
+    # A `support`/`resources`/`reference` segment anywhere marks a helper tree.
+    return any(seg in _SUPPORT_SEGMENTS for seg in rel_parts[:-1])
+
+
+_SNIFF_BYTES = 4096
+
+
+def enumerate_candidates(
+    wpt_dir: Path, min_bytes: int, max_bytes: int
+) -> list[Candidate]:
+    """Walks the checkout and returns sorted, filtered, classified candidates.
+
+    Deterministic: paths are collected then sorted before classification, so
+    the result does not depend on directory-iteration order.
+    """
+    # Collect every file first (sorted) so enumeration is filesystem-order
+    # independent.
+    all_paths = sorted(p for p in wpt_dir.rglob("*") if p.is_file())
+
+    candidates: list[Candidate] = []
+    for p in all_paths:
+        if not is_wpt_test_file(p):
+            continue
+        rel = p.relative_to(wpt_dir)
+        rel_parts = rel.parts
+        if _is_excluded_dir(rel_parts):
+            continue
+
+        try:
+            size = p.stat().st_size
+        except OSError:
+            continue
+        if size < min_bytes or size > max_bytes:
+            continue
+
+        rel_posix = rel.as_posix()
+        # Only read bytes for markup (the only kind whose class needs a sniff).
+        ext = p.suffix.lower()
+        sniff: bytes | None = None
+        if ext in EXTENSIONS["markup"]:
+            try:
+                sniff = p.read_bytes()[:_SNIFF_BYTES]
+            except OSError:
+                continue
+
+        kind = classify(rel_posix, sniff)
+        if kind is None:
+            continue
+        candidates.append(Candidate(path=rel_posix, kind=kind, size=size))
+
+    return candidates
+
+
+# --- Sampling ---------------------------------------------------------------
+
+
+def _top_dir(path: str) -> str:
+    return path.split("/", 1)[0]
+
+
+def sample(
+    candidates: list[Candidate], rng_seed: int
+) -> tuple[list[Candidate], dict[str, int]]:
+    """Draws the stratified sample. Returns (selected, shortfalls).
+
+    Within each kind, shuffles with a fixed-seed RNG and then greedily picks
+    while spreading across top-level directories: a file is skipped on the
+    first pass if its top-level dir is already represented for that kind, so
+    no single feature area (e.g. ``css/``) dominates a kind. A second pass
+    back-fills from the remainder if the diversity pass under-filled.
+    """
+    by_kind: dict[str, list[Candidate]] = {k: [] for k in QUOTAS}
+    for c in candidates:
+        # candidates only ever carry a QUOTAS kind, but guard anyway.
+        if c.kind in by_kind:
+            by_kind[c.kind].append(c)
+
+    rng = random.Random(rng_seed)
+    selected: list[Candidate] = []
+    shortfalls: dict[str, int] = {}
+
+    for kind, quota in QUOTAS.items():
+        pool = sorted(by_kind[kind], key=lambda c: c.path)
+        rng.shuffle(pool)
+
+        picked: list[Candidate] = []
+        seen_dirs: set[str] = set()
+        # Pass 1: at most one per top-level dir, for spread.
+        for c in pool:
+            if len(picked) >= quota:
+                break
+            d = _top_dir(c.path)
+            if d in seen_dirs:
+                continue
+            seen_dirs.add(d)
+            picked.append(c)
+        # Pass 2: back-fill from whatever is left, in shuffled order.
+        if len(picked) < quota:
+            remaining = [c for c in pool if c not in picked]
+            for c in remaining:
+                if len(picked) >= quota:
+                    break
+                picked.append(c)
+
+        if len(picked) < quota:
+            shortfalls[kind] = quota - len(picked)
+        # Stable, readable output: sort the kind's picks by path.
+        selected.extend(sorted(picked, key=lambda c: c.path))
+
+    return selected, shortfalls
+
+
+# --- Output -----------------------------------------------------------------
+
+
+def _entry_id(path: str) -> str:
+    """A stable, readable corpus id derived from the path.
+
+    ``css/css-grid/foo-001.html`` -> ``corpus-css-grid-foo-001``.
+    """
+    stem = path.rsplit("/", 1)[-1]
+    # Strip compound extensions (.https.any.js, .html, ...).
+    stem = stem.split(".", 1)[0]
+    parts = [seg for seg in path.split("/")[:-1] if seg]
+    slug = "-".join([*parts[-2:], stem]) if parts else stem
+    slug = slug.replace("_", "-")
+    return f"corpus-{slug}"
+
+
+def render_yaml(selected: list[Candidate]) -> str:
+    """Renders the selection as a manifest-ready ``corpus:`` block.
+
+    Deliberately hand-rolled (not yaml.dump) so field order and comments match
+    the existing manifest style and the block can be pasted verbatim.
+    """
+    lines = [
+        "corpus:",
+    ]
+    for c in selected:
+        lines.append(f"  - id: {_entry_id(c.path)}")
+        lines.append(f"    path: {c.path}")
+        lines.append(f"    kind: {c.kind}")
+        lines.append(f"    # {c.size} bytes")
+    return "\n".join(lines) + "\n"
+
+
+def _summary(selected: list[Candidate], shortfalls: dict[str, int]) -> str:
+    counts: dict[str, int] = dict.fromkeys(QUOTAS, 0)
+    for c in selected:
+        counts[c.kind] += 1
+    rows = [
+        f"  {kind:<12} {counts[kind]:>2} / {QUOTAS[kind]:<2}"
+        + (f"   ⚠ short by {shortfalls[kind]}" if kind in shortfalls else "")
+        for kind in QUOTAS
+    ]
+    total = len(selected)
+    return f"Selected {total} files:\n" + "\n".join(rows)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Select a stratified consistency corpus from a wpt "
+        "checkout.",
+    )
+    parser.add_argument(
+        "--wpt-dir",
+        type=Path,
+        default=Path("../wpt"),
+        help="Path to the pinned wpt checkout (default: ../wpt).",
+    )
+    parser.add_argument(
+        "--rng-seed",
+        type=int,
+        default=1,
+        help="Seed for the sample's random number generator, fixed so the "
+        "selection is reproducible. Named --rng-seed (not --seed) to avoid "
+        "confusion with the manifest's seeded-defect files.",
+    )
+    parser.add_argument(
+        "--min-bytes",
+        type=int,
+        default=1024,
+        help="Minimum file size, inclusive (default: 1024).",
+    )
+    parser.add_argument(
+        "--max-bytes",
+        type=int,
+        default=15360,
+        help="Maximum file size, inclusive (default: 15360 = 15 KiB).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Write the corpus YAML here (default: stdout).",
+    )
+    args = parser.parse_args(argv)
+
+    wpt_dir = args.wpt_dir.resolve()
+    if not wpt_dir.is_dir():
+        print(f"error: --wpt-dir not found: {wpt_dir}", file=sys.stderr)
+        return 2
+    if args.min_bytes > args.max_bytes:
+        print("error: --min-bytes exceeds --max-bytes", file=sys.stderr)
+        return 2
+
+    print("selecting tests...", file=sys.stderr, flush=True)
+    candidates = enumerate_candidates(wpt_dir, args.min_bytes, args.max_bytes)
+    selected, shortfalls = sample(candidates, args.rng_seed)
+
+    yaml_text = render_yaml(selected)
+    if args.out is not None:
+        args.out.write_text(yaml_text, encoding="utf-8")
+        print(f"Wrote {args.out}", file=sys.stderr)
+    else:
+        print(yaml_text)
+
+    print(
+        f"\n{len(candidates)} candidates after filtering.\n"
+        + _summary(selected, shortfalls),
+        file=sys.stderr,
+    )
+    if shortfalls:
+        print(
+            "\nnote: some kinds under-filled; widen --max-bytes or relax "
+            "filters, or accept a smaller corpus.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/wpt_utils.py
+++ b/scripts/wpt_utils.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dependency-free WPT file-discovery helpers, shared across the benchmark scripts."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# File-extension groups, mirrored from upstream lint.
+EXTENSIONS: dict[str, list[str]] = {
+    "html": [".html", ".htm"],
+    "xhtml": [".xht", ".xhtml"],
+    "svg": [".svg"],
+    "js": [".js", ".mjs"],
+    "python": [".py"],
+}
+EXTENSIONS["markup"] = (
+    EXTENSIONS["html"] + EXTENSIONS["xhtml"] + EXTENSIONS["svg"]
+)
+EXTENSIONS["js_all"] = EXTENSIONS["markup"] + EXTENSIONS["js"]
+
+
+def is_wpt_test_file(path: Path) -> bool:
+    """Whether a file name matches conditions for a WPT test file.
+
+    Filters out non-test files like .yml, .md, .py, .ini, .headers, and hidden.
+    """
+    filename = path.name
+    suffix = path.suffix.lower()
+
+    if path.is_dir():
+        return False
+    if suffix in (".yml", ".yaml", ".md", ".py", ".ini", ".headers", ".txt"):
+        return False
+    if filename in ("MANIFEST", "META.yml", "WEB_FEATURES.yml"):
+        return False
+    if "-ref." in filename:
+        return False
+    if filename.startswith("."):
+        return False
+    return True
+
+
+def is_manual_test(path: str) -> bool:
+    """A test whose filename marks it manual (`-manual` flag before the ext)."""
+    name_stem = os.path.basename(path).split(".", 1)[0]
+    return name_stem.endswith("-manual")
+
+
+def is_worker_js(path: str) -> bool:
+    """A `.worker.js` test file."""
+    return os.path.basename(path).endswith(".worker.js")

--- a/tests/benchmark/test_select_corpus.py
+++ b/tests/benchmark/test_select_corpus.py
@@ -1,0 +1,206 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the consistency-corpus selector.
+
+No wpt checkout needed: the classifier is a pure function of a path (+ an
+optional byte sniff), and the sampler/enumerator run against a tiny synthetic
+tree built in a tmp dir. The properties that matter — correct kind
+classification, mechanical filtering, and *reproducible* sampling — are all
+exercised here.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+# scripts/ is on sys.path via tests/conftest.py.
+from benchmark import select_corpus
+from benchmark.manifest import _parse_corpus
+
+# --- classify ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        # testharness: js globals + plain harness markup
+        ("fetch/api/basic/response-null-body.any.js", "testharness"),
+        ("dom/events/foo.window.js", "testharness"),
+        ("workers/foo.worker.js", "testharness"),
+        # idl: idlharness by name wins over the .js-global classification
+        ("speech-api/idlharness.https.window.js", "idl"),
+        ("webnn/idlharness.https.any.js", "idl"),
+        ("css/foo/idlharness.html", "idl"),
+        # references are never their own test
+        ("css/foo/bar-ref.html", None),
+        ("css/foo/bar-notref.html", None),
+        ("css/foo/bar-ref.xht", None),
+        # crash / manual by flag token, robust to compound extensions
+        ("css/anchor/long-chain-crash.html", "crashtest"),
+        ("accname/manual/name-radio-manual.html", "manual"),
+        ("presentation/onclose-manual.https.html", "manual"),
+        ("svg/import/use-11-f-manual.svg", "manual"),
+        # a bare helper .js is not a standalone test
+        ("resources/helper.js", None),
+        ("css/support/util.mjs", None),
+        # unsupported extension
+        ("tools/foo.py", None),
+    ],
+)
+def test_classify_path_only(path: str, expected: str | None) -> None:
+    # sniff=None exercises path-only classification (no content split).
+    assert select_corpus.classify(path, sniff=None) == expected
+
+
+def test_classify_markup_needs_sniff_to_split() -> None:
+    p = "css/css-grid/grid-001.html"
+    # Path alone can't split plain markup: returns None without a sniff.
+    assert select_corpus.classify(p, sniff=None) is None
+    # Reftest link -> reftest.
+    ref = b'<link rel="match" href="grid-001-ref.html">'
+    assert select_corpus.classify(p, sniff=ref) == "reftest"
+    # mismatch link also counts.
+    mismatch = b"<link rel='mismatch' href='x.html'>"
+    assert select_corpus.classify(p, sniff=mismatch) == "reftest"
+    # testharness import -> testharness.
+    th = b'<script src="/resources/testharness.js"></script>'
+    assert select_corpus.classify(p, sniff=th) == "testharness"
+    # Neither -> visual (a self-describing rendered page).
+    assert select_corpus.classify(p, sniff=b"<html><body>hi</body>") == (
+        "visual"
+    )
+
+
+def test_classify_manual_beats_content_sniff() -> None:
+    # A -manual markup file is manual even if it imports testharness.
+    p = "wai-aria/foo-manual.html"
+    assert select_corpus.classify(p, sniff=b"testharness.js") == "manual"
+
+
+def test_compound_extension_stem() -> None:
+    assert select_corpus._base_stem("bar-crash.https.html") == "bar-crash"
+    assert select_corpus._base_stem("bar.any.js") == "bar"
+    assert select_corpus._base_stem("baz.html") == "baz"
+    assert select_corpus._base_stem("noext") == "noext"
+
+
+# --- enumerate_candidates (mechanical filters) ------------------------------
+
+
+def _write(root: Path, rel: str, content: bytes = b"x") -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(content)
+
+
+def test_enumerate_filters(tmp_path: Path) -> None:
+    root = tmp_path / "wpt"
+    th = b'<script src="/resources/testharness.js"></script>' + b" " * 2000
+    # In-bounds testharness test.
+    _write(root, "css/foo/test-001.html", th)
+    # Too small -> filtered.
+    _write(root, "css/foo/tiny.html", b"<script src='testharness.js'>")
+    # Too big -> filtered.
+    _write(root, "css/foo/huge.html", th + b"z" * 40_000)
+    # Under an excluded top-level dir -> filtered.
+    _write(root, "tools/gen.html", th)
+    # Under a `support` segment -> filtered.
+    _write(root, "css/foo/support/helper.html", th)
+    # A reference -> filtered by classify.
+    _write(root, "css/foo/test-001-ref.html", th)
+    # In-bounds but not a test file -> filtered by is_wpt_test_file gate.
+    _write(root, "css/foo/test-001.html.headers", th)
+
+    cands = select_corpus.enumerate_candidates(
+        root, min_bytes=1024, max_bytes=15360
+    )
+    paths = {c.path for c in cands}
+    assert paths == {"css/foo/test-001.html"}
+    assert cands[0].kind == "testharness"
+    assert cands[0].size >= 1024
+
+
+# --- sample (reproducibility + stratification) ------------------------------
+
+
+def _candidates(spec: list[tuple[str, str]]) -> list[select_corpus.Candidate]:
+    return [select_corpus.Candidate(path=p, kind=k, size=2048) for p, k in spec]
+
+
+def test_sample_is_deterministic() -> None:
+    cands = _candidates(
+        [(f"area{i}/th-{i}.html", "testharness") for i in range(20)]
+    )
+    a, _ = select_corpus.sample(cands, rng_seed=1)
+    b, _ = select_corpus.sample(cands, rng_seed=1)
+    c, _ = select_corpus.sample(cands, rng_seed=2)
+    assert [x.path for x in a] == [x.path for x in b]
+    # A different seed should (with 20 choose 8) pick a different set.
+    assert [x.path for x in a] != [x.path for x in c]
+
+
+def test_sample_respects_quota_and_reports_shortfall() -> None:
+    # Two kinds: testharness over-supplied, idl under-supplied.
+    cands = _candidates(
+        [(f"a{i}/th-{i}.html", "testharness") for i in range(20)]
+        + [("x/idlharness.any.js", "idl")]  # only 1, quota is 4
+    )
+    selected, shortfalls = select_corpus.sample(cands, rng_seed=1)
+    by_kind: dict[str, int] = {}
+    for c in selected:
+        by_kind[c.kind] = by_kind.get(c.kind, 0) + 1
+    assert by_kind["testharness"] == select_corpus.QUOTAS["testharness"]
+    assert by_kind["idl"] == 1
+    assert shortfalls["idl"] == select_corpus.QUOTAS["idl"] - 1
+    assert "testharness" not in shortfalls
+
+
+def test_sample_spreads_across_top_dirs() -> None:
+    # 8 files, all under css/ except two; with per-top-dir spread the sample
+    # must not be all-css when other dirs exist.
+    cands = _candidates(
+        [(f"css/m{i}/th-{i}.html", "testharness") for i in range(8)]
+        + [("dom/th-a.html", "testharness"), ("html/th-b.html", "testharness")]
+    )
+    selected, _ = select_corpus.sample(cands, rng_seed=1)
+    top_dirs = {c.path.split("/", 1)[0] for c in selected}
+    # dom and html each contribute at least once before css repeats.
+    assert "dom" in top_dirs
+    assert "html" in top_dirs
+
+
+# --- render_yaml (manifest-ready output) ------------------------------------
+
+
+def test_render_yaml_parses_as_corpus() -> None:
+    selected = _candidates(
+        [
+            ("css/css-grid/grid-align-001.html", "reftest"),
+            ("fetch/api/response-null-body.any.js", "testharness"),
+        ]
+    )
+    text = select_corpus.render_yaml(selected)
+    raw = yaml.safe_load(text)
+    assert "corpus" in raw
+    entries = [_parse_corpus(e, i) for i, e in enumerate(raw["corpus"])]
+    assert len(entries) == 2
+    # ids are unique and prefixed.
+    ids = [e.entry_id for e in entries]
+    assert all(i.startswith("corpus-") for i in ids)
+    assert len(set(ids)) == len(ids)
+    # kind + path round-trip.
+    assert entries[0].kind == "reftest"
+    assert entries[1].path == "fetch/api/response-null-body.any.js"

--- a/tests/benchmark/test_select_corpus.py
+++ b/tests/benchmark/test_select_corpus.py
@@ -48,6 +48,9 @@ from benchmark.manifest import _parse_corpus
         ("css/foo/bar-ref.html", None),
         ("css/foo/bar-notref.html", None),
         ("css/foo/bar-ref.xht", None),
+        # -expected refs (gentest canvas): marker on the final dot-segment
+        ("html/canvas/foo.grid.pattern-expected.html", None),
+        ("css/foo/bar-expected.html", None),
         # crash / manual by flag token, robust to compound extensions
         ("css/anchor/long-chain-crash.html", "crashtest"),
         ("accname/manual/name-radio-manual.html", "manual"),

--- a/tests/test_lint_ext.py
+++ b/tests/test_lint_ext.py
@@ -17,7 +17,7 @@ Each check is named with its rules.yaml id; these tests assert the gap-set
 checks fire on violations and stay quiet on clean input.
 """
 
-from wptgen.lint_ext import check_file
+from wptgen.lint_ext import check_file, is_manual_test
 
 
 def _rule_ids(path: str, content: bytes) -> list[str]:
@@ -70,6 +70,26 @@ def test_api_005_quiet_on_non_manual_test() -> None:
     """The gate: an ordinary (non-manual) test's setup() is not flagged."""
     assert "MANUAL-004" not in _rule_ids("m.html", b"setup();\n")
     assert "MANUAL-004" not in _rule_ids("m.any.js", b"setup();\n")
+
+
+def test_api_005_flags_manual_with_compound_extension() -> None:
+    """A `-manual` test keeps its flag before secondary extensions.
+
+    `foo-manual.https.html` is still manual; the check must fire. (Regression
+    for the splitext-based is_manual_test, which left `.https` on the stem and
+    missed it.)
+    """
+    assert "MANUAL-004" in _rule_ids("m-manual.https.html", b"setup();\n")
+    assert "MANUAL-004" in _rule_ids("m-manual.sub.html", b"setup();\n")
+
+
+def test_is_manual_test_compound_extensions() -> None:
+    assert is_manual_test("a/b/foo-manual.html") is True
+    assert is_manual_test("a/b/foo-manual.https.html") is True
+    assert is_manual_test("a/b/foo-manual.sub.html") is True
+    # `-manual` must be the trailing name segment, not merely present.
+    assert is_manual_test("a/b/foo-manual-other.html") is False
+    assert is_manual_test("a/b/foo.https.html") is False
 
 
 def test_name_011_flags_crash_suffix_not_last() -> None:

--- a/tests/test_phase_evaluation.py
+++ b/tests/test_phase_evaluation.py
@@ -39,6 +39,7 @@ from wptgen.phases.evaluation import (
     _payload_to_input_scope,
     run_evaluation,
 )
+from wptgen.utils import locate_snippet
 
 # ---------------------------------------------------------------------------
 # InputScope dataclass properties
@@ -80,36 +81,142 @@ def test_payload_to_findings_roundtrips_all_fields() -> None:
             "title": "missing charset",
             "severity": "warn",
             "test_line": "Lines 1-4",
-            "evidence": "<head>...",
+            "citation": "<head>...",
             "source": "wpt/docs/writing-tests/general-guidelines.md:L82-L87",
             "summary": "HTML files must declare encoding.",
         }
     ]
-    findings = _payload_to_findings(payload)
+    findings, demoted = _payload_to_findings(payload)
     assert len(findings) == 1
+    assert demoted == 0
     f = findings[0]
     assert f.title == "missing charset"
     assert f.severity == "warn"
     assert f.test_line == "Lines 1-4"
-    assert f.evidence == "<head>..."
+    assert f.citation == "<head>..."
     assert f.source == "wpt/docs/writing-tests/general-guidelines.md:L82-L87"
     assert f.summary == "HTML files must declare encoding."
 
 
 def test_payload_to_findings_tolerates_missing_fields() -> None:
-    findings = _payload_to_findings([{}])
+    findings, _ = _payload_to_findings([{}])
     assert len(findings) == 1
     f = findings[0]
     assert f.title == ""
     assert f.severity == ""
     assert f.test_line == ""
-    assert f.evidence == ""
+    assert f.citation == ""
     assert f.source == ""
     assert f.summary == ""
 
 
 def test_payload_to_findings_empty_list() -> None:
-    assert _payload_to_findings([]) == []
+    assert _payload_to_findings([]) == ([], 0)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic citation resolution
+# ---------------------------------------------------------------------------
+
+_CITE_SRC = (
+    "<!DOCTYPE html>\n"
+    "<div>a</div>\n"
+    "  <div style='display: float'>x</div>\n"
+    "<div>a</div>\n"
+)
+
+
+def test_locate_snippet_finds_verbatim() -> None:
+    assert locate_snippet("display: float", _CITE_SRC) == [
+        (3, "  <div style='display: float'>x</div>"),
+    ]
+
+
+def test_locate_snippet_normalizes_whitespace() -> None:
+    assert locate_snippet("display:    float", _CITE_SRC)[0][0] == 3
+
+
+def test_locate_snippet_not_found_is_empty() -> None:
+    assert locate_snippet("not in file", _CITE_SRC) == []
+
+
+def test_locate_snippet_empty_is_empty() -> None:
+    assert locate_snippet("", _CITE_SRC) == []
+
+
+def test_locate_snippet_returns_every_occurrence() -> None:
+    # "<div>a</div>" is on lines 2 and 4.
+    matches = locate_snippet("<div>a</div>", _CITE_SRC)
+    assert [line for line, _ in matches] == [2, 4]
+
+
+def test_payload_corrects_line_and_text_from_citation() -> None:
+    # Model gives a wrong line and a rough citation; both are corrected to
+    # the file's exact text and real line.
+    payload = [
+        {
+            "title": "t",
+            "test_line": "Line 99",
+            "citation": "display:   float",
+            "summary": "s",
+        }
+    ]
+    findings, demoted = _payload_to_findings(payload, _CITE_SRC)
+    assert demoted == 0
+    assert findings[0].test_line == "Line 3"
+    assert findings[0].citation == "  <div style='display: float'>x</div>"
+
+
+def test_payload_demotes_unlocatable_citation() -> None:
+    # A citation not in the file is dropped; the finding goes citation-less
+    # rather than emitting an unbacked line, and is counted as demoted.
+    payload = [
+        {
+            "title": "t",
+            "test_line": "Line 5",
+            "citation": "fabricated",
+            "summary": "s",
+        }
+    ]
+    findings, demoted = _payload_to_findings(payload, _CITE_SRC)
+    assert findings[0].citation == ""
+    assert findings[0].test_line == ""
+    assert demoted == 1
+
+
+def test_payload_citationless_passes_through() -> None:
+    payload = [{"title": "t", "citation": "", "summary": "no done() call"}]
+    findings, demoted = _payload_to_findings(payload, _CITE_SRC)
+    assert findings[0].citation == ""
+    assert findings[0].test_line == ""
+    assert demoted == 0  # no citation to demote
+
+
+def test_payload_without_source_is_unchecked() -> None:
+    # No test_source -> fields pass through unvalidated.
+    payload = [
+        {
+            "title": "t",
+            "test_line": "Line 99",
+            "citation": "anything",
+            "summary": "s",
+        }
+    ]
+    findings, demoted = _payload_to_findings(payload)
+    assert findings[0].test_line == "Line 99"
+    assert findings[0].citation == "anything"
+    assert demoted == 0
+
+
+def test_warn_demoted_citations_warns_only_when_nonzero() -> None:
+    from wptgen.phases.evaluation import _warn_demoted_citations
+
+    ui = MagicMock()
+    _warn_demoted_citations(ui, "documentation", 0)
+    ui.warning.assert_not_called()
+    _warn_demoted_citations(ui, "documentation", 2)
+    ui.warning.assert_called_once()
+    assert "2" in ui.warning.call_args[0][0]
 
 
 def test_payload_to_input_scope_full() -> None:
@@ -163,7 +270,7 @@ def _sample_finding(**overrides: Any) -> Finding:
         "title": "missing character encoding declaration",
         "severity": "warn",
         "test_line": "Lines 1-4",
-        "evidence": "<!DOCTYPE html>",
+        "citation": "<!DOCTYPE html>",
         "source": "wpt/docs/writing-tests/general-guidelines.md:L82-L87",
         "summary": "HTML must declare encoding.",
     }
@@ -301,30 +408,49 @@ def test_render_basic_finding() -> None:
     )
     assert "**Summary**: HTML must declare encoding." in report
 
-    # Evidence is code-fenced
+    # Citation is code-fenced.
     assert "```\n  <!DOCTYPE html>\n  ```" in report
 
 
-def test_render_multiline_evidence_stays_inside_code_fence() -> None:
-    """Multi-line evidence renders within a single fenced block."""
-    evidence = "<head>\n  <title>foo</title>\n  <meta>"
+def test_render_multiline_citation_stays_inside_code_fence() -> None:
+    """Multi-line citation renders within a single fenced block."""
+    citation = "<head>\n  <title>foo</title>\n  <meta>"
     report = _render(
         test_path="wpt/foo/bar.html",
-        findings=[_sample_finding(evidence=evidence)],
+        findings=[_sample_finding(citation=citation)],
     )
 
-    # Verify each line of the evidence is inside the fence (indented).
+    # Verify each line of the citation is inside the fence (indented).
     assert "  <head>" in report
     assert "  <title>foo</title>" in report
     assert "  <meta>" in report
 
     # Verify the fenced block is well-formed: opening fence, content,
     # closing fence — and that we have exactly two fence markers for
-    # this finding's evidence.
+    # this finding's citation.
     fence_lines = [
         line for line in report.splitlines() if line.strip() == "```"
     ]
     assert len(fence_lines) == 2
+
+
+def test_render_citationless_finding_shows_file_scoped() -> None:
+    report = _render(
+        test_path="wpt/foo/bar.html",
+        findings=[
+            _sample_finding(
+                citation="",
+                test_line="",
+                summary="No done() call anywhere; worker tests must call it.",
+            )
+        ],
+    )
+    assert "file-scoped (no citation)" in report
+    # No code fence for a citation-less finding.
+    fence_lines = [
+        line for line in report.splitlines() if line.strip() == "```"
+    ]
+    assert len(fence_lines) == 0
 
 
 def test_render_empty_findings_shows_fallback() -> None:
@@ -446,7 +572,7 @@ async def test_run_evaluation_writes_report_when_agent_succeeds(
                 "title": "missing charset",
                 "severity": "warn",
                 "test_line": "Lines 1-4",
-                "evidence": "<!doctype html>",
+                "citation": "<!doctype html>",
                 "source": (
                     "wpt/docs/writing-tests/general-guidelines.md:L82-L87"
                 ),
@@ -526,7 +652,7 @@ def _conformance_finding() -> Finding:
         title="assertion contradicts requirement",
         severity="error",
         test_line="Line 42",
-        evidence="assert_equals(getComputedStyle(el).flexBasis, '0px')",
+        citation="assert_equals(getComputedStyle(el).flexBasis, '0px')",
         source="requirements.xml#R3",
         summary="Spec says flex-basis defaults to 'auto', not '0px'.",
     )
@@ -625,7 +751,7 @@ async def test_run_evaluation_with_spec_url_runs_conformance_pass(
                 "title": "contradicts requirement",
                 "severity": "error",
                 "test_line": "Line 12",
-                "evidence": "assert_equals(x, 'wrong')",
+                "citation": "assert_equals(x, 'wrong')",
                 "source": "requirements.xml#R1",
                 "summary": "Spec requires 'right', not 'wrong'.",
             }
@@ -721,7 +847,7 @@ async def test_run_evaluation_multiple_specs_judged_in_one_pass(
                 "title": "contradicts flexbox",
                 "severity": "error",
                 "test_line": "Line 12",
-                "evidence": "assert_equals(x, 'wrong')",
+                "citation": "assert_equals(x, 'wrong')",
                 "source": f"{spec_a}#R1",
                 "summary": "flexbox disagrees.",
             },
@@ -729,7 +855,7 @@ async def test_run_evaluation_multiple_specs_judged_in_one_pass(
                 "title": "contradicts grid",
                 "severity": "warn",
                 "test_line": "Line 20",
-                "evidence": "assert_true(y)",
+                "citation": "assert_true(y)",
                 "source": f"{spec_b}#R4",
                 "summary": "grid disagrees.",
             },

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,29 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
-from wptgen.utils import retry
+from wptgen.utils import locate_snippet, retry
+
+_SRC = "a\n  <b>x</b>\nc\n  <b>x</b>\n"
+
+
+def test_locate_snippet_finds_and_returns_exact_text() -> None:
+    assert locate_snippet("<b>x</b>", _SRC) == [
+        (2, "  <b>x</b>"),
+        (4, "  <b>x</b>"),
+    ]
+
+
+def test_locate_snippet_normalizes_whitespace() -> None:
+    # A snippet re-indented by the model still matches the file's own line.
+    assert locate_snippet("<b>x</b>", _SRC)[0][0] == 2
+
+
+def test_locate_snippet_missing_is_empty() -> None:
+    assert locate_snippet("nope", _SRC) == []
+
+
+def test_locate_snippet_blank_is_empty() -> None:
+    assert locate_snippet("   \n  ", _SRC) == []
 
 
 def test_retry_success() -> None:

--- a/wptgen/agents/adk_conformance_evaluator.py
+++ b/wptgen/agents/adk_conformance_evaluator.py
@@ -27,7 +27,11 @@ from google.adk.tools.skill_toolset import SkillToolset
 from google.genai import types
 from jinja2 import Environment
 
-from wptgen.agents.adk_evaluator import EVALUATOR_TOOL_ALLOWLIST
+from wptgen.agents.adk_evaluator import (
+    EVALUATOR_TOOL_ALLOWLIST,
+    _read_test_source,
+)
+from wptgen.utils import locate_snippet
 from wptgen.agents.provider import setup_adk_environment
 from wptgen.agents.streaming import ADKStreamManager, StreamConfig, TokenUsage
 from wptgen.agents.tools import create_agent_tools
@@ -105,15 +109,12 @@ async def evaluate_conformance_with_adk(
         attempt to format the report yourself; do NOT write any file.
 
         Args:
-            findings: A list of finding objects, each containing the
-                fields `title` (short description), `severity` (one of
-                "error" or "warn"), `test_line` (a line reference into
-                the test file), `evidence` (the assertion in question),
-                `source` (the concerned spec's URL plus the requirement
-                id, e.g. `https://drafts.csswg.org/css-flexbox/#R3`, so
-                each finding is attributed to the spec it came from), and
-                `summary` (a one-sentence paraphrase of the contradiction
-                or gap).
+            findings: Finding objects with fields `title`, `severity`
+                ("error"/"warn"), `citation` (verbatim snippet from `locate`,
+                "" if none), `source` (the concerned spec's URL + requirement
+                id, e.g. `https://drafts.csswg.org/css-flexbox/#R3`), and
+                `summary` (the requirement and how this test contradicts or
+                gaps it). No `test_line` — it derives from `citation`.
             input_scope: An object describing what was loaded, with the
                 fields `files` (a list of `{path, bytes, role}` rows
                 where `role` is one of "skill", "test", "requirements",
@@ -130,6 +131,29 @@ async def evaluate_conformance_with_adk(
         )
         return {"status": "success", "message": "Evaluation recorded."}
 
+    def locate(snippet: str) -> dict[str, Any]:
+        """Find where a snippet appears in the test file under evaluation.
+
+        Use this to obtain a finding's `citation`: pass the assertion or code
+        you are flagging and record a returned match's `text` (verbatim file
+        content) and `line`. Never write a line number or citation from memory.
+
+        Args:
+            snippet: The code/assertion you are flagging, roughly as recalled.
+                Whitespace differences are tolerated.
+
+        Returns:
+            A dict with `matches`: a list of `{line, text}` objects, one per
+            place the snippet occurs (empty when not in the file).
+        """
+        matches = [
+            {"line": line, "text": text}
+            for line, text in locate_snippet(snippet, test_source or "")
+        ]
+        return {"matches": matches}
+
+    test_source = _read_test_source(test_path)
+
     all_tools = list(
         create_agent_tools(
             wpt_root,
@@ -144,6 +168,7 @@ async def evaluate_conformance_with_adk(
         t for t in all_tools if t.func.__name__ in EVALUATOR_TOOL_ALLOWLIST
     ]
     tools.append(FunctionTool(func=report_conformance_complete))
+    tools.append(FunctionTool(func=locate))
 
     skill_dir = SKILLS_DIR / "wpt-evaluator-conformance"
     if skill_dir.is_dir():

--- a/wptgen/agents/adk_conformance_evaluator.py
+++ b/wptgen/agents/adk_conformance_evaluator.py
@@ -27,16 +27,13 @@ from google.adk.tools.skill_toolset import SkillToolset
 from google.genai import types
 from jinja2 import Environment
 
-from wptgen.agents.adk_evaluator import (
-    EVALUATOR_TOOL_ALLOWLIST,
-    _read_test_source,
-)
-from wptgen.utils import locate_snippet
+from wptgen.agents.adk_evaluator import EVALUATOR_TOOL_ALLOWLIST
 from wptgen.agents.provider import setup_adk_environment
 from wptgen.agents.streaming import ADKStreamManager, StreamConfig, TokenUsage
 from wptgen.agents.tools import create_agent_tools
 from wptgen.config import SKILLS_DIR, Config
 from wptgen.ui import UIProvider
+from wptgen.utils import locate_snippet, read_test_source
 
 # Re-exported so both evaluators share one read-only allowlist
 __all__ = [
@@ -152,7 +149,7 @@ async def evaluate_conformance_with_adk(
         ]
         return {"matches": matches}
 
-    test_source = _read_test_source(test_path)
+    test_source = read_test_source(test_path)
 
     all_tools = list(
         create_agent_tools(

--- a/wptgen/agents/adk_evaluator.py
+++ b/wptgen/agents/adk_evaluator.py
@@ -32,6 +32,7 @@ from wptgen.agents.streaming import ADKStreamManager, StreamConfig, TokenUsage
 from wptgen.agents.tools import create_agent_tools
 from wptgen.config import SKILLS_DIR, Config
 from wptgen.ui import UIProvider
+from wptgen.utils import locate_snippet
 
 # Allow-list of tool names from create_agent_tools() that the evaluator
 # may use. Anything not in this set is filtered out before the agent
@@ -49,6 +50,14 @@ EVALUATOR_TOOL_ALLOWLIST = frozenset(
         "run_lint_ext",
     }
 )
+
+
+def _read_test_source(test_path: Path) -> str | None:
+    """The test file's text (for the `locate` tool), or None if unreadable."""
+    try:
+        return test_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
 
 
 class EvaluatorStrategy(StrEnum):
@@ -117,14 +126,13 @@ async def evaluate_test_with_adk(
         attempt to format the report yourself; do NOT write any file.
 
         Args:
-            findings: A list of finding objects, each containing the
-                fields `rule_id` (the `rules.yaml` rule that was
-                violated, e.g. "GENERAL-005"), `title` (short description),
-                `severity` (one of "error", "warn", "info", "nit"),
-                `test_line` (a line reference into the test file),
-                `evidence` (a short quote or description), `source` (the
-                rule's `wpt/...:Lstart-Lend` provenance), and `summary`
-                (a one-sentence paraphrase of the rule).
+            findings: Finding objects with fields `rule_id` (violated
+                `rules.yaml` rule, e.g. "GENERAL-005"), `title`, `severity`
+                ("error"/"warn"/"info"/"nit"), `citation` (verbatim snippet
+                from `locate`, "" if none), `source` (the rule's
+                `wpt/...:Lstart-Lend` provenance), and `summary` (the rule and
+                how it applies to this test). No `test_line` — it derives from
+                `citation`.
             input_scope: An object describing what was loaded, with the
                 fields `files` (a list of `{path, bytes, role}` rows
                 where `role` is one of "skill", "rules", "test", or
@@ -140,6 +148,32 @@ async def evaluate_test_with_adk(
             {"findings": findings, "input_scope": input_scope}
         )
         return {"status": "success", "message": "Evaluation recorded."}
+
+    def locate(snippet: str) -> dict[str, Any]:
+        """Find where a snippet appears in the test file under evaluation.
+
+        Use this to obtain a finding's `citation`: pass the offending code and
+        record a returned match's `text` (verbatim file content) and `line`.
+        Never write a line number or citation from memory — get them here so
+        they always match the file.
+
+        Args:
+            snippet: The code you are flagging, roughly as you recall it.
+                Whitespace differences are tolerated.
+
+        Returns:
+            A dict with `matches`: a list of `{line, text}` objects, one per
+            place the snippet occurs (empty if it is not in the file, in which
+            case the finding has no citation and should be reported with an
+            empty `citation`).
+        """
+        matches = [
+            {"line": line, "text": text}
+            for line, text in locate_snippet(snippet, test_source or "")
+        ]
+        return {"matches": matches}
+
+    test_source = _read_test_source(test_path)
 
     # Build the evaluator's tool kit: the full create_agent_tools() set,
     # filtered to the allow-list, plus the completion tool.
@@ -157,6 +191,7 @@ async def evaluate_test_with_adk(
         t for t in all_tools if t.func.__name__ in EVALUATOR_TOOL_ALLOWLIST
     ]
     tools.append(FunctionTool(func=report_evaluation_complete))
+    tools.append(FunctionTool(func=locate))
 
     if not isinstance(strategy, EvaluatorStrategy):
         try:

--- a/wptgen/agents/adk_evaluator.py
+++ b/wptgen/agents/adk_evaluator.py
@@ -32,7 +32,7 @@ from wptgen.agents.streaming import ADKStreamManager, StreamConfig, TokenUsage
 from wptgen.agents.tools import create_agent_tools
 from wptgen.config import SKILLS_DIR, Config
 from wptgen.ui import UIProvider
-from wptgen.utils import locate_snippet
+from wptgen.utils import locate_snippet, read_test_source
 
 # Allow-list of tool names from create_agent_tools() that the evaluator
 # may use. Anything not in this set is filtered out before the agent
@@ -50,14 +50,6 @@ EVALUATOR_TOOL_ALLOWLIST = frozenset(
         "run_lint_ext",
     }
 )
-
-
-def _read_test_source(test_path: Path) -> str | None:
-    """The test file's text (for the `locate` tool), or None if unreadable."""
-    try:
-        return test_path.read_text(encoding="utf-8")
-    except OSError:
-        return None
 
 
 class EvaluatorStrategy(StrEnum):
@@ -173,7 +165,7 @@ async def evaluate_test_with_adk(
         ]
         return {"matches": matches}
 
-    test_source = _read_test_source(test_path)
+    test_source = read_test_source(test_path)
 
     # Build the evaluator's tool kit: the full create_agent_tools() set,
     # filtered to the allow-list, plus the completion tool.

--- a/wptgen/lint_ext.py
+++ b/wptgen/lint_ext.py
@@ -44,9 +44,9 @@ Error = tuple[str, str, str, int | None]
 
 
 def is_manual_test(path: str) -> bool:
-    """A test whose filename marks it manual (`-manual` before the ext)."""
-    stem, _ = os.path.splitext(os.path.basename(path))
-    return stem.endswith("-manual")
+    """A test whose filename marks it manual (`-manual` flag before the ext)."""
+    name_stem = os.path.basename(path).split(".", 1)[0]
+    return name_stem.endswith("-manual")
 
 
 def is_worker_js(path: str) -> bool:

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -42,18 +42,30 @@ from wptgen.llm import get_llm_client
 from wptgen.models import WorkflowContext
 from wptgen.phases.requirements_extraction import run_requirements_extraction
 from wptgen.ui import UIProvider
+from wptgen.utils import locate_snippet
 
 
 @dataclass
 class Finding:
-    """A single advisory finding produced by the evaluator."""
+    """A single advisory finding produced by the evaluator.
+
+    ``citation`` and ``test_line`` are line-anchored provenance: the exact file
+    text the finding points at and its line. They are derived deterministically
+    from the ``locate`` tool / a post-hoc lookup, never authored by the model,
+    so they cannot cite text that is not in the file. A finding may be
+    citation-less (``citation=""``, ``test_line=""``) when it concerns
+    something missing or a whole-file property; its ``summary`` then carries the
+    reasoning alone. ``summary`` is the model's prose: the governing rule and
+    how it applies to this test.
+    """
 
     title: str
     severity: str  # "error", "warn", "info", or "nit"
-    test_line: str  # e.g. "Line 24" or "Lines 21-23" or "filename"
-    evidence: str
+    test_line: str  # e.g. "Line 24" or "Lines 21-23"; "" when citation-less
     source: str  # e.g. "wpt/docs/writing-tests/general-guidelines.md:L82-L87"
-    summary: str
+    summary: str  # the rule + how it applies to this finding
+    # Exact verbatim file text the finding anchors to; "" when citation-less.
+    citation: str = ""
     rule_id: str = (
         ""  # e.g. "GENERAL-005"; empty for findings not tied to a rule
     )
@@ -168,26 +180,61 @@ def _input_scope_to_payload(input_scope: InputScope) -> dict[str, Any]:
     }
 
 
-def _payload_to_findings(payload: list[dict[str, Any]]) -> list[Finding]:
+def _read_test_source(test_path: Path) -> str | None:
+    """The test file's text for citation resolution, or None if unreadable."""
+    try:
+        return test_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _payload_to_findings(
+    payload: list[dict[str, Any]], test_source: str | None = None
+) -> tuple[list[Finding], int]:
     """Converts the agent's JSON-shaped findings payload into Finding objects.
 
     Tolerates missing fields by substituting empty strings — the renderer
     will display the gap rather than crash.
+
+    ``citation``/``test_line`` are validated against ``test_source`` (the
+    evaluated file's text): a citation is re-located in the file and its
+    ``test_line`` set from that location, with the citation replaced by the
+    exact file text. A citation that cannot be located is dropped and the
+    finding demoted to citation-less (never emit a line the file does not
+    back). Omitting ``test_source`` passes the fields through unchecked.
+
+    Returns ``(findings, demoted)`` where ``demoted`` counts citations the
+    model supplied that were not in the file (a hallucination quality signal).
     """
     findings: list[Finding] = []
+    demoted = 0
     for item in payload:
+        citation = str(item.get("citation", ""))
+        test_line = str(item.get("test_line", ""))
+        if test_source is not None and citation.strip():
+            located = locate_snippet(citation, test_source)
+            if located:
+                line, exact_text = located[0]
+                citation = exact_text
+                test_line = f"Line {line}"
+            else:
+                # Fabricated citation: demote to citation-less rather than
+                # emit an unbacked line.
+                citation = ""
+                test_line = ""
+                demoted += 1
         findings.append(
             Finding(
                 title=str(item.get("title", "")),
                 severity=str(item.get("severity", "")),
-                test_line=str(item.get("test_line", "")),
-                evidence=str(item.get("evidence", "")),
+                test_line=test_line,
                 source=str(item.get("source", "")),
                 summary=str(item.get("summary", "")),
+                citation=citation,
                 rule_id=str(item.get("rule_id", "")),
             )
         )
-    return findings
+    return findings, demoted
 
 
 def _payload_to_input_scope(payload: dict[str, Any]) -> InputScope:
@@ -302,11 +349,14 @@ async def _run_conformance(
         conformance_scope,
         conformance_tokens,
     )
+    conf_findings, conf_demoted = _payload_to_findings(
+        conformance_payload.get("findings", []) or [],
+        _read_test_source(test_path),
+    )
+    _warn_demoted_citations(ui, "conformance", conf_demoted)
     return ConformanceSection(
         specs=specs,
-        findings=_payload_to_findings(
-            conformance_payload.get("findings", []) or []
-        ),
+        findings=conf_findings,
         input_scope=conformance_scope,
     )
 
@@ -366,7 +416,11 @@ async def run_evaluation(
         return None
 
     agent_payload, doc_inputs_tokens = agent_result
-    findings = _payload_to_findings(agent_payload.get("findings", []) or [])
+    findings, demoted = _payload_to_findings(
+        agent_payload.get("findings", []) or [],
+        _read_test_source(test_path),
+    )
+    _warn_demoted_citations(ui, "documentation", demoted)
     input_scope = _payload_to_input_scope(
         agent_payload.get("input_scope", {}) or {}
     )
@@ -432,6 +486,20 @@ def _files_by_role(input_scope: InputScope) -> dict[str, int]:
     for file in input_scope.files:
         counts[file.role] = counts.get(file.role, 0) + 1
     return counts
+
+
+def _warn_demoted_citations(ui: UIProvider, label: str, demoted: int) -> None:
+    """Surfaces the count of citations that were not in the file.
+
+    A demotion means the model supplied a citation the file does not contain;
+    the backstop stripped it so no bad line reaches the report. The report
+    stays clean — this is a run-quality signal, not a report annotation.
+    """
+    if demoted:
+        ui.warning(
+            f"{label}: {demoted} finding citation(s) were not found in the "
+            "test file and were dropped (line reference removed)."
+        )
 
 
 def _report_pass_summaries(

--- a/wptgen/phases/evaluation.py
+++ b/wptgen/phases/evaluation.py
@@ -42,7 +42,7 @@ from wptgen.llm import get_llm_client
 from wptgen.models import WorkflowContext
 from wptgen.phases.requirements_extraction import run_requirements_extraction
 from wptgen.ui import UIProvider
-from wptgen.utils import locate_snippet
+from wptgen.utils import locate_snippet, read_test_source
 
 
 @dataclass
@@ -178,14 +178,6 @@ def _input_scope_to_payload(input_scope: InputScope) -> dict[str, Any]:
         "total_bytes": input_scope.total_bytes,
         "approximate_input_tokens": input_scope.approximate_input_tokens,
     }
-
-
-def _read_test_source(test_path: Path) -> str | None:
-    """The test file's text for citation resolution, or None if unreadable."""
-    try:
-        return test_path.read_text(encoding="utf-8")
-    except OSError:
-        return None
 
 
 def _payload_to_findings(
@@ -351,7 +343,7 @@ async def _run_conformance(
     )
     conf_findings, conf_demoted = _payload_to_findings(
         conformance_payload.get("findings", []) or [],
-        _read_test_source(test_path),
+        read_test_source(test_path),
     )
     _warn_demoted_citations(ui, "conformance", conf_demoted)
     return ConformanceSection(
@@ -418,7 +410,7 @@ async def run_evaluation(
     agent_payload, doc_inputs_tokens = agent_result
     findings, demoted = _payload_to_findings(
         agent_payload.get("findings", []) or [],
-        _read_test_source(test_path),
+        read_test_source(test_path),
     )
     _warn_demoted_citations(ui, "documentation", demoted)
     input_scope = _payload_to_input_scope(

--- a/wptgen/skills/wpt-evaluator-conformance/SKILL.md
+++ b/wptgen/skills/wpt-evaluator-conformance/SKILL.md
@@ -45,13 +45,15 @@ For each finding:
     may be legitimate reasons for such tests, but the absence of a
     matching requirement is worth surfacing.
   - `info` and `nit` are not used by this skill.
-- **Line reference** into the test file under evaluation.
-- **Short evidence quote** from the test file (the assertion in
-  question).
+- **`citation`**: the exact verbatim assertion/snippet from the test file
+  the finding concerns — obtained from the `locate` tool, never written
+  from memory. Leave empty when there is no snippet to quote. The line
+  reference is derived from it; do not provide `test_line` yourself.
 - **Source citation**: the requirement ID (e.g. `R3`) that the finding
   relates to, formatted as `requirements.xml#R3`. For `warn` findings
   where no requirement matches, use `requirements.xml#none-matched`.
-- **One-sentence summary** of the contradiction or gap.
+- **`summary`**: one or two sentences stating the requirement and how this
+  test contradicts or gaps it.
 
 ### Prohibited outputs
 

--- a/wptgen/skills/wpt-evaluator/SKILL.md
+++ b/wptgen/skills/wpt-evaluator/SKILL.md
@@ -40,11 +40,15 @@ test, or human review. It complements those steps; it does not replace them.
 For each issue, a finding with these fields:
 
 - `severity`: `error`, `warn`, `info`, or `nit`.
-- `test_line`: a line reference into the test file under evaluation.
-- `evidence`: a short verbatim quote from the test file.
+- `citation`: the exact verbatim snippet from the test file the finding
+  points at — obtained from the `locate` tool, never written from memory.
+  Leave empty for a finding about something missing or a whole-file
+  property. The line reference is derived from it; do not provide
+  `test_line` yourself.
 - `source`: provenance for the finding (see the strategy-specific note
   below).
-- `summary`: a one-sentence paraphrase of what the guidance requires.
+- `summary`: one or two sentences stating the governing rule and how it
+  applies to this test.
 
 Strategy-specific fields:
 
@@ -211,18 +215,14 @@ corpus you used.
 Applies when `strategy: distilled`. All rules live in
 [`references/rules.yaml`](references/rules.yaml). Each rule carries:
 
-- `id`: stable identifier, prefixed with the category code (e.g.,
-  `CHECKLIST-017`, `CHECKLIST-012`). This is what you report as a finding's
-  `rule_id`.
+- `id`: stable identifier with a topic prefix (e.g., `CHECKLIST-017`,
+  `GENERAL-005`). This is what you report as a finding's `rule_id`.
 - `source`: provenance — a repo-root-relative path whose first segment
   identifies the originating repository (`wpt/...` for upstream
   `web-platform-tests/wpt`, `wpt-gen/...` for this repository), with a
   `#L<start>-L<end>` line anchor where the location is stable. Copy this
   through to a finding's `source`. See [`UPSTREAM.md`](UPSTREAM.md) for
   the convention.
-- `category`: the topic of the rule. Categories describe *what kind of issue*
-  the rule covers, never *what kind of test* it applies to. See the list
-  below.
 - `applies_to`: which test kinds the rule is relevant to (e.g.,
   `testharness`, `reftest`, `manual`, `idl`, `visual`, `js`, `html`, `css`,
   `any`, `worker`). Used for filtering the corpus when loading into context.
@@ -233,24 +233,10 @@ Applies when `strategy: distilled`. All rules live in
 - `rule`: the normative statement. This is the self-contained text you
   evaluate the test against.
 
-### Categories
-
-| Code     | Category       | Covers                                                       |
-| -------- | -------------- | ------------------------------------------------------------ |
-| `FMT`    | `file-format`  | File format, encoding, boilerplate and harness inclusion.    |
-| `NAME`   | `filename`     | Filename, path length, suffix flags and their ordering.      |
-| `META`   | `metadata`     | `<meta>` elements and `// META:` comment directives.         |
-| `ASSERT` | `assertions`   | Choice and specificity of test assertions.                   |
-| `ASYNC`  | `async-timing` | Timing, timeouts, event-based waits, animation frames.       |
-| `INDEP`  | `independence` | Test isolation, cleanup, and consistency across runs.        |
-| `STRUCT` | `structure`    | Structural shape of a test (e.g., reftest links, refs, instructions). |
-| `API`    | `api-usage`    | Correct use of WPT harness APIs (`idlharness`, `setup()`, etc.). |
-| `PORT`   | `portability`  | Cross-platform and self-containment requirements.            |
-| `FOCUS`  | `focus`        | Test scope, conservatism, and self-description.              |
-| `REV`    | `review`       | General reviewer checklist items not covered above.          |
-
-The full corpus is small enough to load once. Upstream provenance for the
-rule set is documented in [`UPSTREAM.md`](UPSTREAM.md).
+Rules are grouped by the `id` prefix (`GENERAL-*`, `CHECKLIST-*`,
+`TESTHARNESS-*`, `REFTESTS-*`, etc.). Read `references/rules.yaml` directly
+for the authoritative set — it is small enough to load once. Upstream
+provenance is documented in [`UPSTREAM.md`](UPSTREAM.md).
 
 ## Corpus: raw
 

--- a/wptgen/templates/adk_conformance_evaluator.jinja
+++ b/wptgen/templates/adk_conformance_evaluator.jinja
@@ -12,9 +12,11 @@ Consider the specifications together: an assertion may satisfy one spec while di
 </spec>
 {% endfor %}
 
+To anchor a finding to a line, call the `locate` tool with the offending assertion/snippet and record a returned match's `text` as the finding's `citation`. Never write a line number or citation from memory. If a finding has no snippet to quote, leave `citation` empty.
+
 When the evaluation is complete, submit your findings via the `report_conformance_complete` tool. Pass:
 
-- `findings`: a list of finding objects (one per issue raised). Each finding must include the fields `title`, `severity`, `test_line`, `evidence`, `source`, and `summary` as described in the tool's parameter spec. Use only the severities `error` (contradicts a requirement) and `warn` (assertion on behavior not in the requirements). Attribute each finding to the spec it concerns: set `source` to that spec's URL followed by the requirement id, e.g. `https://drafts.csswg.org/css-flexbox/#R3`. If you found no issues, pass an empty list.
+- `findings`: a list of finding objects (one per issue raised). Each finding must include the fields `title`, `severity`, `citation` (verbatim from `locate`, or `""`), `source`, and `summary` (the requirement and how this test contradicts or gaps it) as described in the tool's parameter spec. Do NOT include `test_line`. Use only the severities `error` (contradicts a requirement) and `warn` (assertion on behavior not in the requirements). Attribute each finding to the spec it concerns: set `source` to that spec's URL followed by the requirement id, e.g. `https://drafts.csswg.org/css-flexbox/#R3`. If you found no issues, pass an empty list.
 - `input_scope`: an object describing every file you opened during the evaluation. Include `files` (a list of `{path, bytes, role}` rows; roles are `skill`, `test`, `requirements`, or `dependency`), `dependencies_not_read` (framework + external dependencies you detected but did not open), and `strategy` (set to `"distilled"` — conformance judges against the distilled requirements).
 
 Do NOT format the report yourself; the wpt-gen CLI renders the final Markdown from the data you submit. Do NOT write any file to disk.

--- a/wptgen/templates/adk_evaluator.jinja
+++ b/wptgen/templates/adk_evaluator.jinja
@@ -2,12 +2,14 @@ Evaluate the WPT test file at the path below using the {{ skill_name }} skill. R
 
 <test_file>{{ test_path }}</test_file>
 
+To anchor a finding to a line, call the `locate` tool with the offending snippet and record a returned match's `text` as the finding's `citation`. Never write a line number or citation from memory — a citation must come from `locate` so it always matches the file. If a finding is about something missing or a whole-file property (no snippet to quote), leave `citation` empty.
+
 When the evaluation is complete, submit your findings via the `report_evaluation_complete` tool. Pass:
 
 {% if strategy == "distilled" -%}
-- `findings`: a list of finding objects (one per rule violation raised). Each finding must include the fields `rule_id` (the violated `rules.yaml` rule, e.g. `GENERAL-005`), `title`, `severity`, `test_line`, `evidence`, `source`, and `summary` as described in the tool's parameter spec. If you found no issues, pass an empty list.
+- `findings`: a list of finding objects (one per rule violation raised). Each finding must include the fields `rule_id` (the violated `rules.yaml` rule, e.g. `GENERAL-005`), `title`, `severity`, `citation` (verbatim from `locate`, or `""`), `source`, and `summary` (the rule and how it applies to this test) as described in the tool's parameter spec. Do NOT include `test_line`. If you found no issues, pass an empty list.
 {% else -%}
-- `findings`: a list of finding objects (one per issue raised). Each finding must include the fields `title`, `severity`, `test_line`, `evidence`, `source` (the upstream doc path + line range that prompted the finding), and `summary` as described in the tool's parameter spec. If you found no issues, pass an empty list.
+- `findings`: a list of finding objects (one per issue raised). Each finding must include the fields `title`, `severity`, `citation` (verbatim from `locate`, or `""`), `source` (the upstream doc path + line range that prompted the finding), and `summary` (the guidance and how it applies to this test) as described in the tool's parameter spec. Do NOT include `test_line`. If you found no issues, pass an empty list.
 {% endif -%}
 - `input_scope`: an object describing every file you opened during the evaluation. Include `files` (a list of `{path, bytes, role}` rows), `dependencies_not_read` (framework + external dependencies you detected but did not open), and `strategy` (set to `"{{ strategy }}"`).
 

--- a/wptgen/templates/evaluator_report.jinja
+++ b/wptgen/templates/evaluator_report.jinja
@@ -13,11 +13,13 @@ Model: `{{ run_metadata.model }}` (provider: `{{ run_metadata.provider }}`)
 - **Rule**: `{{ f.rule_id }}`
 {% endif -%}
 - **Severity**: {{ f.severity }}
-- **Test line**: {{ f.test_line }}
-- **Evidence**:
+- **Test line**: {{ f.test_line if f.test_line else "file-scoped (no citation)" }}
+{% if f.citation -%}
+- **Citation**:
   ```
-  {{ f.evidence | indent(2, first=False) }}
+  {{ f.citation | indent(2, first=False) }}
   ```
+{% endif -%}
 - **Source**: `{{ f.source }}`
 - **Summary**: {{ f.summary }}
 
@@ -41,11 +43,13 @@ No findings raised.
 ### Conformance finding {{ loop.index }} — {{ f.title }}
 
 - **Severity**: {{ f.severity }}
-- **Test line**: {{ f.test_line }}
-- **Evidence**:
+- **Test line**: {{ f.test_line if f.test_line else "file-scoped (no citation)" }}
+{% if f.citation -%}
+- **Citation**:
   ```
-  {{ f.evidence | indent(2, first=False) }}
+  {{ f.citation | indent(2, first=False) }}
   ```
+{% endif -%}
 - **Source**: `{{ f.source }}`
 - **Summary**: {{ f.summary }}
 

--- a/wptgen/utils.py
+++ b/wptgen/utils.py
@@ -61,6 +61,33 @@ def clean_file_content(content: str) -> str:
     return content.rstrip("\r\n") + "\n"
 
 
+def _normalize_ws(text: str) -> str:
+    """Collapses whitespace runs to one space and trims, for permissive
+    matching of a snippet the model may have reflowed or re-indented."""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def locate_snippet(snippet: str, source: str) -> list[tuple[int, str]]:
+    """Every (1-based line, exact source text) where ``snippet`` appears.
+
+    Whitespace-normalized substring match on the snippet's first non-blank
+    line. Returns the source's own text for each hit, so a caller can anchor a
+    finding to real file content that it never has to transcribe. Empty when
+    the snippet is not present.
+    """
+    snippet_lines = [ln for ln in snippet.splitlines() if ln.strip()]
+    if not snippet_lines:
+        return []
+    needle = _normalize_ws(snippet_lines[0])
+    if not needle:
+        return []
+    return [
+        (i, src_line)
+        for i, src_line in enumerate(source.splitlines(), start=1)
+        if needle in _normalize_ws(src_line)
+    ]
+
+
 def extract_xml_tag(text: str, tag: str) -> str | None:
     """Extracts the content of an XML-like tag from a string."""
     match = re.search(f"<{tag}>(.*?)</{tag}>", text, re.DOTALL)

--- a/wptgen/utils.py
+++ b/wptgen/utils.py
@@ -61,6 +61,14 @@ def clean_file_content(content: str) -> str:
     return content.rstrip("\r\n") + "\n"
 
 
+def read_test_source(test_path: Path) -> str | None:
+    """The test file's text (for citation resolution), or None if unreadable."""
+    try:
+        return test_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
 def _normalize_ws(text: str) -> str:
     """Collapses whitespace runs to one space and trims, for permissive
     matching of a snippet the model may have reflowed or re-indented."""


### PR DESCRIPTION
Adds `scripts/benchmark/select_corpus.py`, the tool that picks the **consistency corpus** — a set of real merged wpt files the evaluator is run against repeatedly to measure *precision* (run-to-run judgment variance). 

### CLI

Every flag is optional; the defaults _are_ the pinned recipe:

```bash
python scripts/benchmark/select_corpus.py \
  [--wpt-dir ../wpt] \
  [--rng-seed 1] \
  [--min-bytes 1024] [--max-bytes 15360] \
  [--out benchmarks/corpus.candidate.yaml]
```

The `corpus:` YAML goes to stdout (or `--out`).

### Intended workflow

Selection is a **one-time, reproducible** procedure, not something the benchmark runs on every invocation:
1. Run the script against the pinned wpt checkout → get a candidate `corpus:` block.
2. A maintainer reviews the list (dependency-completeness and "is this representative?" are deliberately left to human review, not automated).
3. Paste the reviewed block verbatim into `benchmarks/manifest.yaml`.

Files are classified by kind (testharness / reftest / visual / manual / idl / crashtest) and filtered on size + not-a-support-file, reusing `wptgen`'s existing `is_wpt_test_file` and `lint_ext` filename predicates so the benchmark and the generator agree on what counts as a test.
### Randomizer strategy

The sample is a **fixed-seed** stratified draw: per-kind quotas, spread across top-level directories so no single feature area dominates. Same seed + same checkout ⇒ makes a pinned corpus reproducible for future refreshes. 

**Target Quota**
```
  testharness   8 / 8 
  reftest       6 / 6 
  visual        4 / 4 
  manual        4 / 4 
  idl           4 / 4 
  crashtest     3 / 3 
```
### Tests

`tests/benchmark/test_select_corpus.py` covers classification, mechanical filtering, sampler determinism/quota/spread, and manifest-ready YAML output — all against synthetic trees, no wpt checkout or agent calls needed. Compound-extension regression tests added for `is_manual_test` / MANUAL-004.  