### PR TITLE
refactors benchmarks & reports for CI

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -156,26 +156,36 @@ The intended defect (`testharness.md`) is a true positive that fired every
 repeat; the noisy `checklist.md` finding is a false positive that fired only
 once — flaky *and* spurious.
 
-A **golden** entry reports recall against its annotated labels instead — no
-TP/FP split, just a recall line and its findings:
+A **golden** entry reports recall against its annotated labels. It splits its
+findings into **True positives** (matched an annotated label) and **Unmatched**
+(did not) — the same shape as a seed, but the unmatched bucket is *not* charged
+against a score (a golden unmatched finding may be a real issue the reviewer
+missed, not a false positive):
 
 ```
 ### `golden-43400-afe0767a` (golden/testharness)
 
 - Golden: recall 0.5 (TP 1, FN 1, unmatched 1)
 
+**True positives**
+
 | title | source | firing rate | warnings |
 | --- | --- | --- | --- |
 | X25519 derivation length | `CHECKLIST-005` @ L32-32 | 3/3 (1.0) |  |
+
+**Unmatched**
+
+| title | source | firing rate | warnings |
+| --- | --- | --- | --- |
 | Redundant length assertion | `CHECKLIST-002` @ L18-18 | 2/3 (0.667) |  |
 ```
 
 This PR carried two annotated `CHECKLIST-005` labels (L32 and L4). The
-evaluator caught the L32 one every repeat (the TP) and never the L4 one (the
-FN → recall 0.5). The table lists only findings the evaluator *produced*, so
-the never-fired label has no row — it appears only in the FN count. The second
-row matched no annotated label: that is the `unmatched 1`, counted but not
-charged (it may be a real finding the reviewer missed).
+evaluator caught the L32 one every repeat (the true positive) and never the L4
+one (recall 0.5). A never-fired label has no row — it appears only in the
+`FN 1` of the recall line. The `CHECKLIST-002` finding matched no annotated
+label, so it lands under **Unmatched** — the `unmatched 1`, counted but not
+charged.
 
 ### Consistency
 
@@ -369,3 +379,13 @@ tier a labels-free stability signal today. Note the band resolution depends
 on `--repeats`: at the regression tier's 3 repeats only 0 / 0.33 / 0.67 / 1.0
 are reachable, so `high`/`low` collapse and the gate is a coarse
 flaky/not-flaky flag; the release tier's 8 repeats give the graded bands.
+
+### Future idea: rate-limit backoff for `--jobs`
+
+Not implemented, and a prerequisite for trusting `--jobs > 1`. Each run is an
+LLM agent call, so the concurrency bound is the provider's rate limit — and the harness has no 429 retry. A throttled run currently records a
+nonzero exit but still scores as an **empty result** (no findings, counted in
+the denominator), so heavy parallelism can silently corrupt the numbers rather
+than failing loudly. Needs bounded exponential backoff per task plus a way to
+distinguish a throttled run from a genuinely empty one. Until then, raise
+`--jobs` cautiously and watch for `FAILED` lines / unexpectedly empty entries.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -12,78 +12,127 @@ python scripts/benchmark/run_benchmark.py --repeats 3 [--filter role=seed]
 With no other flags the harness defaults `--manifest` to
 `benchmarks/manifest.yaml`, `--wpt-dir` to the `wpt_path` in `wpt-gen.yml`,
 and `--out` to a timestamped `bench-runs/<date>-<time>/`. All are
-overridable; other flags are `--provider`, `--config`, `--filter` (e.g.
-`role=seed`, `role=corpus`, `kind=reftest`), and `--score-only`.
+overridable. Other flags:
 
+- `--provider`, `--config` — passed through to each `wpt-gen evaluate`.
+- `--filter field=value` — `role=` (`seed`/`corpus`/`golden`) or `kind=`.
+- `--jobs N` — concurrent evaluator runs (default 1; the bound is provider
+  rate limits, not cores).
+- `--smoke` — the regression tier: run only the manifest's `smoke` sets
+  (see [Tiers](#tiers)). Composes with `--filter`.
+- `--golden-set NAME` / `--golden-prs 43400,…` — select golden entries.
+- `--min-precision` / `--min-recall` / `--min-golden-recall` / `--max-fn`
+  — CI quality gates (see [Quality gates](#quality-gates)).
+- `--score-only` — re-score existing run dirs in `--out` without the agent.
 
-The harness validates the manifest against the checkout, stages seeds into
-`<wpt-dir>/wpt-gen-bench/`, runs
+The harness stages seeds/golden into `<wpt-dir>/wpt-gen-bench/`, runs
 `wpt-gen evaluate` `--repeats` times per entry into
-`<out>/runs/<entry-id>/rep-<i>/`, then scores every entry and writes
-`<out>/report.md` + `<out>/report.json`. `--score-only` re-scores existing
-run dirs without invoking the agent (pass the same `--out`). Scoring itself lives in
-`scripts/benchmark/scoring.py` and is covered by
-`tests/benchmark/test_run_benchmark.py`, which runs entirely on synthetic run
-dirs (no agent calls).
+`<out>/runs/<entry-id>/rep-<i>/`, then scores and writes `<out>/report.md`
++ `<out>/report.json`.
+
+Scoring lives in `scripts/benchmark/scoring.py`, covered by
+`tests/benchmark/` on synthetic run dirs (no agent calls).
+
+### Tiers
+
+Two suggestions for how to run, differing only in selection and repeats:
+
+- **Release** — full manifest, 8 repeats (`run_benchmark.py`). Establishes
+  the consistency band; run before a corpus/skill release or after a model
+  change.
+- **Regression** — `--smoke --repeats 3`. Runs the manifest's `smoke`
+  corpus/seed/golden sets only; a fast guard for skill/evaluator changes.
+
+Tiers are selection, not schema: the manifest defines which entries are in
+`smoke` (see [Manifest schema](#manifest-schema)); `--repeats` and any
+quality gate stay on the command line.
+
+### Quality gates
+
+For CI. A gate lets a build **fail on a quality regression** — e.g. a skill
+change that drops seed recall — so the drop blocks the change instead of
+landing silently. The report is always written *first*, so a failing build
+can still post its full table onto the PR.
+
+The four `--min-*`/`--max-fn` flags gate the **exit code**: any breach exits
+non-zero. Omitting a flag leaves that check off, so by default a run always
+exits 0. `--max-fn` sums seed and golden false negatives.
 
 ## Reading a benchmark report
 
 Each run writes `report.md` (this section is what it links to) and an
-identical-content `report.json`. Precision and Recall metrics are computed only over `seed`
-entries.
+identical-content `report.json`. It opens with a **scope** line (entry counts
+per type and repeats),
+then a per-dataset **summary**, then a **per-entry** breakdown. Which numbers
+an entry contributes to the report depends on its type — seed precision/recall over `seed`
+entries, golden recall over `golden` entries, and `corpus` entries feed
+consistency only.
 
-**Precision** — of the findings the evaluator emitted, the fraction that
-were expected. Target **1.0** (no false positives). 
+### The summary table
 
-**Recall** — of the
-seeded defects, the fraction the evaluator caught. Target **1.0** (nothing
-missed).
+One row per dataset present in the run — its headline number and entry count:
 
-Abbreviations in the seed scores:
+| dataset | metric | value | entries |
+| --- | --- | --- | --- |
+| seed | precision / recall | 0.83 / 1.0 | 12 |
+| golden | recall | 0.75 | 8 |
+| corpus | flaky findings (mid) | 2 | 29 |
+
+**Precision** — of the findings the evaluator emitted, the fraction that were
+expected. Target **1.0** (no false positives).
+
+**Recall** — of the expected findings, the fraction the evaluator caught.
+Target **1.0** (nothing missed).
+
+The corpus row counts **mid**-band (flaky) findings — see
+[Consistency](#consistency); corpus is not scored for precision or recall.
+A one-line caveat under the table surfaces anything counted-but-not-scored
+(golden unmatched predictions, advisory notes).
+
+The seed scores abbreviate as:
 
 - **TP** — true positive: an expected finding fired.
 - **FP** — false positive: an unexpected finding fired (including any
   finding on a known-clean seed).
 - **FN** — false negative: an expected finding was missed.
 
-**Advisory notes** — findings whose `source` cites an upstream doc that is
-*not* on the evaluator's curated reading list (parsed from the evaluator
-SKILL.md), which suggests an invented citation. This is *advisory only*, not
-a pass/fail gate: the report counts them and annotates each finding's row,
-but they do not count against any score. This check is meaningful while the
-evaluator reads the raw curated docs; a future rules-based strategy would
-replace it with a rule-id validity check.
+**The two recall 1.0s are not the same kind of target.** Seed recall is 1.0
+against a defect *you injected* — an exact, fixed answer key. Golden recall is
+1.0 against a *human-derived, hand-annotated* denominator: which PRs are in the
+set and how each comment is annotated are both judgment calls, still iterating.
+So golden recall is a target on a moving denominator — a miss may mean the
+evaluator regressed *or* that a label needs re-annotation — where seed recall
+is more of a hard invariant. Golden also has no precision number yet: unmatched
+predictions are counted but not charged, since one may be a valid finding the
+reviewer missed rather than a false positive.
 
-The **Aggregate** table rolls the seed scores up across all seeds:
+### Per-entry findings
 
-| metric | value | target |
-| --- | --- | --- |
-| seed precision | 0.83 | 1.0 |
-| seed recall | 1.0 | 1.0 |
-| seed TP / FP / FN | 5 / 1 / 0 | FP=0, FN=0 |
+Each entry then lists the findings it produced as a table:
+`title | source | firing rate | warnings`. The `firing rate` column is
+`firings/repeats (rate)`, and `warnings` counts that finding's advisory notes
+(e.g. `⚠ source ×2`, see [Advisory notes](#advisory-notes)). What differs by
+entry type is how those findings are scored.
 
- `corpus` entries are measured for
-consistency only.
+A **corpus** entry has no labels, so it shows a single **Findings** table —
+every finding read for its firing rate, none scored:
 
-**Consistency** — how often each finding fires across the repeats. There is
-no single target: a finding *should* sit at an extreme (**always** or
-**never**); the **mid** band is the flaky zone to drive out. The report
-buckets every finding's firing rate:
+```
+### `corpus-url-data-uri-fragment` (corpus/testharness)
 
-| bucket | firing rate | meaning |
-| --- | --- | --- |
-| always | 1.0 | fires every repeat - trustworthy |
-| high | ≥0.75 | usually fires |
-| mid | 0.25–0.75 | flaky zone |
-| low | >0 | rarely fires |
-| never | 0.0 | never fires |
+**Findings**
 
-Each entry then lists its own findings as a table. **Seed** entries split
-their findings into **True positives** (matched a gold label) and **False
-positives** (did not); **corpus** entries, which have no labels, show one
-**Findings** table. The `firing rate` column is `firings/repeats (rate)`,
-and `warnings` counts that finding's advisory notes (e.g. `⚠ source ×2`).
-A per-entry example:
+| title | source | firing rate | warnings |
+| --- | --- | --- | --- |
+| Missing metadata comment | `GENERAL-004` @ L1-1 | 3/3 (1.0) |  |
+| Ambiguous assertion message | `TESTHARNESS-006` @ L22-22 | 2/3 (0.667) |  |
+```
+
+The `GENERAL-004` finding is stable (**always**); the flaky `TESTHARNESS-006`
+one (2/3) sits in the **mid** band (see [Consistency](#consistency)).
+
+A **seed** entry splits its findings into **True positives** (matched a gold
+label) and **False positives** (did not):
 
 ```
 ### `seed-worker-missing-done` (seed/testharness)
@@ -103,11 +152,64 @@ A per-entry example:
 | Test not in spec directory | `wpt/docs/reviewing-tests/checklist.md` @ L1-1 | 1/3 (0.333) |  |
 ```
 
-Here the intended defect (`testharness.md`) is a true positive that fired
-every repeat, while a noisy `checklist.md` finding is a false positive that
-also fired only once — flaky *and* spurious.
+The intended defect (`testharness.md`) is a true positive that fired every
+repeat; the noisy `checklist.md` finding is a false positive that fired only
+once — flaky *and* spurious.
 
-## Layout
+A **golden** entry reports recall against its annotated labels instead — no
+TP/FP split, just a recall line and its findings:
+
+```
+### `golden-43400-afe0767a` (golden/testharness)
+
+- Golden: recall 0.5 (TP 1, FN 1, unmatched 1)
+
+| title | source | firing rate | warnings |
+| --- | --- | --- | --- |
+| X25519 derivation length | `CHECKLIST-005` @ L32-32 | 3/3 (1.0) |  |
+| Redundant length assertion | `CHECKLIST-002` @ L18-18 | 2/3 (0.667) |  |
+```
+
+This PR carried two annotated `CHECKLIST-005` labels (L32 and L4). The
+evaluator caught the L32 one every repeat (the TP) and never the L4 one (the
+FN → recall 0.5). The table lists only findings the evaluator *produced*, so
+the never-fired label has no row — it appears only in the FN count. The second
+row matched no annotated label: that is the `unmatched 1`, counted but not
+charged (it may be a real finding the reviewer missed).
+
+### Consistency
+
+Every finding also carries a **firing rate** — how often it fired across the
+repeats. There is no single target: a finding *should* sit at an extreme
+(**always** or **never**); the **mid** band is the flaky zone to drive out.
+`corpus` entries are measured for this *only* — a corpus file is a known-real
+merged test, so a finding on one is arguably a false positive, but today corpus
+feeds only this histogram, never precision.
+
+| bucket | firing rate | meaning |
+| --- | --- | --- |
+| always | 1.0 | fires every repeat - trustworthy |
+| high | ≥0.75 | usually fires |
+| mid | 0.25–0.75 | flaky zone |
+| low | >0 | rarely fires |
+| never | 0.0 | never fires |
+
+### Advisory notes
+
+Findings whose `source` cites an upstream doc *not* on the evaluator's curated
+reading list (parsed from the evaluator SKILL.md), suggesting an invented or
+off-list source. This guards the `source` field (which doc the finding cites);
+the separate `citation` field — the verbatim snippet and its line — is verified
+deterministically at evaluation time, so a fabricated line number never reaches
+the report.
+
+Advisory notes are *advisory only*, not a pass/fail gate: the report counts
+them and annotates each finding's row (the `⚠` in the `warnings` column), but
+they do not count against any score. Most meaningful while the evaluator reads
+the raw curated docs; a `rules.yaml` strategy would replace it with a rule-id
+validity check.
+
+## Directory Layout
 
 ```
 benchmarks/
@@ -117,9 +219,14 @@ benchmarks/
     reftest/
     clean/        # well-formed files; any finding is a false positive
   golden/
-    candidates/   # harvested PR snapshots (Not Yet Implemented)); holdout-window
-                  # annotations live in a private location, not here
+    candidates/   # harvested merged-PR snapshots (public)
+    annotated/    # human-review answer keys (dev-window set; see golden/README.md)
 ```
+
+The golden set (real merged PRs scored for recall vs. human review) has its
+own workflow — harvest, annotate, score — documented in
+[`golden/README.md`](golden/README.md), including the dev-window vs. holdout
+split for annotations.
 
 ## Datasets
 
@@ -128,6 +235,7 @@ benchmarks/
 | consistency corpus (`corpus:` entries) | none | run-to-run variance per finding key |
 | seeded-defect set (`seeds:` with non-empty `expect`) | exact (injected) | precision / recall |
 | known-clean (`seeds:` with empty `expect`) | exact (no findings) | precision |
+| golden set (`golden/`) | human PR review | recall vs. review (see `golden/README.md`) |
 
 Corpus entries are real merged wpt files referenced by path inside the
 checkout. 
@@ -170,7 +278,7 @@ the cases). Both share `id` and `kind`:
 - `seeds[]` — checked-in seed files with gold labels:
   - `seed` — path relative to `benchmarks/seeds/`.
   - `expect[]` — gold labels: finding keys that MUST fire (empty `[]` for a
-    known-clean seed).
+    known-clean seed). Fields:
     - `source_doc` — a path *into the wpt docs* naming the passage this seed
       targets. The finding key when `rule_id` is null; once `rule_id` is set,
       it becomes documentation only. May carry a trailing `:L…` doc-line
@@ -184,14 +292,6 @@ the cases). Both share `id` and `kind`:
       (not in the source doc), inclusive. This is where the finding should
       anchor; a prediction whose `test_line` falls outside the window does
       not match this label.
-
-### Future idea: a `forbid` list for known false positives
-
-Not implemented. A per-seed `forbid` list
-could file and categorize *repeated, known* false positives seen in the wild
-(distinct from novel ones), so a regression that re-introduces a catalogued
-FP is flagged on its own rather than folded into the aggregate. Worth adding
-when the benchmark runs continuously and an FP backlog accumulates.
 
 ## Finding keys: rule ids
 
@@ -236,23 +336,36 @@ them.
   the `// META:` block trips the linter's `STRAY-METADATA` rule.
 - Re-review seeds whenever `rules.yaml` bumps its version.
 
-## Current status: proof of concept
+## Current status
 
-The seeds here are a deliberately small proof of concept — enough to wire up
-and test the harness, not the full stratified set. Two reasons to keep it
-small for now:
+The consistency corpus is a stratified, maintainer-reviewed set (across every
+kind), suggested by `scripts/benchmark/select_corpus.py` and pinned via
+`wpt_upstream_commit`. The golden dev set is in place (see `golden/README.md`).
 
-1. Seed authoring is the expensive, judgment-heavy part of this work, and it
-   gets substantially cheaper once `rules.yaml` lands: each rule already
-   names its violation and its source anchor, so seeds (and their `expect`
-   labels) can be **generated from the rules corpus** and then translated
-   back to doc keys for the pre-merge baseline.
-2. The "consistency corpus" (20–40 files across every kind) should be selected by a
-   scripted, fixed-seed procedure and pinned after maintainer review.
-
-The current entries exercise the schema end to end (a violation seed with
-a doc-keyed label, a reference-quality seed, a clean file, and two real
-corpus files).
+Seeds remain a deliberately small proof of concept — enough to exercise the
+schema, not the full set. Seed authoring is the expensive, judgment-heavy
+part; it gets cheaper now that `rules.yaml` has landed, since each rule names
+its violation and source anchor, so seeds and their `expect` labels can be
+generated from the rules corpus.
 
 The benchmark runs the WPT Docs Eval agent only; the --spec conformance check is 
 out of scope until spec requirements XML can be pinned per test.
+
+### Future idea: a `forbid` list for known false positives
+
+Not implemented. A per-seed `forbid` list
+could file and categorize *repeated, known* false positives seen in the wild
+(distinct from novel ones), so a regression that re-introduces a catalogued
+FP is flagged on its own rather than folded into the aggregate. Worth adding
+when the benchmark runs continuously and an FP backlog accumulates.
+
+### Future idea: a consistency gate (`--max-mid`)
+
+Not implemented. The consistency histogram is currently **informational
+only** — rendered in the report, but not a quality gate. The `mid` band is
+"the flaky zone to drive out," but nothing enforces it. A `--max-mid` (max
+flaky rows) gate would make the histogram gateable, giving the regression
+tier a labels-free stability signal today. Note the band resolution depends
+on `--repeats`: at the regression tier's 3 repeats only 0 / 0.33 / 0.67 / 1.0
+are reachable, so `high`/`low` collapse and the gate is a coarse
+flaky/not-flaky flag; the release tier's 8 repeats give the graded bands.

--- a/benchmarks/manifest.yaml
+++ b/benchmarks/manifest.yaml
@@ -178,8 +178,19 @@ seeds:
 # Run one with `--golden-set <name>`. With no --golden-set/--golden-prs, all
 # annotated PRs run. A missing artifact for a listed PR is warned and skipped.
 golden_sets:
-  # Fast smoke: one self-contained reftest with an invalid-CSS (CHECKLIST-002)
-  # label the structural evaluator can catch by reading the single file.
   smoke: [47302]
   # Every dev-set PR that maps at least one rule (drops the all-no-rule ones).
   mapped: [43400, 46642, 47302, 47662, 47856, 48260, 49133, 49140]
+
+# Named subsets of corpus/seeds by entry id, parallel to golden_sets. 
+# `--smoke` unions the three `smoke` sets.
+corpus_sets:
+  # A few files spanning kinds, enough to catch gross variance regressions.
+  smoke:
+    - corpus-url-data-uri-fragment            # testharness
+    - corpus-CSS2-tables-table-anonymous-objects-110  # reftest
+    - corpus-notifications-idlharness         # idl
+# High-quality seeds still in-progress
+seed_sets:
+  smoke:
+    - seed-clean-headers-append

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,102 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the WPT evaluator benchmark on Cloud Build. Trigger it manually
+# (`gcloud builds submit`) or from a manual Cloud Build trigger — not on every
+# push, since a run spends provider API budget. The provider API key is pulled
+# from Secret Manager.
+#
+# Two tiers, selected by substitutions (defaults = release):
+#   Release     full manifest, 8 repeats, no quality gate. Establishes the
+#               consistency band; run before a corpus/skill release or after a
+#               model change. ~240 agent runs.
+#                 gcloud builds submit --config cloudbuild.yaml
+#   Regression  the manifest's `smoke` sets only, 3 repeats, gated on seed
+#               recall. Guards against regressions on a skill/evaluator change.
+#                 gcloud builds submit --config cloudbuild.yaml \
+#                   --substitutions=_SELECT=--smoke,_REPEATS=3,_MIN_RECALL=1.0
+#
+# Substitutions:
+#   _PROVIDER    provider to evaluate with (blank = config default)
+#   _SECRET      Secret Manager secret holding the provider API key
+#   _JOBS        concurrent evaluator runs (raise once rate limits allow)
+#   _REPEATS     repeats per entry (release 8, regression 3)
+#   _SELECT      entry selection (blank = full manifest; `--smoke` = the tier)
+#   _MIN_RECALL  seed-recall gate; blank leaves it off (release doesn't gate)
+#   _WPT_PIN     wpt commit to check out; keep in sync with
+#                benchmarks/manifest.yaml:wpt_upstream_commit
+substitutions:
+  _PROVIDER: ''
+  _SECRET: 'GEMINI_API_KEY'
+  _JOBS: '1'
+  _REPEATS: '8'
+  _SELECT: ''
+  _MIN_RECALL: ''
+  _WPT_PIN: 'f5a7deaba2bffac7a534dfafaa3baf14b9a253cf'
+
+# The _SECRET key is decrypted into a generic build-time env; the run step
+# re-exports it under the provider-specific name config.py expects.
+availableSecrets:
+  secretManager:
+    - versionName: projects/$PROJECT_ID/secrets/${_SECRET}/versions/latest
+      env: PROVIDER_API_KEY
+
+steps:
+  - id: clone-wpt
+    name: gcr.io/cloud-builders/git
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        git clone --filter=blob:none \
+          https://github.com/web-platform-tests/wpt.git /workspace/wpt
+        git -C /workspace/wpt checkout "${_WPT_PIN}"
+
+  # Install and run in one Python step so the venv/deps persist across the
+  # invocation. config.py reads a provider-specific <PROVIDER>_API_KEY, so the
+  # generic secret is re-exported under that name (falling back to _SECRET when
+  # the provider is the config default).
+  - id: run-benchmark
+    name: python:3.13-slim
+    entrypoint: bash
+    secretEnv: ['PROVIDER_API_KEY']
+    args:
+      - -c
+      - |
+        set -euo pipefail
+        key_var="${_PROVIDER:+$(echo "${_PROVIDER}" | tr '[:lower:]' '[:upper:]')_API_KEY}"
+        export "${key_var:-${_SECRET}}"="${PROVIDER_API_KEY}"
+        apt-get update && apt-get install -y --no-install-recommends git
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+        python scripts/benchmark/run_benchmark.py \
+          --manifest benchmarks/manifest.yaml \
+          --wpt-dir /workspace/wpt \
+          --jobs "${_JOBS}" \
+          --repeats "${_REPEATS}" \
+          ${_SELECT} \
+          ${_PROVIDER:+--provider "${_PROVIDER}"} \
+          ${_MIN_RECALL:+--min-recall "${_MIN_RECALL}"}
+
+# Agent calls are slow; cap the build rather than let it hang. The release tier
+# (~240 runs) can approach this; drop it for the smaller regression tier.
+timeout: 7200s
+
+# Keep the report regardless of outcome, so a failed run (including a tripped
+# quality gate) stays inspectable.
+artifacts:
+  objects:
+    location: 'gs://${PROJECT_ID}-wpt-gen-bench/$BUILD_ID/'
+    paths:
+      - 'bench-runs/**'

--- a/scripts/benchmark/manifest.py
+++ b/scripts/benchmark/manifest.py
@@ -151,6 +151,9 @@ class Manifest:
     # commit/bytes/labels still come from the on-disk artifacts. An empty list
     # means "all annotated PRs".
     golden_sets: dict[str, list[int]] = field(default_factory=dict)
+    # Named corpus/seed subsets: set name -> entry ids.
+    corpus_sets: dict[str, list[str]] = field(default_factory=dict)
+    seed_sets: dict[str, list[str]] = field(default_factory=dict)
 
     @property
     def entries(self) -> list[BenchmarkEntry]:
@@ -281,7 +284,29 @@ def load_manifest(path: Path) -> Manifest:
         seeds=seeds,
         source_path=path,
         golden_sets=_parse_golden_sets(raw.get("golden_sets")),
+        corpus_sets=_parse_id_sets(raw.get("corpus_sets"), "corpus_sets"),
+        seed_sets=_parse_id_sets(raw.get("seed_sets"), "seed_sets"),
     )
+
+
+def _parse_id_sets(raw: Any, block: str) -> dict[str, list[str]]:
+    """Parses a ``<block>`` mapping (name -> entry ids), if present."""
+    if raw is None:
+        return {}
+    _require(isinstance(raw, dict), f'"{block}" must be a mapping')
+    sets: dict[str, list[str]] = {}
+    for name, ids in raw.items():
+        _require(
+            isinstance(ids, list),
+            f'{block}["{name}"] must be a list of entry ids',
+        )
+        for entry_id in ids:
+            _require(
+                isinstance(entry_id, str),
+                f'{block}["{name}"] has a non-string id: {entry_id!r}',
+            )
+        sets[str(name)] = list(ids)
+    return sets
 
 
 def _parse_golden_sets(raw: Any) -> dict[str, list[int]]:

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -42,7 +42,9 @@ import re
 import shutil
 import subprocess
 import sys
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
@@ -213,87 +215,80 @@ def _rep_dir(out: Path, entry_id: str, repeat: int) -> Path:
 
 
 class Progress:
-    """Prints one stderr line per evaluator invocation"""
+    """Prints one atomic completion line per evaluator invocation.
+
+    Workers run concurrently, each worker emits a single line when its run
+    finishes. The counter increment and write are lock-guarded.
+    """
 
     def __init__(self, total: int) -> None:
         self.total = total
         self.done = 0
+        self._lock = threading.Lock()
 
-    def start_repeat(self, entry_id: str, repeat: int, repeats: int) -> None:
-        sys.stderr.write(
-            f"[{self.done + 1}/{self.total}] {entry_id} "
-            f"rep {repeat + 1}/{repeats} ... "
-        )
-        sys.stderr.flush()
-
-    def end_repeat(self, exit_code: int, elapsed: float) -> None:
-        self.done += 1
+    def complete(
+        self, entry_id: str, repeat: int, exit_code: int, elapsed: float
+    ) -> None:
         status = "ok" if exit_code == 0 else f"FAILED ({exit_code})"
-        sys.stderr.write(f"{status} {elapsed:.1f}s\n")
-        sys.stderr.flush()
+        with self._lock:
+            self.done += 1
+            sys.stderr.write(
+                f"[{self.done}/{self.total}] {entry_id} rep {repeat + 1} "
+                f"{status} {elapsed:.1f}s\n"
+            )
+            sys.stderr.flush()
 
 
-def run_entry(
+def run_single(
     entry: BenchmarkEntry,
-    manifest: Manifest,
+    repeat: int,
     wpt_dir: Path,
     out: Path,
-    repeats: int,
     provider: str | None,
     config: Path,
     progress: Progress | None = None,
-) -> list[RunRecord]:
-    """Invokes ``wpt-gen evaluate`` ``repeats`` times for one entry."""
-    records: list[RunRecord] = []
-    test_rel = entry.test_rel_path()
-    test_abs = wpt_dir / test_rel
+) -> RunRecord:
+    """Invokes ``wpt-gen evaluate`` once for one (entry, repeat) pair."""
+    rep_dir = _rep_dir(out, entry.entry_id, repeat)
+    rep_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "wpt-gen",
+        "evaluate",
+        str(wpt_dir / entry.test_rel_path()),
+        "--wpt-dir",
+        str(wpt_dir),
+        "--output-dir",
+        str(rep_dir),
+        "--config",
+        str(config),
+    ]
+    if provider:
+        cmd += ["--provider", provider]
 
-    for i in range(repeats):
-        rep_dir = _rep_dir(out, entry.entry_id, i)
-        rep_dir.mkdir(parents=True, exist_ok=True)
-        cmd = [
-            "wpt-gen",
-            "evaluate",
-            str(test_abs),
-            "--wpt-dir",
-            str(wpt_dir),
-            "--output-dir",
-            str(rep_dir),
-            "--config",
-            str(config),
-        ]
-        if provider:
-            cmd += ["--provider", provider]
-
-        if progress:
-            progress.start_repeat(entry.entry_id, i, repeats)
-        started = time.monotonic()
-        completed = subprocess.run(  # noqa: S603 - fixed argv, no shell
-            cmd,
-            capture_output=True,
-            text=True,
-            check=False,
+    started = time.monotonic()
+    completed = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    elapsed = time.monotonic() - started
+    if progress:
+        progress.complete(entry.entry_id, repeat, completed.returncode, elapsed)
+    if completed.returncode != 0:
+        # Record it and move on; an errored repeat scores as an empty run
+        # (no findings) and still counts in the denominator.
+        sys.stderr.write(
+            f"[warn] {entry.entry_id} rep-{repeat} exited "
+            f"{completed.returncode}\n{completed.stderr}\n"
         )
-        elapsed = time.monotonic() - started
-        if progress:
-            progress.end_repeat(completed.returncode, elapsed)
-        if completed.returncode != 0:
-            # Record it and move on; an errored repeat scores as an empty
-            # run (no findings) and still counts in the denominator.
-            sys.stderr.write(
-                f"[warn] {entry.entry_id} rep-{i} exited "
-                f"{completed.returncode}\n{completed.stderr}\n"
-            )
-        records.append(
-            RunRecord(
-                entry_id=entry.entry_id,
-                repeat=i,
-                exit_code=completed.returncode,
-                wall_seconds=elapsed,
-                output_dir=str(rep_dir),
-            )
-        )
-    return records
+    return RunRecord(
+        entry_id=entry.entry_id,
+        repeat=repeat,
+        exit_code=completed.returncode,
+        wall_seconds=elapsed,
+        output_dir=str(rep_dir),
+    )
 
 
 # --- Scoring an entry from its run dirs -------------------------------------
@@ -858,6 +853,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Output/run directory (default: bench-runs/<date>-<time>/).",
     )
     parser.add_argument("--repeats", type=int, default=8)
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=1,
+        help="Concurrent evaluator runs (default: 1). The bound is provider "
+        "rate limits, not cores; 4-8 is usually safe.",
+    )
     parser.add_argument("--provider", default=None)
     parser.add_argument(
         "--filter", default=None, help="field=value, e.g. kind=reftest"
@@ -930,7 +932,7 @@ def select_golden(
         if set_name not in manifest.golden_sets:
             raise HarnessError(
                 f"--golden-set {set_name!r} not in manifest golden_sets "
-                f"({', '.join(sorted(manifest.golden_sets)) or 'none'})"
+                f'({", ".join(sorted(manifest.golden_sets)) or "none"})'
             )
         prs = manifest.golden_sets[set_name]
         if prs:  # empty list means "all"
@@ -1037,20 +1039,28 @@ def main(argv: list[str] | None = None) -> int:
                 stage_seeds(seeds_root, args.wpt_dir, seed_entries)
             if gold_entries:
                 stage_golden(args.wpt_dir, gold_entries)
-            progress = Progress(total=len(entries) * args.repeats)
-            for entry in entries:
-                run_records.extend(
-                    run_entry(
+            # Flatten to (entry, repeat) tasks so the pool fills evenly.
+            tasks = [
+                (entry, i) for entry in entries for i in range(args.repeats)
+            ]
+            progress = Progress(total=len(tasks))
+            with ThreadPoolExecutor(max_workers=args.jobs) as pool:
+                futures = [
+                    pool.submit(
+                        run_single,
                         entry=entry,
-                        manifest=manifest,
+                        repeat=i,
                         wpt_dir=args.wpt_dir,
                         out=args.out,
-                        repeats=args.repeats,
                         provider=args.provider,
                         config=args.config,
                         progress=progress,
                     )
-                )
+                    for entry, i in tasks
+                ]
+                run_records = [f.result() for f in as_completed(futures)]
+            # Completion order is nondeterministic; sort for a stable report.
+            run_records.sort(key=lambda r: (r.entry_id, r.repeat))
 
         reports, models = score_all(
             manifest=manifest,

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -226,6 +226,11 @@ class Progress:
         self.done = 0
         self._lock = threading.Lock()
 
+    def start(self, entry_id: str, repeat: int) -> None:
+        with self._lock:
+            sys.stderr.write(f"[started] {entry_id} rep {repeat + 1}\n")
+            sys.stderr.flush()
+
     def complete(
         self, entry_id: str, repeat: int, exit_code: int, elapsed: float
     ) -> None:
@@ -265,6 +270,8 @@ def run_single(
     if provider:
         cmd += ["--provider", provider]
 
+    if progress:
+        progress.start(entry.entry_id, repeat)
     started = time.monotonic()
     completed = subprocess.run(  # noqa: S603 - fixed argv, no shell
         cmd,
@@ -459,6 +466,10 @@ def score_entry(
     elif isinstance(entry, GoldenEntry):
         golden_score_dict = _golden_score_to_dict(
             score_golden(runs, entry.expect)
+        )
+        # Same classifier as seeds; renders TP vs. unmatched (uncharged).
+        classification_dict = _classification_to_dict(
+            classify_consistency_rows(cons_rows, entry.expect), notes
         )
 
     return EntryReport(
@@ -794,18 +805,28 @@ def _render_entry_consistency(entry: dict[str, Any]) -> list[str]:
     if outcome is None:  # corpus: no labels to classify by
         return ["**Findings**", "", *_finding_table(entry["consistency"])]
 
+    # Golden unmatched findings are not charged (possible human misses), so
+    # they read differently from a seed's false positives.
+    is_golden = entry["role"] == "golden"
+    unmatched_header = "**Unmatched**" if is_golden else "**False positives**"
+    missed_header = (
+        "**Missed labels** (never fired):"
+        if is_golden
+        else "**False negatives** (expected but never fired):"
+    )
+
     lines = [
         "**True positives**",
         "",
         *_finding_table(outcome["true_positives"]),
     ]
     lines += [
-        "**False positives**",
+        unmatched_header,
         "",
         *_finding_table(outcome["false_positives"]),
     ]
     if outcome["missed_labels"]:
-        lines.append("**False negatives** (expected but never fired):")
+        lines.append(missed_header)
         lines.append("")
         for label in outcome["missed_labels"]:
             window = (

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -513,6 +513,51 @@ def _aggregate(reports: list[EntryReport]) -> dict[str, Any]:
     }
 
 
+# --- Quality gates ----------------------------------------------------------
+
+
+@dataclass
+class QualityThresholds:
+    """CI pass/fail bounds. None disables a check."""
+
+    min_precision: float | None = None
+    min_recall: float | None = None
+    min_golden_recall: float | None = None
+    max_fn: int | None = None
+
+
+def check_quality_gates(
+    aggregate: dict[str, Any], thresholds: QualityThresholds
+) -> list[str]:
+    """Returns one message per breached threshold (empty = all pass).
+
+    Reads the keys ``_aggregate`` already emits; ``max_fn`` sums seed and
+    golden false negatives.
+    """
+    failures: list[str] = []
+    t = thresholds
+    if t.min_precision is not None:
+        got = aggregate["seed_precision"]
+        if got < t.min_precision:
+            failures.append(f"seed precision {got} < {t.min_precision}")
+    if t.min_recall is not None:
+        got = aggregate["seed_recall"]
+        if got < t.min_recall:
+            failures.append(f"seed recall {got} < {t.min_recall}")
+    if t.min_golden_recall is not None:
+        got = aggregate["golden_recall"]
+        if got < t.min_golden_recall:
+            failures.append(f"golden recall {got} < {t.min_golden_recall}")
+    if t.max_fn is not None:
+        got = (
+            aggregate["seed_false_negatives"]
+            + aggregate["golden_false_negatives"]
+        )
+        if got > t.max_fn:
+            failures.append(f"false negatives {got} > {t.max_fn}")
+    return failures
+
+
 # --- Report emission --------------------------------------------------------
 
 
@@ -893,6 +938,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Re-score existing run dirs in --out; do not run the agent.",
     )
+    # CI quality gates: reports are always written first; these only affect the
+    # exit code. Omit a flag to leave that check off.
+    parser.add_argument("--min-precision", type=float, default=None)
+    parser.add_argument("--min-recall", type=float, default=None)
+    parser.add_argument("--min-golden-recall", type=float, default=None)
+    parser.add_argument("--max-fn", type=int, default=None)
     return parser.parse_args(argv)
 
 
@@ -1087,6 +1138,23 @@ def main(argv: list[str] | None = None) -> int:
     )
     write_reports(args.out, report)
     sys.stderr.write(f'wrote {args.out / "report.md"}\n')
+
+    # Gate the exit code only after reports are on disk, so CI can publish the
+    # full table even on a failing run.
+    failures = check_quality_gates(
+        report.aggregate,
+        QualityThresholds(
+            min_precision=args.min_precision,
+            min_recall=args.min_recall,
+            min_golden_recall=args.min_golden_recall,
+            max_fn=args.max_fn,
+        ),
+    )
+    if failures:
+        sys.stderr.write("quality gate failed:\n")
+        for failure in failures:
+            sys.stderr.write(f"  - {failure}\n")
+        return 1
     return 0
 
 

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -934,6 +934,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "Intersected with --golden-set if both are given.",
     )
     parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Regression tier: the manifest's `smoke` corpus/seed/golden sets "
+        "only. Composes with --filter; repeats stay --repeats.",
+    )
+    parser.add_argument(
         "--score-only",
         action="store_true",
         help="Re-score existing run dirs in --out; do not run the agent.",
@@ -1008,6 +1014,33 @@ def select_golden(
     return [by_pr[pr] for pr in sorted(wanted & by_pr.keys())]
 
 
+SMOKE_SET_NAME = "smoke"
+
+
+def select_smoke(
+    manifest: Manifest, corpus: list[CorpusEntry], seeds: list[SeedEntry]
+) -> tuple[list[CorpusEntry], list[SeedEntry]]:
+    """Narrows corpus/seeds to their ``smoke`` set (the regression tier).
+
+    An id listed in a set but absent from the manifest is a stale grouping;
+    fail loudly rather than silently run a smaller tier.
+    """
+    return (
+        _by_ids(corpus, manifest.corpus_sets.get(SMOKE_SET_NAME, []), "corpus"),
+        _by_ids(seeds, manifest.seed_sets.get(SMOKE_SET_NAME, []), "seed"),
+    )
+
+
+def _by_ids(entries: list[Any], ids: list[str], label: str) -> list[Any]:
+    by_id = {e.entry_id: e for e in entries}
+    missing = [i for i in ids if i not in by_id]
+    if missing:
+        raise HarnessError(
+            f"{label} smoke set names unknown ids: {', '.join(missing)}"
+        )
+    return [by_id[i] for i in ids]
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
@@ -1034,15 +1067,19 @@ def main(argv: list[str] | None = None) -> int:
     seeds_root = args.manifest.parent / "seeds"
 
     try:
+        corpus, seeds = manifest.corpus, manifest.seeds
+        golden_set = args.golden_set
+        if args.smoke:
+            corpus, seeds = select_smoke(manifest, corpus, seeds)
+            # Smoke drives golden via its own set unless one was named.
+            golden_set = golden_set or SMOKE_SET_NAME
         golden_entries = select_golden(
             _load_golden(args.golden_dir),
             manifest,
-            args.golden_set,
+            golden_set,
             args.golden_prs,
         )
-        entries = apply_filter(
-            [*manifest.entries, *golden_entries], args.filter
-        )
+        entries = apply_filter([*corpus, *seeds, *golden_entries], args.filter)
     except HarnessError as exc:
         sys.stderr.write(f"{exc}\n")
         return 2

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -643,6 +643,40 @@ def _render_consistency_table(hist: dict[str, int]) -> list[str]:
     return lines
 
 
+def _entry_counts(entries: list[dict[str, Any]]) -> dict[str, int]:
+    """Entry count per role."""
+    counts = {"seed": 0, "golden": 0, "corpus": 0}
+    for entry in entries:
+        counts[entry["role"]] = counts.get(entry["role"], 0) + 1
+    return counts
+
+
+def _render_summary(report: BenchmarkReport) -> list[str]:
+    """Per-dataset headline table: one row per dataset that has entries."""
+    agg = report.aggregate
+    counts = _entry_counts(report.entries)
+    mid = agg["consistency_histogram"]["mid"]
+    lines = ["## Summary", "", "| dataset | metric | value | entries |"]
+    lines.append("| --- | --- | --- | --- |")
+    if counts["seed"]:
+        lines.append(
+            f'| seed | precision / recall | {agg["seed_precision"]} / '
+            f'{agg["seed_recall"]} | {counts["seed"]} |'
+        )
+    if counts["golden"]:
+        lines.append(
+            f'| golden | recall | {agg["golden_recall"]} '
+            f'| {counts["golden"]} |'
+        )
+    if counts["corpus"]:
+        lines.append(
+            f"| corpus | flaky findings (mid) | {mid} "
+            f'| {counts["corpus"]} |'
+        )
+    lines.append("")
+    return lines
+
+
 def render_report_markdown(report: BenchmarkReport) -> str:
     """Renders the benchmark report as Markdown from its JSON payload."""
     agg = report.aggregate
@@ -651,10 +685,14 @@ def render_report_markdown(report: BenchmarkReport) -> str:
     lines.append("")
     model = report.model or "unknown"
     provider = report.provider or "unknown"
+    counts = _entry_counts(report.entries)
     lines.append(f"- **Model**: `{model}` (provider: `{provider}`)")
+    lines.append(
+        f'- **Scope**: {counts["seed"]} seed, {counts["golden"]} golden, '
+        f'{counts["corpus"]} corpus · {report.repeats} repeats'
+    )
     lines.append(f"- Manifest: `{report.manifest}`")
     lines.append(f"- wpt checkout: `{report.wpt_dir}`")
-    lines.append(f"- Repeats per entry: {report.repeats}")
     if report.wpt_upstream_commit_expected:
         pinned = report.wpt_upstream_commit_expected
         actual = report.wpt_upstream_commit_actual or "unknown"
@@ -666,67 +704,52 @@ def render_report_markdown(report: BenchmarkReport) -> str:
 
     lines.extend(_render_legend())
 
-    lines.append("## Aggregate")
-    lines.append("")
-    lines.append("| metric | value | target |")
-    lines.append("| --- | --- | --- |")
-    lines.append(f'| seed precision | {agg["seed_precision"]} | 1.0 |')
-    lines.append(f'| seed recall | {agg["seed_recall"]} | 1.0 |')
-    lines.append(
-        f'| seed TP / FP / FN | {agg["seed_true_positives"]} / '
-        f'{agg["seed_false_positives"]} / {agg["seed_false_negatives"]} '
-        "| FP=0, FN=0 |"
-    )
-    lines.append(
-        f'| golden recall (vs. human) | {agg["golden_recall"]} '
-        f'| TP {agg["golden_true_positives"]}, '
-        f'FN {agg["golden_false_negatives"]} |'
-    )
-    lines.append("")
-    lines.append(
-        f'Golden unmatched predictions: {agg["golden_unmatched_predictions"]} '
-        "finding(s) with no gold label — not charged as false positives "
-        "(possible human misses)."
-    )
-    lines.append("")
-    lines.append("- **TP** — true positive: an expected finding fired.")
-    lines.append("- **FP** — false positive: an unexpected finding fired.")
-    lines.append("- **FN** — false negative: an expected finding was missed.")
-    lines.append("")
-    lines.append(
-        f'Advisory notes: {agg["advisory_notes"]} finding(s) cite a source '
-        "doc that is not on the evaluator's curated reading list. Advisory "
-        "only — not a pass/fail gate."
-    )
-    lines.append("")
+    lines.extend(_render_summary(report))
+
+    # Golden unmatched + advisory are not in the summary (neither is scored);
+    # surface them as a compact caveat line so they are not lost.
+    caveats = []
+    if agg["golden_unmatched_predictions"]:
+        caveats.append(
+            f'{agg["golden_unmatched_predictions"]} golden unmatched '
+            "(not charged)"
+        )
+    if agg["advisory_notes"]:
+        caveats.append(f'{agg["advisory_notes"]} advisory note(s)')
+    if caveats:
+        lines.append("_" + "; ".join(caveats) + "._")
+        lines.append("")
+
     lines.extend(_render_consistency_table(agg["consistency_histogram"]))
 
     lines.append("## Per entry")
     lines.append("")
     for entry in report.entries:
-        lines.append(
-            f'### `{entry["entry_id"]}` ({entry["role"]}/{entry["kind"]})'
-        )
-        lines.append("")
-        if entry["seed_score"]:
-            ss = entry["seed_score"]
-            lines.append(
-                f'- Seed: precision {ss["precision"]}, recall '
-                f'{ss["recall"]} '
-                f'(TP {ss["true_positives"]}, FP {ss["false_positives"]}, '
-                f'FN {ss["false_negatives"]})'
-            )
-        if entry["golden_score"]:
-            gs = entry["golden_score"]
-            lines.append(
-                f'- Golden: recall {gs["recall"]} '
-                f'(TP {gs["true_positives"]}, FN {gs["false_negatives"]}, '
-                f'unmatched {gs["unmatched_predictions"]})'
-            )
-        lines.append("")
-        lines.extend(_render_entry_consistency(entry))
+        lines.extend(_render_entry(entry))
 
     return "\n".join(lines) + "\n"
+
+
+def _render_entry(entry: dict[str, Any]) -> list[str]:
+    """One entry's heading, score line, and finding tables."""
+    lines = [f'### `{entry["entry_id"]}` ({entry["role"]}/{entry["kind"]})', ""]
+    if entry["seed_score"]:
+        ss = entry["seed_score"]
+        lines.append(
+            f'- Seed: precision {ss["precision"]}, recall {ss["recall"]} '
+            f'(TP {ss["true_positives"]}, FP {ss["false_positives"]}, '
+            f'FN {ss["false_negatives"]})'
+        )
+    if entry["golden_score"]:
+        gs = entry["golden_score"]
+        lines.append(
+            f'- Golden: recall {gs["recall"]} '
+            f'(TP {gs["true_positives"]}, FN {gs["false_negatives"]}, '
+            f'unmatched {gs["unmatched_predictions"]})'
+        )
+    lines.append("")
+    lines.extend(_render_entry_consistency(entry))
+    return lines
 
 
 def _bucket_label(row: dict[str, Any]) -> str:

--- a/scripts/benchmark/scoring.py
+++ b/scripts/benchmark/scoring.py
@@ -480,7 +480,7 @@ class ConsistencyClassification:
 
 
 def classify_consistency_rows(
-    rows: list[ConsistencyRow], expect: list[ExpectLabel]
+    rows: list[ConsistencyRow], expect: Sequence[ExpectLabel]
 ) -> ConsistencyClassification:
     """Partitions consistency rows into TP/FP and finds missed labels."""
 

--- a/tests/benchmark/test_run_benchmark.py
+++ b/tests/benchmark/test_run_benchmark.py
@@ -1154,6 +1154,53 @@ def test_summary_omits_absent_datasets() -> None:
     assert "corpus" not in md
 
 
+def test_progress_start_prints_atomic_line(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run_benchmark.Progress(total=4).start("seed-a", 1)
+    err = capsys.readouterr().err
+    # One atomic, newline-terminated line naming the started rep (1-indexed).
+    assert err == "[started] seed-a rep 2\n"
+
+
+def _finding_row(key: str, rate: float) -> dict[str, Any]:
+    return {
+        "key": key,
+        "title": key,
+        "line_bucket": [1, 1],
+        "firings": 2,
+        "repeats": 2,
+        "rate": rate,
+        "warnings": {},
+    }
+
+
+def test_golden_entry_renders() -> None:
+    entry = {
+        "entry_id": "golden-1-abcd",
+        "role": "golden",
+        "kind": "testharness",
+        "seed_score": None,
+        "golden_score": {
+            "recall": 1.0,
+            "true_positives": 1,
+            "false_negatives": 0,
+            "unmatched_predictions": 1,
+        },
+        "consistency": [_finding_row("CHECKLIST-005", 1.0)],
+        "consistency_by_outcome": {
+            "true_positives": [_finding_row("CHECKLIST-005", 1.0)],
+            "false_positives": [_finding_row("GENERAL-007", 0.5)],
+            "missed_labels": [],
+        },
+    }
+    md = "\n".join(run_benchmark._render_entry(entry))
+    assert "**True positives**" in md
+    assert "**Unmatched**" in md
+    # Golden must not borrow the seed vocabulary.
+    assert "**False positives**" not in md
+
+
 def test_off_reading_list_citation_is_advisory_note(tmp_path: Path) -> None:
     manifest = load_manifest(_write_manifest(tmp_path, _valid_manifest_dict()))
     out = tmp_path / "out"

--- a/tests/benchmark/test_run_benchmark.py
+++ b/tests/benchmark/test_run_benchmark.py
@@ -1083,19 +1083,75 @@ def test_score_all_and_report(tmp_path: Path) -> None:
     assert full.aggregate["seed_recall"] == pytest.approx(1.0)
     md = run_benchmark.render_report_markdown(full)
     assert "WPT evaluator benchmark report" in md
-    assert "seed recall" in md
     # The model/provider must appear in the report header.
     assert "claude-opus-4-6" in md
     assert "anthropic" in md
     # Structural anchors only (not prose, which is subject to change): the
-    # legend link, the aggregate bucket table, and the per-entry finding
-    # tables (TP/FP sections + the finding-table column header).
+    # legend link, the per-dataset summary + scope line, the aggregate bucket
+    # table, and the per-entry finding tables.
     assert "#reading-a-benchmark-report" in md
+    assert "## Summary" in md
+    assert "| seed | precision / recall |" in md
+    assert "| corpus | flaky findings (mid) |" in md
+    assert "**Scope**:" in md
     assert "### Consistency buckets" in md
     assert "| bucket | firing rate | count | meaning |" in md
     assert "**True positives**" in md
     assert "**False positives**" in md
     assert "| title | source | firing rate | warnings |" in md
+
+
+def _bench_report(
+    entries: list[dict[str, Any]], aggregate: dict[str, Any]
+) -> Any:
+    return run_benchmark.BenchmarkReport(
+        manifest="m.yaml",
+        provider="p",
+        model="mdl",
+        wpt_dir="/wpt",
+        wpt_upstream_commit_expected=None,
+        wpt_upstream_commit_actual=None,
+        repeats=3,
+        entries=entries,
+        run_records=[],
+        aggregate=aggregate,
+    )
+
+
+def test_summary_renders_a_row_per_present_dataset() -> None:
+    entries = [
+        {"role": "seed", "kind": "testharness"},
+        {"role": "golden", "kind": "js"},
+        {"role": "corpus", "kind": "reftest"},
+    ]
+    agg = {
+        "seed_precision": 0.8,
+        "seed_recall": 1.0,
+        "golden_recall": 0.75,
+        "consistency_histogram": {"mid": 2},
+        "golden_unmatched_predictions": 0,
+        "advisory_notes": 0,
+    }
+    lines = run_benchmark._render_summary(_bench_report(entries, agg))
+    md = "\n".join(lines)
+    assert "| seed | precision / recall | 0.8 / 1.0 | 1 |" in md
+    assert "| golden | recall | 0.75 | 1 |" in md
+    assert "| corpus | flaky findings (mid) | 2 | 1 |" in md
+
+
+def test_summary_omits_absent_datasets() -> None:
+    # A seed-only run has no golden/corpus rows.
+    entries = [{"role": "seed", "kind": "testharness"}]
+    agg = {
+        "seed_precision": 1.0,
+        "seed_recall": 1.0,
+        "golden_recall": 1.0,
+        "consistency_histogram": {"mid": 0},
+    }
+    md = "\n".join(run_benchmark._render_summary(_bench_report(entries, agg)))
+    assert "| seed |" in md
+    assert "golden" not in md
+    assert "corpus" not in md
 
 
 def test_off_reading_list_citation_is_advisory_note(tmp_path: Path) -> None:

--- a/tests/benchmark/test_run_benchmark.py
+++ b/tests/benchmark/test_run_benchmark.py
@@ -1415,3 +1415,65 @@ def test_manifest_golden_sets_non_int_rejected(tmp_path: Path) -> None:
     data["golden_sets"] = {"bad": ["43400"]}
     with pytest.raises(ManifestError, match="non-integer"):
         load_manifest(_write_manifest(tmp_path, data))
+
+
+# --- Smoke / regression tier ------------------------------------------------
+
+
+def _manifest_with_id_sets(
+    tmp_path: Path,
+    corpus_sets: dict[str, list[str]] | None = None,
+    seed_sets: dict[str, list[str]] | None = None,
+) -> Any:
+    data = _valid_manifest_dict()
+    if corpus_sets is not None:
+        data["corpus_sets"] = corpus_sets
+    if seed_sets is not None:
+        data["seed_sets"] = seed_sets
+    return load_manifest(_write_manifest(tmp_path, data))
+
+
+def test_manifest_id_sets_parsed(tmp_path: Path) -> None:
+    manifest = _manifest_with_id_sets(
+        tmp_path, corpus_sets={"smoke": ["corpus-a"]}, seed_sets={}
+    )
+    assert manifest.corpus_sets == {"smoke": ["corpus-a"]}
+    assert manifest.seed_sets == {}
+
+
+def test_manifest_id_sets_non_string_rejected(tmp_path: Path) -> None:
+    data = _valid_manifest_dict()
+    data["corpus_sets"] = {"smoke": [123]}
+    with pytest.raises(ManifestError, match="non-string"):
+        load_manifest(_write_manifest(tmp_path, data))
+
+
+def test_select_smoke_narrows_corpus_and_seeds(tmp_path: Path) -> None:
+    manifest = _manifest_with_id_sets(
+        tmp_path,
+        corpus_sets={"smoke": ["corpus-a"]},
+        seed_sets={"smoke": ["seed-a"]},
+    )
+    corpus, seeds = run_benchmark.select_smoke(
+        manifest, manifest.corpus, manifest.seeds
+    )
+    assert [c.entry_id for c in corpus] == ["corpus-a"]
+    assert [s.entry_id for s in seeds] == ["seed-a"]
+
+
+def test_select_smoke_empty_set_selects_nothing(tmp_path: Path) -> None:
+    # No `smoke` entry for a type -> that type contributes nothing.
+    manifest = _manifest_with_id_sets(tmp_path, corpus_sets={"smoke": []})
+    corpus, seeds = run_benchmark.select_smoke(
+        manifest, manifest.corpus, manifest.seeds
+    )
+    assert corpus == []
+    assert seeds == []
+
+
+def test_select_smoke_unknown_id_errors(tmp_path: Path) -> None:
+    manifest = _manifest_with_id_sets(
+        tmp_path, corpus_sets={"smoke": ["corpus-nope"]}
+    )
+    with pytest.raises(run_benchmark.HarnessError, match="corpus-nope"):
+        run_benchmark.select_smoke(manifest, manifest.corpus, manifest.seeds)

--- a/tests/benchmark/test_run_benchmark.py
+++ b/tests/benchmark/test_run_benchmark.py
@@ -861,6 +861,67 @@ def test_parallel_runs_match_sequential_set(
     assert _run_all(jobs=4) == expected
 
 
+# --- Quality gates ----------------------------------------------------------
+
+
+def _agg(
+    seed_precision: float = 1.0,
+    seed_recall: float = 1.0,
+    golden_recall: float = 1.0,
+    seed_fn: int = 0,
+    golden_fn: int = 0,
+) -> dict[str, Any]:
+    return {
+        "seed_precision": seed_precision,
+        "seed_recall": seed_recall,
+        "golden_recall": golden_recall,
+        "seed_false_negatives": seed_fn,
+        "golden_false_negatives": golden_fn,
+    }
+
+
+def test_quality_gates_pass_when_unset() -> None:
+    # No thresholds set -> nothing checked, even on a poor aggregate.
+    agg = _agg(seed_precision=0.0, seed_recall=0.0, golden_recall=0.0)
+    assert (
+        run_benchmark.check_quality_gates(
+            agg, run_benchmark.QualityThresholds()
+        )
+        == []
+    )
+
+
+def test_quality_gates_flag_each_breach() -> None:
+    agg = _agg(
+        seed_precision=0.5, seed_recall=0.5, golden_recall=0.5, seed_fn=3
+    )
+    failures = run_benchmark.check_quality_gates(
+        agg,
+        run_benchmark.QualityThresholds(
+            min_precision=0.9,
+            min_recall=0.9,
+            min_golden_recall=0.9,
+            max_fn=2,
+        ),
+    )
+    assert len(failures) == 4
+
+
+def test_quality_gate_max_fn_sums_seed_and_golden() -> None:
+    agg = _agg(seed_fn=1, golden_fn=2)
+    thresholds = run_benchmark.QualityThresholds(max_fn=2)
+    assert run_benchmark.check_quality_gates(agg, thresholds) == [
+        "false negatives 3 > 2"
+    ]
+
+
+def test_quality_gate_boundary_is_inclusive() -> None:
+    # Exactly meeting a floor passes; exactly at max_fn passes.
+    agg = _agg(seed_precision=0.8, seed_fn=2)
+    thresholds = run_benchmark.QualityThresholds(min_precision=0.8, max_fn=2)
+    assert run_benchmark.check_quality_gates(agg, thresholds) == []
+
+
 def test_stage_seeds_refuses_unmarked_existing_dir(tmp_path: Path) -> None:
     seeds_root = tmp_path / "seeds"
     (seeds_root / "testharness").mkdir(parents=True)

--- a/tests/benchmark/test_run_benchmark.py
+++ b/tests/benchmark/test_run_benchmark.py
@@ -21,6 +21,7 @@ against JSON.
 """
 
 import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
@@ -803,6 +804,61 @@ def _seed_entry(seed: str, kind: str = "testharness") -> SeedEntry:
         kind=kind,
         seed=seed,
     )
+
+
+class _FakeProc:
+    def __init__(self) -> None:
+        self.returncode = 0
+        self.stdout = ""
+        self.stderr = ""
+
+
+def _fake_run_recording(calls: list[list[str]]) -> Any:
+    """A subprocess.run stand-in that records argv and returns success."""
+
+    def _run(cmd: list[str], *a: Any, **k: Any) -> _FakeProc:
+        calls.append(cmd)
+        return _FakeProc()
+
+    return _run
+
+
+def test_parallel_runs_match_sequential_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The flattened pool produces the same (entry_id, repeat) records as the
+    sequential path, regardless of completion order."""
+    wpt_dir = tmp_path / "wpt"
+    wpt_dir.mkdir()
+    entries = [_seed_entry("testharness/a.js"), _seed_entry("testharness/b.js")]
+    repeats = 3
+    tasks = [(e, i) for e in entries for i in range(repeats)]
+
+    def _run_all(jobs: int) -> set[tuple[str, int]]:
+        calls: list[list[str]] = []
+        monkeypatch.setattr(
+            "benchmark.run_benchmark.subprocess.run",
+            _fake_run_recording(calls),
+        )
+        with ThreadPoolExecutor(max_workers=jobs) as pool:
+            futures = [
+                pool.submit(
+                    run_benchmark.run_single,
+                    entry=e,
+                    repeat=i,
+                    wpt_dir=wpt_dir,
+                    out=tmp_path / "out",
+                    provider=None,
+                    config=Path("wpt-gen.yml"),
+                )
+                for e, i in tasks
+            ]
+            records = [f.result() for f in as_completed(futures)]
+        return {(r.entry_id, r.repeat) for r in records}
+
+    expected = {(e.entry_id, i) for e, i in tasks}
+    assert _run_all(jobs=1) == expected
+    assert _run_all(jobs=4) == expected
 
 
 def test_stage_seeds_refuses_unmarked_existing_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
Makes the WPT evaluator benchmark faster to run and ready for CI, and adds the
golden test type to the report. 

## Added
- **Parallel runs** — `--jobs N` (default 1) runs evaluations concurrently.
- **Regression / release tiers** — `--smoke` selects named `smoke` sets across
  corpus/seeds/golden; the full manifest is the release tier.
- **CI quality gates** — `--min-precision` / `--min-recall` /
  `--min-golden-recall` / `--max-fn` gate the exit code (report is always
  written first).
- **Cloud Build sample** — `cloudbuild.yaml` wires both tiers, provider-agnostic
  secret handling.
- **Report refactor** — per-dataset summary + scope line up top; golden entries
  split true positives from unmatched findings.

The workflow, tiers, gates, and report format are all documented in updated
[`benchmarks/README.md`](benchmarks/README.md). 

## Deferred
- **429 backoff** — the harness has no rate-limit retry yet; a throttled run
  currently scores as an empty result, so treat `--jobs > 1` with care until
  this lands. Tracked in the README to-dos alongside a
  `--max-mid` consistency gate.
